### PR TITLE
fix: support multi-camera RGB envs with per-camera encoders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,8 @@ Before finishing code changes:
 
 `PegInsertionSidePegOnly-v1` is vendored from Residual_RL into `rl_garden/envs/custom/`. It depends on custom Panda wrist-camera/fixed-gripper agents and custom controller configs, also vendored under the same package.
 
+The peg env registers two cameras (`base_camera` + `hand_camera`). To avoid ManiSkill's default channel-stacked single `rgb` key, `examples/train_sac_rgbd_peg.py` enables `per_camera_rgbd=True` and `image_fusion_mode="per_key"` so each camera gets its own `rgb_<camera>` key and its own 3-channel encoder. This is what makes ResNet + ImageNet pretrained weights load without channel-shape mismatch.
+
 The generic RGBD trainer should remain independent of this env. Use:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ Image fusion modes:
   `stack_channels` are effectively equivalent at the tensor level: both feed the
   same `B x 3 x H x W` image into a ResNet/CNN. Differences matter when there
   are multiple visual keys (for example `rgb+depth` or multi-camera RGB).
+- Multi-camera envs (e.g. `PegInsertionSidePegOnly-v1` with `base_camera` +
+  `hand_camera`): ManiSkill's default `FlattenRGBDObservationWrapper` channel-
+  stacks all cameras into one `rgb` key, which collapses `per_key` back into a
+  single 6-channel encoder and breaks 3-channel ImageNet pretrained weights.
+  Pass `--per_camera_rgbd` (or set `per_camera_rgbd=True` on
+  `ManiSkillEnvConfig`) to keep each camera as its own `rgb_<camera>` key. The
+  `train_sac_rgbd_peg.py` entrypoint enables this by default and pairs it with
+  `--image_fusion_mode per_key`.
 
 Recommended visual training settings:
 
@@ -177,6 +185,23 @@ leaving the pooling/bottleneck head trainable. For Dict observations, SAC calls
 the shared extractor with `stop_gradient=True` on actor updates, so image
 encodings do not receive actor-loss gradients. Critic updates call the extractor
 with `stop_gradient=False`, so the image encoder/head is updated by critic loss.
+
+`ResNetEncoder` uses its own parameter naming (`stem_conv` / `stem_norm` /
+`blocks.<i>.{conv,norm,proj}*`), so torchvision-style checkpoints
+(`conv1`, `bn1`, `layer<N>.<block>.bn1/2`, `downsample.0/1`, ...) need to be
+re-keyed before `--pretrained_weights` can load them. Run the conversion once:
+
+```bash
+python scripts/convert_resnet_checkpoint.py \
+  --input pretrained_models/resnet10_pretrained.pt \
+  --output pretrained_models/resnet10_pretrained_converted.pt \
+  --arch resnet10
+```
+
+Then pass the converted name (without the `.pt` suffix) via
+`--pretrained_weights resnet10_pretrained_converted`. The script drops the
+ImageNet `fc.*` classification head, which is intentional — only backbone
+weights are loaded.
 
 Shell launchers:
 

--- a/examples/train_sac_rgbd.py
+++ b/examples/train_sac_rgbd.py
@@ -18,7 +18,7 @@ from rl_garden.common.cli_args import (
     VisionSACTrainingArgs,
     apply_log_env_overrides,
     image_encoder_factory_from_args,
-    image_keys_from_obs_mode,
+    image_keys_from_env,
     resolve_checkpoint_dir,
     resolve_eval_record_dir,
 )
@@ -67,6 +67,7 @@ def main() -> None:
         camera_width=args.camera_width,
         camera_height=args.camera_height,
         render_mode=args.render_mode,
+        per_camera_rgbd=args.per_camera_rgbd,
     )
     eval_record_dir = resolve_eval_record_dir(args, run_name)
     eval_cfg = ManiSkillEnvConfig(
@@ -83,12 +84,13 @@ def main() -> None:
         save_video=args.capture_video,
         video_fps=args.video_fps,
         max_steps_per_video=args.num_eval_steps,
+        per_camera_rgbd=args.per_camera_rgbd,
     )
     env = make_maniskill_env(env_cfg)
     eval_env = make_maniskill_env(eval_cfg)
 
     factory = image_encoder_factory_from_args(args)
