### PR TITLE
refactor: streamline offline metric logging and introduce explicit namespace mapping

### DIFF
--- a/examples/pretrain_offline.py
+++ b/examples/pretrain_offline.py
@@ -37,6 +37,7 @@ from rl_garden.common.cli_args import (
     apply_log_env_overrides,
     resolve_checkpoint_dir,
 )
+from rl_garden.envs import ManiSkillEnvConfig, make_maniskill_env
 
 OfflinePretrainAgent: TypeAlias = CQL | CalQL | WSRL
 
@@ -246,6 +247,23 @@ def main(
         if args.std_log:
             print(f"[pretrain] resumed_from={args.load_checkpoint}", flush=True)
 
+    # --- setup optional eval env ---
+    eval_env = None
+    if args.env_id is not None:
+        eval_env = make_maniskill_env(
+            ManiSkillEnvConfig(
+                env_id=args.env_id,
+                num_envs=args.num_eval_envs,
+                control_mode=args.control_mode,
+                sim_backend=args.sim_backend,
+                render_backend=args.render_backend,
+                reconfiguration_freq=1,
+            )
+        )
+        agent.eval_env = eval_env
+        agent.eval_freq = args.eval_freq
+        agent.num_eval_steps = args.num_eval_steps
+
     run_offline_pretraining(
         agent,
         num_steps=args.num_offline_steps,
@@ -256,8 +274,12 @@ def main(
         save_final_checkpoint=args.save_final_checkpoint,
         log_freq=args.log_freq,
         std_log=args.std_log,
+        eval_freq=agent.eval_freq if eval_env is not None else 0,
         desc=f"{algorithm}-offline",
     )
+
+    if eval_env is not None:
+        eval_env.close()
     logger.close()
 
 

--- a/examples/train_wsrl.py
+++ b/examples/train_wsrl.py
@@ -58,7 +58,7 @@ def _offline_update_loop(
         interval_update_time += time.perf_counter() - update_t
         interval_update_steps += gradient_steps
         if log_freq > 0 and (step + 1) % log_freq == 0:
-            logger.log_offline_metrics(losses, global_step)
+            logger.log_metrics(losses, global_step)
             offline_update_fps = (
                 interval_update_steps / interval_update_time
                 if interval_update_time > 0
@@ -68,7 +68,7 @@ def _offline_update_loop(
             logger.add_scalar("time/offline_update_fps", offline_update_fps, global_step)
             if std_log:
                 progress = 100.0 * (step + 1) / steps if steps > 0 else 100.0
-                loss_summary, q_summary = logger.format_offline_metrics(losses)
+                loss_summary, q_summary = logger.format_metrics(losses)
                 q_part = f" q={q_summary}" if q_summary else ""
                 print(
                     "[offline] "

--- a/examples/train_wsrl.py
+++ b/examples/train_wsrl.py
@@ -37,43 +37,6 @@ class Args(WSRLTrainingArgs):
     pass
 
 
-_Q_METRIC_LABELS = {
-    "predicted_q": "predicted",
-    "target_q": "target",
-    "cql_ood_values": "cql_ood",
-    "cql_q_diff": "cql_diff",
-}
-
-
-def _split_q_metrics(metrics: dict[str, float]) -> tuple[dict[str, float], dict[str, float]]:
-    q_metrics: dict[str, float] = {}
-    other_metrics: dict[str, float] = {}
-    for key, value in metrics.items():
-        if not isinstance(value, (int, float)):
-            continue
-        if key in _Q_METRIC_LABELS:
-            q_metrics[_Q_METRIC_LABELS[key]] = float(value)
-        else:
-            other_metrics[key] = float(value)
-    return other_metrics, q_metrics
-
-
-def _metric_summary(metrics: dict[str, float]) -> str:
-    return " ".join(f"{k}={v:.4f}" for k, v in metrics.items())
-
-
-def _log_offline_metrics(
-    logger: Logger,
-    metrics: dict[str, float],
-    step: int,
-) -> None:
-    other_metrics, q_metrics = _split_q_metrics(metrics)
-    for key, value in other_metrics.items():
-        logger.add_scalar(f"losses/{key}", value, step)
-    for key, value in q_metrics.items():
-        logger.add_scalar(f"q/{key}", value, step)
-
-
 def _offline_update_loop(
     agent: WSRL,
     steps: int,
@@ -95,7 +58,7 @@ def _offline_update_loop(
         interval_update_time += time.perf_counter() - update_t
         interval_update_steps += gradient_steps
         if log_freq > 0 and (step + 1) % log_freq == 0:
-            _log_offline_metrics(logger, losses, global_step)
+            logger.log_offline_metrics(losses, global_step)
             offline_update_fps = (
                 interval_update_steps / interval_update_time
                 if interval_update_time > 0
@@ -105,9 +68,7 @@ def _offline_update_loop(
             logger.add_scalar("time/offline_update_fps", offline_update_fps, global_step)
             if std_log:
                 progress = 100.0 * (step + 1) / steps if steps > 0 else 100.0
-                other_metrics, q_metrics = _split_q_metrics(losses)
-                loss_summary = _metric_summary(other_metrics)
-                q_summary = _metric_summary(q_metrics)
+                loss_summary, q_summary = logger.format_offline_metrics(losses)
                 q_part = f" q={q_summary}" if q_summary else ""
                 print(
                     "[offline] "

--- a/examples/train_wsrl.py
+++ b/examples/train_wsrl.py
@@ -62,6 +62,18 @@ def _metric_summary(metrics: dict[str, float]) -> str:
     return " ".join(f"{k}={v:.4f}" for k, v in metrics.items())
 
 
+def _log_offline_metrics(
+    logger: Logger,
+    metrics: dict[str, float],
+    step: int,
+) -> None:
+    other_metrics, q_metrics = _split_q_metrics(metrics)
+    for key, value in other_metrics.items():
+        logger.add_scalar(f"losses/{key}", value, step)
+    for key, value in q_metrics.items():
+        logger.add_scalar(f"q/{key}", value, step)
+
+
 def _offline_update_loop(
     agent: WSRL,
     steps: int,
@@ -83,7 +95,7 @@ def _offline_update_loop(
         interval_update_time += time.perf_counter() - update_t
         interval_update_steps += gradient_steps
         if log_freq > 0 and (step + 1) % log_freq == 0:
-            agent._log_update_metrics(losses, global_step)
+            _log_offline_metrics(logger, losses, global_step)
             offline_update_fps = (
                 interval_update_steps / interval_update_time
                 if interval_update_time > 0

--- a/examples/train_wsrl.py
+++ b/examples/train_wsrl.py
@@ -37,6 +37,31 @@ class Args(WSRLTrainingArgs):
     pass
 
 
+_Q_METRIC_LABELS = {
+    "predicted_q": "predicted",
+    "target_q": "target",
+    "cql_ood_values": "cql_ood",
+    "cql_q_diff": "cql_diff",
+}
+
+
+def _split_q_metrics(metrics: dict[str, float]) -> tuple[dict[str, float], dict[str, float]]:
+    q_metrics: dict[str, float] = {}
+    other_metrics: dict[str, float] = {}
+    for key, value in metrics.items():
+        if not isinstance(value, (int, float)):
+            continue
+        if key in _Q_METRIC_LABELS:
+            q_metrics[_Q_METRIC_LABELS[key]] = float(value)
+        else:
+            other_metrics[key] = float(value)
+    return other_metrics, q_metrics
+
+
+def _metric_summary(metrics: dict[str, float]) -> str:
+    return " ".join(f"{k}={v:.4f}" for k, v in metrics.items())
+
+
 def _offline_update_loop(
     agent: WSRL,
     steps: int,
@@ -49,25 +74,40 @@ def _offline_update_loop(
     gradient_steps = (
         int(agent.utd) if float(agent.utd).is_integer() and agent.utd > 1 else 1
     )
+    interval_update_time = 0.0
+    interval_update_steps = 0
     for step in trange(steps, desc="offline"):
         global_step = start_step + step + 1
+        update_t = time.perf_counter()
         losses = agent.train(gradient_steps)
+        interval_update_time += time.perf_counter() - update_t
+        interval_update_steps += gradient_steps
         if log_freq > 0 and (step + 1) % log_freq == 0:
             agent._log_update_metrics(losses, global_step)
+            offline_update_fps = (
+                interval_update_steps / interval_update_time
+                if interval_update_time > 0
+                else float("nan")
+            )
+            logger.add_scalar("time/offline_update_time", interval_update_time, global_step)
+            logger.add_scalar("time/offline_update_fps", offline_update_fps, global_step)
             if std_log:
                 progress = 100.0 * (step + 1) / steps if steps > 0 else 100.0
-                loss_summary = " ".join(
-                    f"{k}={v:.4f}"
-                    for k, v in losses.items()
-                    if isinstance(v, (int, float))
-                )
+                other_metrics, q_metrics = _split_q_metrics(losses)
+                loss_summary = _metric_summary(other_metrics)
+                q_summary = _metric_summary(q_metrics)
+                q_part = f" q={q_summary}" if q_summary else ""
                 print(
                     "[offline] "
                     f"step={step + 1}/{steps} "
                     f"global_step={global_step} "
-                    f"({progress:.2f}%) {loss_summary}",
+                    f"({progress:.2f}%) "
+                    f"fps={offline_update_fps:.4f} "
+                    f"{loss_summary}{q_part}",
                     flush=True,
                 )
+            interval_update_time = 0.0
+            interval_update_steps = 0
     return start_step + steps
 
 

--- a/examples/train_wsrl_rgbd.py
+++ b/examples/train_wsrl_rgbd.py
@@ -41,45 +41,14 @@ class Args(VisionWSRLTrainingArgs):
     pass
 
 
-_Q_METRIC_LABELS = {
-    "predicted_q": "predicted",
-    "target_q": "target",
-    "cql_ood_values": "cql_ood",
-    "cql_q_diff": "cql_diff",
-}
-
-
-def _split_q_metrics(metrics: dict[str, float]) -> tuple[dict[str, float], dict[str, float]]:
-    q_metrics: dict[str, float] = {}
-    other_metrics: dict[str, float] = {}
-    for key, value in metrics.items():
-        if not isinstance(value, (int, float)):
-            continue
-        if key in _Q_METRIC_LABELS:
-            q_metrics[_Q_METRIC_LABELS[key]] = float(value)
-        else:
-            other_metrics[key] = float(value)
-    return other_metrics, q_metrics
-
-
-def _metric_summary(metrics: dict[str, float]) -> str:
-    return " ".join(f"{k}={v:.4f}" for k, v in metrics.items())
-
-
-def _log_offline_metrics(
-    logger: Logger,
-    metrics: dict[str, float],
-    step: int,
-) -> None:
-    other_metrics, q_metrics = _split_q_metrics(metrics)
-    for key, value in other_metrics.items():
-        logger.add_scalar(f"losses/{key}", value, step)
-    for key, value in q_metrics.items():
-        logger.add_scalar(f"q/{key}", value, step)
-
-
 def _offline_update_loop(
-    agent: WSRLRGBD, steps: int, logger: Logger, log_freq: int, std_log: bool
+    agent: WSRLRGBD, 
+    steps: int, 
+    logger: Logger, 
+    log_freq: int, 
+    std_log: bool,
+    *,
+    start_step: int = 0,
 ) -> None:
     gradient_steps = (
         int(agent.utd) if float(agent.utd).is_integer() and agent.utd > 1 else 1
@@ -92,7 +61,7 @@ def _offline_update_loop(
         interval_update_time += time.perf_counter() - update_t
         interval_update_steps += gradient_steps
         if log_freq > 0 and (step + 1) % log_freq == 0:
-            _log_offline_metrics(logger, losses, step + 1)
+            logger.log_offline_metrics(losses, step + 1)
             offline_update_fps = (
                 interval_update_steps / interval_update_time
                 if interval_update_time > 0
@@ -102,9 +71,7 @@ def _offline_update_loop(
             logger.add_scalar("time/offline_update_fps", offline_update_fps, step + 1)
             if std_log:
                 progress = 100.0 * (step + 1) / steps if steps > 0 else 100.0
-                other_metrics, q_metrics = _split_q_metrics(losses)
-                loss_summary = _metric_summary(other_metrics)
-                q_summary = _metric_summary(q_metrics)
+                loss_summary, q_summary = logger.format_offline_metrics(losses)
                 q_part = f" q={q_summary}" if q_summary else ""
                 print(
                     "[offline] "

--- a/examples/train_wsrl_rgbd.py
+++ b/examples/train_wsrl_rgbd.py
@@ -61,7 +61,7 @@ def _offline_update_loop(
         interval_update_time += time.perf_counter() - update_t
         interval_update_steps += gradient_steps
         if log_freq > 0 and (step + 1) % log_freq == 0:
-            logger.log_offline_metrics(losses, step + 1)
+            logger.log_metrics(losses, step + 1)
             offline_update_fps = (
                 interval_update_steps / interval_update_time
                 if interval_update_time > 0
@@ -71,7 +71,7 @@ def _offline_update_loop(
             logger.add_scalar("time/offline_update_fps", offline_update_fps, step + 1)
             if std_log:
                 progress = 100.0 * (step + 1) / steps if steps > 0 else 100.0
-                loss_summary, q_summary = logger.format_offline_metrics(losses)
+                loss_summary, q_summary = logger.format_metrics(losses)
                 q_part = f" q={q_summary}" if q_summary else ""
                 print(
                     "[offline] "

--- a/examples/train_wsrl_rgbd.py
+++ b/examples/train_wsrl_rgbd.py
@@ -73,7 +73,7 @@ def _log_offline_metrics(
 ) -> None:
     other_metrics, q_metrics = _split_q_metrics(metrics)
     for key, value in other_metrics.items():
-        logger.add_scalar(f"offline_losses/{key}", value, step)
+        logger.add_scalar(f"losses/{key}", value, step)
     for key, value in q_metrics.items():
         logger.add_scalar(f"q/{key}", value, step)
 

--- a/examples/train_wsrl_rgbd.py
+++ b/examples/train_wsrl_rgbd.py
@@ -41,29 +41,80 @@ class Args(VisionWSRLTrainingArgs):
     pass
 
 
+_Q_METRIC_LABELS = {
+    "predicted_q": "predicted",
+    "target_q": "target",
+    "cql_ood_values": "cql_ood",
+    "cql_q_diff": "cql_diff",
+}
+
+
+def _split_q_metrics(metrics: dict[str, float]) -> tuple[dict[str, float], dict[str, float]]:
+    q_metrics: dict[str, float] = {}
+    other_metrics: dict[str, float] = {}
+    for key, value in metrics.items():
+        if not isinstance(value, (int, float)):
+            continue
+        if key in _Q_METRIC_LABELS:
+            q_metrics[_Q_METRIC_LABELS[key]] = float(value)
+        else:
+            other_metrics[key] = float(value)
+    return other_metrics, q_metrics
+
+
+def _metric_summary(metrics: dict[str, float]) -> str:
+    return " ".join(f"{k}={v:.4f}" for k, v in metrics.items())
+
+
+def _log_offline_metrics(
+    logger: Logger,
+    metrics: dict[str, float],
+    step: int,
+) -> None:
+    other_metrics, q_metrics = _split_q_metrics(metrics)
+    for key, value in other_metrics.items():
+        logger.add_scalar(f"offline_losses/{key}", value, step)
+    for key, value in q_metrics.items():
+        logger.add_scalar(f"q/{key}", value, step)
+
+
 def _offline_update_loop(
     agent: WSRLRGBD, steps: int, logger: Logger, log_freq: int, std_log: bool
 ) -> None:
     gradient_steps = (
         int(agent.utd) if float(agent.utd).is_integer() and agent.utd > 1 else 1
     )
+    interval_update_time = 0.0
+    interval_update_steps = 0
     for step in trange(steps, desc="offline"):
+        update_t = time.perf_counter()
         losses = agent.train(gradient_steps)
+        interval_update_time += time.perf_counter() - update_t
+        interval_update_steps += gradient_steps
         if log_freq > 0 and (step + 1) % log_freq == 0:
-            for key, value in losses.items():
-                logger.add_scalar(f"offline_losses/{key}", value, step + 1)
+            _log_offline_metrics(logger, losses, step + 1)
+            offline_update_fps = (
+                interval_update_steps / interval_update_time
+                if interval_update_time > 0
+                else float("nan")
+            )
+            logger.add_scalar("time/offline_update_time", interval_update_time, step + 1)
+            logger.add_scalar("time/offline_update_fps", offline_update_fps, step + 1)
             if std_log:
                 progress = 100.0 * (step + 1) / steps if steps > 0 else 100.0
-                loss_summary = " ".join(
-                    f"{k}={v:.4f}"
-                    for k, v in losses.items()
-                    if isinstance(v, (int, float))
-                )
+                other_metrics, q_metrics = _split_q_metrics(losses)
+                loss_summary = _metric_summary(other_metrics)
+                q_summary = _metric_summary(q_metrics)
+                q_part = f" q={q_summary}" if q_summary else ""
                 print(
                     "[offline] "
-                    f"step={step + 1}/{steps} ({progress:.2f}%) {loss_summary}",
+                    f"step={step + 1}/{steps} ({progress:.2f}%) "
+                    f"fps={offline_update_fps:.4f} "
+                    f"{loss_summary}{q_part}",
                     flush=True,
                 )
+            interval_update_time = 0.0
+            interval_update_steps = 0
 
 
 def main() -> None:

--- a/rl_garden/algorithms/base_algorithm.py
+++ b/rl_garden/algorithms/base_algorithm.py
@@ -52,6 +52,28 @@ class BaseAlgorithm(ABC):
     @abstractmethod
     def learn(self, total_timesteps: int) -> "BaseAlgorithm": ...
 
+    def _obs_to_policy_device(self, obs):
+        """Move CPU-backed env observations to the policy device for inference.
+
+        GPU ManiSkill envs already return tensors on ``self.device`` and this is
+        a no-op. This fallback exists for CPU simulator backends such as
+        ``physx_cpu``; model training and replay sampling remain CUDA-first.
+        """
+        if isinstance(obs, dict):
+            return {
+                k: v if v.device == self.device else v.to(self.device)
+                for k, v in obs.items()
+            }
+        if obs.device == self.device:
+            return obs
+        return obs.to(self.device)
+
+    def _eval_action(self, obs) -> torch.Tensor:
+        with torch.no_grad():
+            return self.policy.predict(
+                self._obs_to_policy_device(obs), deterministic=True
+            )
+
     # --- checkpointing ---
 
     def _optimizer_names(self) -> tuple[str, ...]:

--- a/rl_garden/algorithms/off_policy.py
+++ b/rl_garden/algorithms/off_policy.py
@@ -101,8 +101,7 @@ class OffPolicyAlgorithm(BaseAlgorithm):
     def _log_update_metrics(self, metrics: dict[str, float], step: int) -> None:
         if self.logger is None:
             return
-        for key, value in metrics.items():
-            self.logger.add_scalar(f"losses/{key}", value, step)
+        self.logger.log_offline_metrics(metrics, step)
 
     def _explore_action(self, obs) -> torch.Tensor:
         """Random uniform action in [-1, 1] across all envs. Used pre-learning."""

--- a/rl_garden/algorithms/off_policy.py
+++ b/rl_garden/algorithms/off_policy.py
@@ -101,7 +101,8 @@ class OffPolicyAlgorithm(BaseAlgorithm):
     def _log_update_metrics(self, metrics: dict[str, float], step: int) -> None:
         if self.logger is None:
             return
-        self.logger.log_offline_metrics(metrics, step)
+        for key, value in metrics.items():
+            self.logger.add_scalar(f"losses/{key}", value, step)
 
     def _explore_action(self, obs) -> torch.Tensor:
         """Random uniform action in [-1, 1] across all envs. Used pre-learning."""

--- a/rl_garden/algorithms/offline.py
+++ b/rl_garden/algorithms/offline.py
@@ -77,12 +77,13 @@ class OfflineRLAlgorithm(BaseAlgorithm):
         log_freq: int = 1_000,
         eval_freq: int = 0,
         num_eval_steps: int = 50,
+        eval_env: Optional[Any] = None,
         checkpoint_dir: Optional[str] = None,
         checkpoint_freq: int = 0,
         save_replay_buffer: bool = False,
         save_final_checkpoint: bool = True,
     ) -> None:
-        super().__init__(env=env, eval_env=None, seed=seed, device=device, logger=logger)
+        super().__init__(env=env, eval_env=eval_env, seed=seed, device=device, logger=logger)
         self.buffer_size = buffer_size
         self.buffer_device = buffer_device
         self.batch_size = batch_size
@@ -128,23 +129,6 @@ class OfflineRLAlgorithm(BaseAlgorithm):
 
     # --- eval ---
 
-    def _obs_to_policy_device(self, obs):
-        """Move CPU-backed env observations to the policy device for inference."""
-        if isinstance(obs, dict):
-            return {
-                k: v if v.device == self.device else v.to(self.device)
-                for k, v in obs.items()
-            }
-        if obs.device == self.device:
-            return obs
-        return obs.to(self.device)
-
-    def _eval_action(self, obs) -> torch.Tensor:
-        with torch.no_grad():
-            return self.policy.predict(
-                self._obs_to_policy_device(obs), deterministic=True
-            )
-
     def _evaluate(self) -> dict[str, float]:
         if self.eval_env is None:
             return {}
@@ -182,7 +166,7 @@ class OfflineRLAlgorithm(BaseAlgorithm):
     def _log_update_metrics(self, metrics: dict[str, float], step: int) -> None:
         if self.logger is None:
             return
-        self.logger.log_offline_metrics(metrics, step)
+        self.logger.log_metrics(metrics, step)
 
 
 def infer_box_specs_from_h5(
@@ -249,7 +233,7 @@ def _log_update_metrics(agent: Any, metrics: dict[str, float], step: int) -> Non
     logger = getattr(agent, "logger", None)
     if logger is None:
         return
-    logger.log_offline_metrics(metrics, step)
+    logger.log_metrics(metrics, step)
 
 
 def _log_eval_stdout(agent: Any, metrics: dict[str, float], step: int) -> None:

--- a/rl_garden/algorithms/offline.py
+++ b/rl_garden/algorithms/offline.py
@@ -182,8 +182,7 @@ class OfflineRLAlgorithm(BaseAlgorithm):
     def _log_update_metrics(self, metrics: dict[str, float], step: int) -> None:
         if self.logger is None:
             return
-        for key, value in metrics.items():
-            self.logger.add_scalar(f"losses/{key}", value, step)
+        self.logger.log_offline_metrics(metrics, step)
 
 
 def infer_box_specs_from_h5(
@@ -250,8 +249,7 @@ def _log_update_metrics(agent: Any, metrics: dict[str, float], step: int) -> Non
     logger = getattr(agent, "logger", None)
     if logger is None:
         return
-    for key, value in metrics.items():
-        logger.add_scalar(f"losses/{key}", value, step)
+    logger.log_offline_metrics(metrics, step)
 
 
 def _log_eval_stdout(agent: Any, metrics: dict[str, float], step: int) -> None:

--- a/rl_garden/algorithms/offline.py
+++ b/rl_garden/algorithms/offline.py
@@ -7,7 +7,9 @@ pretraining entrypoints.
 """
 from __future__ import annotations
 
+import time
 from abc import abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -73,6 +75,8 @@ class OfflineRLAlgorithm(BaseAlgorithm):
         logger: Optional[Logger] = None,
         std_log: bool = True,
         log_freq: int = 1_000,
+        eval_freq: int = 0,
+        num_eval_steps: int = 50,
         checkpoint_dir: Optional[str] = None,
         checkpoint_freq: int = 0,
         save_replay_buffer: bool = False,
@@ -86,6 +90,8 @@ class OfflineRLAlgorithm(BaseAlgorithm):
         self.offline_sampling = offline_sampling
         self.std_log = std_log
         self.log_freq = log_freq
+        self.eval_freq = eval_freq
+        self.num_eval_steps = num_eval_steps
         self.checkpoint_dir = checkpoint_dir
         self.checkpoint_freq = checkpoint_freq
         self.save_replay_buffer = save_replay_buffer
@@ -117,7 +123,51 @@ class OfflineRLAlgorithm(BaseAlgorithm):
             save_final_checkpoint=self.save_final_checkpoint,
             log_freq=self.log_freq,
             std_log=self.std_log,
+            eval_freq=self.eval_freq,
         )
+
+    # --- eval ---
+
+    def _obs_to_policy_device(self, obs):
+        """Move CPU-backed env observations to the policy device for inference."""
+        if isinstance(obs, dict):
+            return {
+                k: v if v.device == self.device else v.to(self.device)
+                for k, v in obs.items()
+            }
+        if obs.device == self.device:
+            return obs
+        return obs.to(self.device)
+
+    def _eval_action(self, obs) -> torch.Tensor:
+        with torch.no_grad():
+            return self.policy.predict(
+                self._obs_to_policy_device(obs), deterministic=True
+            )
+
+    def _evaluate(self) -> dict[str, float]:
+        if self.eval_env is None:
+            return {}
+        self.policy.eval()
+        obs, _ = self.eval_env.reset()
+        metrics: dict[str, list[torch.Tensor]] = defaultdict(list)
+        for _ in range(self.num_eval_steps):
+            with torch.no_grad():
+                obs, _, _, _, infos = self.eval_env.step(self._eval_action(obs))
+                if "final_info" in infos:
+                    for k, v in infos["final_info"]["episode"].items():
+                        metrics[k].append(v)
+        self.policy.train()
+        out: dict[str, float] = {}
+        for k, vs in metrics.items():
+            out[k] = float(torch.stack(vs).float().mean().item())
+        return out
+
+    def _log_eval_metrics(self, metrics: dict[str, float], step: int) -> None:
+        if self.logger is None:
+            return
+        for key, value in metrics.items():
+            self.logger.add_scalar(f"eval/{key}", value, step)
 
     def _checkpoint_metadata(self) -> dict[str, Any]:
         return {
@@ -204,6 +254,26 @@ def _log_update_metrics(agent: Any, metrics: dict[str, float], step: int) -> Non
         logger.add_scalar(f"losses/{key}", value, step)
 
 
+def _log_eval_stdout(agent: Any, metrics: dict[str, float], step: int) -> None:
+    """Print a one-line eval summary to stdout in the style of
+    ``OffPolicyAlgorithm.learn``."""
+    # Use _first_metric if the agent provides it, otherwise fall back to dict.get.
+    first = getattr(agent, "_first_metric", None)
+    if first is not None:
+        eval_return = first(metrics, ("return",))
+        eval_success = first(metrics, ("success_at_end", "success_once"))
+    else:
+        eval_return = metrics.get("return", float("nan"))
+        eval_success = metrics.get("success_at_end", metrics.get("success_once", float("nan")))
+    fmt = getattr(agent, "_fmt_metric", lambda v: "nan" if v != v else f"{v:.4f}")
+    print(
+        f"[offline_eval] step={step} "
+        f"return={fmt(eval_return)} "
+        f"success_at_end={fmt(eval_success)}",
+        flush=True,
+    )
+
+
 def run_offline_pretraining(
     agent: Any,
     *,
@@ -216,12 +286,17 @@ def run_offline_pretraining(
     save_final_checkpoint: bool = True,
     log_freq: int = 1_000,
     std_log: bool = True,
+    eval_freq: int = 0,
     desc: str = "offline",
 ) -> OfflinePretrainResult:
     """Run an offline gradient loop for any agent exposing ``train()``.
 
     ``agent._global_step`` is advanced in offline update-step units. The agent's
     own ``train()`` method remains responsible for ``_global_update``.
+
+    When *eval_freq* > 0 and the agent provides ``_evaluate`` /
+    ``_log_eval_metrics``, the loop evaluates the current policy at regular
+    intervals.  The agent must have a real ``eval_env`` set beforehand.
     """
     if num_steps <= 0:
         raise ValueError(f"num_steps must be positive, got {num_steps}.")
@@ -235,10 +310,26 @@ def run_offline_pretraining(
     start_step = int(getattr(agent, "_global_step", 0))
     final_target = start_step + num_steps
 
+    _has_eval = (
+        eval_freq > 0
+        and hasattr(agent, "_evaluate")
+        and hasattr(agent, "_log_eval_metrics")
+    )
+
     for step in trange(start_step, final_target, desc=desc):
         last_metrics = agent.train(gradient_steps)
         global_step = step + 1
         agent._global_step = global_step
+
+        if _has_eval and global_step % eval_freq == 0 and getattr(agent, "eval_env", None) is not None:
+            t0 = time.perf_counter()
+            eval_metrics = agent._evaluate()
+            agent._log_eval_metrics(eval_metrics, global_step)
+            if std_log:
+                _log_eval_stdout(agent, eval_metrics, global_step)
+            logger = getattr(agent, "logger", None)
+            if logger is not None:
+                logger.add_scalar("time/eval_time", time.perf_counter() - t0, global_step)
 
         if log_freq > 0 and global_step % log_freq == 0:
             _log_update_metrics(agent, last_metrics, global_step)

--- a/rl_garden/algorithms/wsrl.py
+++ b/rl_garden/algorithms/wsrl.py
@@ -264,37 +264,16 @@ class WSRL(_CalQLRolloutTrainingShell):
 
     @staticmethod
     def _update_metric_tags(metrics: dict[str, float]) -> dict[str, float]:
+        """Map raw metric keys to namespaced paths using Logger's mapping."""
         tagged: dict[str, float] = {}
-        loss_keys = {
-            "critic_loss",
-            "actor_loss",
-            "td_loss",
-            "cql_loss",
-            "alpha_loss",
-            "cql_alpha_loss",
-        }
-        for key, value in metrics.items():
-            if key in loss_keys:
-                tagged[f"losses/{key}"] = value
-            elif key == "predicted_q":
-                tagged["q/predicted"] = value
-            elif key == "target_q":
-                tagged["q/target"] = value
-            elif key == "cql_ood_values":
-                tagged["q/cql_ood"] = value
-            elif key == "cql_q_diff":
-                tagged["q/cql_diff"] = value
-            elif key == "cql_alpha":
-                tagged["cql/alpha"] = value
-            elif key == "calql_bound_rate":
-                tagged["cql/bound_rate"] = value
-            elif key == "alpha":
-                tagged["entropy/alpha"] = value
-            elif key == "utd_ratio":
-                tagged["train/utd_ratio"] = value
-            else:
-                tagged[f"losses/{key}"] = value
+        namespaces = Logger.OFFLINE_METRIC_NAMESPACES
 
+        for key, value in metrics.items():
+            # Use explicit mapping or default to losses namespace
+            full_path = namespaces.get(key, f"losses/{key}")
+            tagged[full_path] = value
+
+        # Derived metric: TD RMSE from TD loss
         if "td_loss" in metrics:
             tagged["q/td_rmse"] = float(np.sqrt(max(metrics["td_loss"], 0.0)))
         return tagged

--- a/rl_garden/algorithms/wsrl.py
+++ b/rl_garden/algorithms/wsrl.py
@@ -266,7 +266,7 @@ class WSRL(_CalQLRolloutTrainingShell):
     def _update_metric_tags(metrics: dict[str, float]) -> dict[str, float]:
         """Map raw metric keys to namespaced paths using Logger's mapping."""
         tagged: dict[str, float] = {}
-        namespaces = Logger.OFFLINE_METRIC_NAMESPACES
+        namespaces = Logger.METRIC_NAMESPACES
 
         for key, value in metrics.items():
             # Use explicit mapping or default to losses namespace

--- a/rl_garden/common/cli_args.py
+++ b/rl_garden/common/cli_args.py
@@ -261,6 +261,13 @@ class OfflinePretrainArgs(LoggingArgs, CheckpointArgs):
     action_high: float = 1.0
     spec_num_envs: int = 1
 
+    # --- offline eval (optional) ---
+    env_id: Optional[str] = None
+    num_eval_envs: int = 1
+    control_mode: str = "pd_joint_delta_pos"
+    sim_backend: str = "gpu"
+    render_backend: str = "gpu"
+
 
 CQLTrainingArgs = OfflinePretrainArgs
 

--- a/rl_garden/common/logger.py
+++ b/rl_garden/common/logger.py
@@ -114,6 +114,103 @@ class Logger:
         elif self.writer is not None:
             self.writer.add_text(tag, str(value))
 
+    # --- Offline RL logging utilities ---
+
+    # Explicit namespace mapping for offline RL metrics
+    OFFLINE_METRIC_NAMESPACES = {
+        # Q-value metrics
+        "predicted_q": "q/predicted",
+        "target_q": "q/target",
+        "cql_ood_values": "q/cql_ood",
+        "cql_q_diff": "q/cql_diff",
+        # Loss metrics
+        "actor_loss": "losses/actor_loss",
+        "critic_loss": "losses/critic_loss",
+        "td_loss": "losses/td_loss",
+        "cql_loss": "losses/cql_loss",
+        "alpha_loss": "losses/alpha_loss",
+        "cql_alpha_loss": "losses/cql_alpha_loss",
+        # CQL-specific metrics
+        "cql_alpha": "cql/alpha",
+        "calql_bound_rate": "cql/bound_rate",
+        # Entropy metrics
+        "alpha": "entropy/alpha",
+        # Training metrics
+        "utd_ratio": "train/utd_ratio",
+    }
+
+    def log_offline_metrics(
+        self,
+        metrics: dict[str, float],
+        step: int,
+        *,
+        metric_namespaces: dict[str, str] | None = None,
+        default_namespace: str = "losses",
+    ) -> None:
+        """Log offline RL training metrics with explicit namespace mapping.
+
+        Each metric is logged to its explicitly defined namespace path.
+        Unknown metrics are logged to the default namespace.
+
+        Args:
+            metrics: Raw metric dict from training.
+            step: Global step for logging.
+            metric_namespaces: Mapping from metric keys to full namespace paths.
+                Example: {"predicted_q": "q/predicted", "actor_loss": "losses/actor_loss"}
+                If None, uses Logger.OFFLINE_METRIC_NAMESPACES.
+            default_namespace: Namespace prefix for unmapped metrics (default: "losses").
+        """
+        if metric_namespaces is None:
+            metric_namespaces = self.OFFLINE_METRIC_NAMESPACES
+
+        for key, value in metrics.items():
+            if not isinstance(value, (int, float)):
+                continue
+            # Use explicit mapping or default namespace
+            full_path = metric_namespaces.get(key, f"{default_namespace}/{key}")
+            self.add_scalar(full_path, value, step)
+
+    @staticmethod
+    def format_offline_metrics(
+        metrics: dict[str, float],
+        *,
+        metric_namespaces: dict[str, str] | None = None,
+    ) -> tuple[str, str]:
+        """Format offline metrics for console output.
+
+        Separates metrics into loss and Q-value groups based on their namespace.
+
+        Args:
+            metrics: Raw metric dict from training.
+            metric_namespaces: Mapping from metric keys to full namespace paths.
+                If None, uses Logger.OFFLINE_METRIC_NAMESPACES.
+
+        Returns:
+            (loss_summary, q_summary) as formatted strings.
+        """
+        if metric_namespaces is None:
+            metric_namespaces = Logger.OFFLINE_METRIC_NAMESPACES
+
+        loss_parts: list[str] = []
+        q_parts: list[str] = []
+
+        for key, value in metrics.items():
+            if not isinstance(value, (int, float)):
+                continue
+
+            # Get the full namespace path
+            full_path = metric_namespaces.get(key, f"losses/{key}")
+            namespace, _, display_key = full_path.rpartition("/")
+
+            # Group by namespace for console output
+            if namespace == "q":
+                q_parts.append(f"{display_key}={value:.4f}")
+            elif namespace == "losses":
+                # For losses and other namespaces, show the key as-is
+                loss_parts.append(f"{key}={value:.4f}")
+
+        return " ".join(loss_parts), " ".join(q_parts)
+
     def close(self) -> None:
         if self.writer is not None:
             self.writer.close()

--- a/rl_garden/common/logger.py
+++ b/rl_garden/common/logger.py
@@ -114,10 +114,10 @@ class Logger:
         elif self.writer is not None:
             self.writer.add_text(tag, str(value))
 
-    # --- Offline RL logging utilities ---
+    # --- RL metric logging utilities ---
 
-    # Explicit namespace mapping for offline RL metrics
-    OFFLINE_METRIC_NAMESPACES = {
+    # Explicit namespace mapping for RL training metrics (shared by online and offline)
+    METRIC_NAMESPACES = {
         # Q-value metrics
         "predicted_q": "q/predicted",
         "target_q": "q/target",
@@ -139,7 +139,7 @@ class Logger:
         "utd_ratio": "train/utd_ratio",
     }
 
-    def log_offline_metrics(
+    def log_metrics(
         self,
         metrics: dict[str, float],
         step: int,
@@ -147,7 +147,7 @@ class Logger:
         metric_namespaces: dict[str, str] | None = None,
         default_namespace: str = "losses",
     ) -> None:
-        """Log offline RL training metrics with explicit namespace mapping.
+        """Log RL training metrics with explicit namespace mapping.
 
         Each metric is logged to its explicitly defined namespace path.
         Unknown metrics are logged to the default namespace.
@@ -157,11 +157,11 @@ class Logger:
             step: Global step for logging.
             metric_namespaces: Mapping from metric keys to full namespace paths.
                 Example: {"predicted_q": "q/predicted", "actor_loss": "losses/actor_loss"}
-                If None, uses Logger.OFFLINE_METRIC_NAMESPACES.
+                If None, uses Logger.METRIC_NAMESPACES.
             default_namespace: Namespace prefix for unmapped metrics (default: "losses").
         """
         if metric_namespaces is None:
-            metric_namespaces = self.OFFLINE_METRIC_NAMESPACES
+            metric_namespaces = self.METRIC_NAMESPACES
 
         for key, value in metrics.items():
             if not isinstance(value, (int, float)):
@@ -171,25 +171,25 @@ class Logger:
             self.add_scalar(full_path, value, step)
 
     @staticmethod
-    def format_offline_metrics(
+    def format_metrics(
         metrics: dict[str, float],
         *,
         metric_namespaces: dict[str, str] | None = None,
     ) -> tuple[str, str]:
-        """Format offline metrics for console output.
+        """Format training metrics for console output.
 
         Separates metrics into loss and Q-value groups based on their namespace.
 
         Args:
             metrics: Raw metric dict from training.
             metric_namespaces: Mapping from metric keys to full namespace paths.
-                If None, uses Logger.OFFLINE_METRIC_NAMESPACES.
+                If None, uses Logger.METRIC_NAMESPACES.
 
         Returns:
             (loss_summary, q_summary) as formatted strings.
         """
         if metric_namespaces is None:
-            metric_namespaces = Logger.OFFLINE_METRIC_NAMESPACES
+            metric_namespaces = Logger.METRIC_NAMESPACES
 
         loss_parts: list[str] = []
         q_parts: list[str] = []


### PR DESCRIPTION
TODO：
1. 扩展 `Logger.METRIC_NAMESPACES`：
将 `OFFLINE_METRIC_NAMESPACES` 扩展为全局的 `METRIC_NAMESPACES`，包含所有 RL metrics
2.添加通用的 `log_metrics()` 方法