-    image_keys = image_keys_from_obs_mode(args.obs_mode)
+    image_keys = image_keys_from_env(env, args)
 
     agent = SAC(
         env=env,

--- a/examples/train_sac_rgbd_peg.py
+++ b/examples/train_sac_rgbd_peg.py
@@ -18,7 +18,7 @@ from rl_garden.common.cli_args import (
     VisionSACTrainingArgs,
     apply_log_env_overrides,
     image_encoder_factory_from_args,
-    image_keys_from_obs_mode,
+    image_keys_from_env,
     resolve_checkpoint_dir,
     resolve_eval_record_dir,
 )
@@ -35,6 +35,11 @@ class Args(VisionSACTrainingArgs):
     robot_uids: str = "panda_wristcam_gripper_closed_wo_norm"
     fix_peg_pose: bool = False
     fix_box: bool = True
+    # Peg env has two cameras (base + hand): emit them as separate keys and
+    # encode independently under ``per_key`` so each gets a 3-channel ResNet
+    # that can load ImageNet pretrained weights without shape mismatch.
+    per_camera_rgbd: bool = True
+    image_fusion_mode: str = "per_key"
 
 
 def main() -> None:
@@ -80,6 +85,7 @@ def main() -> None:
         fix_box=args.fix_box,
         camera_width=args.camera_width,
         camera_height=args.camera_height,
+        per_camera_rgbd=args.per_camera_rgbd,
     )
     eval_cfg = ManiSkillEnvConfig(
         env_id=args.env_id,
@@ -101,12 +107,13 @@ def main() -> None:
         save_video=args.capture_video,
         video_fps=args.video_fps,
         max_steps_per_video=args.num_eval_steps,
+        per_camera_rgbd=args.per_camera_rgbd,
     )
     env = make_maniskill_env(env_cfg)
     eval_env = make_maniskill_env(eval_cfg)
 
     factory = image_encoder_factory_from_args(args)
-    image_keys = image_keys_from_obs_mode(args.obs_mode)
+    image_keys = image_keys_from_env(env, args)
 
     agent = SAC(
         env=env,

--- a/rl_garden/common/cli_args.py
+++ b/rl_garden/common/cli_args.py
@@ -72,6 +72,10 @@ class VisionArgs:
     pretrained_weights: Optional[str] = None
     freeze_resnet_encoder: bool = False
     freeze_resnet_backbone: bool = False
+    # Keep each camera as its own ``rgb_<cam>`` / ``depth_<cam>`` key instead of
+    # channel-stacking. Required for multi-camera envs (e.g. peg) when each
+    # camera should feed an independent encoder under ``per_key`` fusion.
+    per_camera_rgbd: bool = False
 
 
 @dataclass
@@ -329,3 +333,18 @@ def image_encoder_factory_from_args(args: VisionArgs):
 
 def image_keys_from_obs_mode(obs_mode: str) -> tuple[str, ...]:
     return ("rgb",) if obs_mode == "rgb" else ("rgb", "depth")
+
+
+def image_keys_from_env(env: Any, args: VisionArgs) -> tuple[str, ...]:
+    """Resolve image keys for ``CombinedExtractor`` from the built env.
+
+    When ``args.per_camera_rgbd`` is set the env emits one ``rgb_<cam>`` (and
+    optionally ``depth_<cam>``) key per camera; we discover them from the
+    observation space. Otherwise we fall back to the single-key default that
+    matches ``FlattenRGBDObservationWrapper``.
+    """
+    if args.per_camera_rgbd:
+        from rl_garden.encoders import discover_image_keys
+
+        return discover_image_keys(env.single_observation_space)
+    return image_keys_from_obs_mode(args.obs_mode)

--- a/rl_garden/encoders/__init__.py
+++ b/rl_garden/encoders/__init__.py
@@ -6,6 +6,7 @@ from rl_garden.encoders.combined import (
     ImageEncoderFactory,
     ProprioEncoder,
     default_image_encoder_factory,
+    discover_image_keys,
 )
 from rl_garden.encoders.film import FiLM
 from rl_garden.encoders.flatten import FlattenExtractor
@@ -29,5 +30,6 @@ __all__ = [
     "SpatialLearnedEmbeddings",
     "SpatialSoftmax",
     "default_image_encoder_factory",
+    "discover_image_keys",
     "resnet_encoder_factory",
 ]

--- a/rl_garden/encoders/combined.py
+++ b/rl_garden/encoders/combined.py
@@ -237,3 +237,22 @@ class CombinedExtractor(BaseFeaturesExtractor):
 
     def forward(self, obs: dict[str, torch.Tensor]) -> torch.Tensor:
         return self.extract(obs, stop_gradient=False)
+
+
+def discover_image_keys(observation_space: spaces.Dict) -> tuple[str, ...]:
+    """Return all keys in ``observation_space`` whose names start with ``rgb``
+    or ``depth``.
+
+    RGB keys come before depth keys; within each group, keys are sorted
+    alphabetically for determinism. Used by per-camera training entrypoints
+    (e.g. peg) to discover ``rgb_<cam>`` / ``depth_<cam>`` keys produced by
+    :class:`PerCameraRGBDWrapper`.
+    """
+    if not isinstance(observation_space, spaces.Dict):
+        raise TypeError(
+            "discover_image_keys expects a Dict observation space, got "
+            f"{type(observation_space).__name__}"
+        )
+    rgb_keys = sorted(k for k in observation_space.spaces if k.startswith("rgb"))
+    depth_keys = sorted(k for k in observation_space.spaces if k.startswith("depth"))
+    return tuple(rgb_keys + depth_keys)

--- a/rl_garden/envs/maniskill.py
+++ b/rl_garden/envs/maniskill.py
@@ -39,6 +39,11 @@ class ManiSkillEnvConfig:
     record_metrics: bool = True
     reward_scale: float = 1.0
     reward_bias: float = 0.0
+    # When True, keep each camera as its own ``rgb_<cam>`` / ``depth_<cam>`` key
+    # instead of channel-stacking all cameras into a single ``rgb`` / ``depth``
+    # tensor. Required for multi-camera envs (e.g. peg) when each camera should
+    # feed an independent encoder under ``fusion_mode="per_key"``.
+    per_camera_rgbd: bool = False
     # Recording
     record_dir: Optional[str] = None
     save_video: bool = False
@@ -103,12 +108,22 @@ def make_maniskill_env(cfg: ManiSkillEnvConfig):
 
     # RGBD dict -> flat {rgb(/depth), state} dict
     if _is_visual_obs_mode(cfg.obs_mode):
-        env = FlattenRGBDObservationWrapper(
-            env,
-            rgb=("rgb" in cfg.obs_mode),
-            depth=("depth" in cfg.obs_mode),
-            state=cfg.include_state,
-        )
+        if cfg.per_camera_rgbd:
+            from rl_garden.envs.wrappers import PerCameraRGBDWrapper
+
+            env = PerCameraRGBDWrapper(
+                env,
+                rgb=("rgb" in cfg.obs_mode),
+                depth=("depth" in cfg.obs_mode),
+                state=cfg.include_state,
+            )
+        else:
+            env = FlattenRGBDObservationWrapper(
+                env,
+                rgb=("rgb" in cfg.obs_mode),
+                depth=("depth" in cfg.obs_mode),
+                state=cfg.include_state,
+            )
 
     if isinstance(env.action_space, gym.spaces.Dict):
         env = FlattenActionSpaceWrapper(env)

--- a/rl_garden/envs/wrappers/__init__.py
+++ b/rl_garden/envs/wrappers/__init__.py
@@ -1,3 +1,4 @@
+from rl_garden.envs.wrappers.per_camera_rgbd import PerCameraRGBDWrapper
 from rl_garden.envs.wrappers.reward_transform import RewardScaleBiasWrapper
 
-__all__ = ["RewardScaleBiasWrapper"]
+__all__ = ["PerCameraRGBDWrapper", "RewardScaleBiasWrapper"]

--- a/rl_garden/envs/wrappers/per_camera_rgbd.py
+++ b/rl_garden/envs/wrappers/per_camera_rgbd.py
@@ -1,0 +1,77 @@
+"""Per-camera RGBD observation wrapper.
+
+Mirrors :class:`mani_skill.utils.wrappers.flatten.FlattenRGBDObservationWrapper`
+but keeps each camera's image as its own observation key
+(``rgb_<camera_name>`` / ``depth_<camera_name>``) instead of channel-stacking
+all cameras into a single ``rgb`` / ``depth`` tensor.
+
+This matches hil-serl's ``EncodingWrapper`` style: each camera gets its own
+3-channel encoder via :class:`CombinedExtractor` ``fusion_mode="per_key"``, so
+ImageNet-pretrained ResNet stems load without channel-shape mismatches and
+normalization stays correct per camera.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import gymnasium as gym
+
+
+class PerCameraRGBDWrapper(gym.ObservationWrapper):
+    """Per-camera variant of ``FlattenRGBDObservationWrapper``.
+
+    Args:
+        env: The underlying ManiSkill env.
+        rgb: Include per-camera RGB keys.
+        depth: Include per-camera depth keys.
+        state: Include the flat ``state`` key.
+
+    Output observation dict keys:
+        * ``rgb_<camera_name>``: ``Box(shape=(H, W, 3), dtype=uint8)`` per camera
+        * ``depth_<camera_name>``: ``Box(shape=(H, W, 1), dtype=float32)`` per camera
+        * ``state``: flat agent/extra state, when ``state=True``
+    """
+
+    def __init__(
+        self,
+        env: gym.Env,
+        rgb: bool = True,
+        depth: bool = True,
+        state: bool = True,
+    ) -> None:
+        # Late imports so importing rl_garden without mani_skill stays cheap.
+        from mani_skill.envs.sapien_env import BaseEnv
+
+        self.base_env: BaseEnv = env.unwrapped
+        super().__init__(env)
+        self.include_rgb = rgb
+        self.include_depth = depth
+        self.include_state = state
+
+        first_cam = next(iter(self.base_env._init_raw_obs["sensor_data"].values()))
+        if "rgb" not in first_cam:
+            self.include_rgb = False
+        if "depth" not in first_cam:
+            self.include_depth = False
+
+        new_obs = self.observation(self.base_env._init_raw_obs)
+        self.base_env.update_obs_space(new_obs)
+
+    def observation(self, observation: dict[str, Any]) -> dict[str, Any]:
+        from mani_skill.utils import common
+
+        sensor_data = observation.pop("sensor_data")
+        observation.pop("sensor_param", None)
+
+        ret: dict[str, Any] = {}
+        for cam_name, cam_data in sensor_data.items():
+            if self.include_rgb and "rgb" in cam_data:
+                ret[f"rgb_{cam_name}"] = cam_data["rgb"]
+            if self.include_depth and "depth" in cam_data:
+                ret[f"depth_{cam_name}"] = cam_data["depth"]
+
+        if self.include_state:
+            ret["state"] = common.flatten_state_dict(
+                observation, use_torch=True, device=self.base_env.device
+            )
+        return ret

--- a/tests/test_policy_kwargs.py
+++ b/tests/test_policy_kwargs.py
@@ -319,3 +319,45 @@ def test_sac_dict_checkpoint_metadata_includes_image_fields():
     meta = agent._checkpoint_metadata()
     assert meta["image_keys"] == ("rgb",)
     assert meta["use_proprio"] is True
+
+
+def _multi_camera_env() -> DummyVecEnv:
+    obs_space = spaces.Dict(
+        {
+            "rgb_base_camera": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "rgb_hand_camera": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "state": spaces.Box(low=-1.0, high=1.0, shape=(5,), dtype=np.float32),
+        }
+    )
+    act_space = spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+    return DummyVecEnv(obs_space, act_space)
+
+
+def test_sac_per_camera_keys_build_separate_encoders():
+    agent = SAC(
+        env=_multi_camera_env(),
+        **_agent_kwargs(),
+        image_keys=("rgb_base_camera", "rgb_hand_camera"),
+        image_fusion_mode="per_key",
+    )
+    ext = agent.policy.features_extractor
+    assert isinstance(ext, CombinedExtractor)
+    assert set(ext.image_encoders.keys()) == {"rgb_base_camera", "rgb_hand_camera"}
+    for enc in ext.image_encoders.values():
+        # Each per-camera encoder is built from a 3-channel (C, H, W) Box.
+        assert enc._observation_space.shape[0] == 3
+
+
+def test_discover_image_keys_orders_rgb_before_depth():
+    from rl_garden.encoders import discover_image_keys
+
+    obs_space = spaces.Dict(
+        {
+            "state": spaces.Box(low=-1.0, high=1.0, shape=(5,), dtype=np.float32),
+            "rgb_hand_camera": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "rgb_base_camera": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "depth_base_camera": spaces.Box(low=0.0, high=1.0, shape=(64, 64, 1), dtype=np.float32),
+        }
+    )
+    keys = discover_image_keys(obs_space)
+    assert keys == ("rgb_base_camera", "rgb_hand_camera", "depth_base_camera")


### PR DESCRIPTION
ManiSkill's FlattenRGBDObservationWrapper channel-stacks all cameras into one 6-channel `rgb` key, which collapses `per_key` fusion back into a single multi-channel encoder and breaks 3-channel ImageNet pretrained ResNet weights. Add a PerCameraRGBDWrapper that keeps each camera as its own `rgb_<cam>`/`depth_<cam>` key, plumb `per_camera_rgbd` through the env factory and `VisionArgs`, and have train_sac_rgbd_peg.py enable it with `image_fusion_mode="per_key"` by default. Document the existing scripts/convert_resnet_checkpoint.py for re-keying torchvision-style pretrained checkpoints so they load into ResNetEncoder.