### PR TITLE
fix(sac): stabilize vmap resnet training

### DIFF
--- a/examples/train_sac_rgbd.py
+++ b/examples/train_sac_rgbd.py
@@ -107,6 +107,7 @@ def main() -> None:
         utd=args.utd,
         policy_lr=args.policy_lr,
         q_lr=args.q_lr,
+        critic_impl=args.critic_impl,
         seed=args.seed,
         logger=logger,
         std_log=args.std_log,

--- a/examples/train_sac_state.py
+++ b/examples/train_sac_state.py
@@ -90,6 +90,7 @@ def main() -> None:
         utd=args.utd,
         policy_lr=args.policy_lr,
         q_lr=args.q_lr,
+        critic_impl=args.critic_impl,
         seed=args.seed,
         logger=logger,
         std_log=args.std_log,

--- a/rl_garden/algorithms/sac.py
+++ b/rl_garden/algorithms/sac.py
@@ -68,6 +68,7 @@ class SAC(SACCore, OffPolicyAlgorithm):
         critic_hidden_dims: Optional[Sequence[int]] = None,
         n_critics: int = 2,
         critic_subsample_size: Optional[int] = None,
+        critic_impl: Literal["vmap", "legacy"] = "vmap",
         actor_feature_dim: Optional[int] = None,
         critic_spatial_emb_dim: int = 1024,
         image_encoder_factory: Optional[ImageEncoderFactory] = None,
@@ -138,6 +139,7 @@ class SAC(SACCore, OffPolicyAlgorithm):
         )
         self.n_critics = n_critics
         self.critic_subsample_size = critic_subsample_size
+        self.critic_impl = critic_impl
         self.actor_feature_dim = actor_feature_dim
         self.critic_spatial_emb_dim = critic_spatial_emb_dim
 
@@ -211,6 +213,7 @@ class SAC(SACCore, OffPolicyAlgorithm):
             "net_arch": self.net_arch,
             "n_critics": self.n_critics,
             "critic_subsample_size": self.critic_subsample_size,
+            "critic_impl": self.critic_impl,
         }
         if self._is_dict_obs:
             meta.update(
@@ -370,6 +373,7 @@ class SAC(SACCore, OffPolicyAlgorithm):
             net_arch=self.net_arch,
             n_critics=self.n_critics,
             critic_subsample_size=self.critic_subsample_size,
+            critic_impl=self.critic_impl,
             actor_feature_dim=self.actor_feature_dim,
             critic_spatial_emb_dim=self.critic_spatial_emb_dim,
         )

--- a/rl_garden/common/cli_args.py
+++ b/rl_garden/common/cli_args.py
@@ -58,6 +58,7 @@ class SACTrainingArgs(ManiSkillRunArgs, CheckpointArgs):
     tau: float = 0.01
     policy_lr: float = 3e-4
     q_lr: float = 3e-4
+    critic_impl: Literal["vmap", "legacy"] = "vmap"
 
 
 @dataclass

--- a/rl_garden/networks/__init__.py
+++ b/rl_garden/networks/__init__.py
@@ -1,5 +1,6 @@
 from rl_garden.networks.actor_critic import (
     BackboneType,
+    CriticImpl,
     DiagGaussianActor,
     EnsembleQCritic,
     SquashedGaussianActor,
@@ -11,6 +12,7 @@ from rl_garden.networks.value import ValueNetwork
 
 __all__ = [
     "BackboneType",
+    "CriticImpl",
     "DiagGaussianActor",
     "EnsembleQCritic",
     "KernelInit",

--- a/rl_garden/networks/actor_critic.py
+++ b/rl_garden/networks/actor_critic.py
@@ -11,6 +11,7 @@ from gymnasium import spaces
 from rl_garden.networks.mlp import KernelInit, MLPResNet, create_mlp
 
 BackboneType = Literal["mlp", "mlp_resnet"]
+CriticImpl = Literal["vmap", "legacy"]
 
 
 def get_actor_critic_arch(
@@ -340,24 +341,20 @@ def _dotted_from_safe(safe: str, prefix: str) -> str:
 
 
 class EnsembleQCritic(nn.Module):
-    """Ensemble of Q(s, a) networks, vmap-fused via ``torch.func``.
+    """Ensemble of Q(s, a) networks.
 
-    Replaces the old ``nn.ModuleList`` of N independent ``_QHead`` instances
-    with a single prototype + stacked parameters of shape ``(n_critics, ...)``.
-    ``forward`` runs all N critics in one fused pass via
-    ``torch.func.vmap(functional_call)``, eliminating per-critic kernel launch
-    overhead. The public API (``forward`` returning a tuple, ``forward_all``
-    returning ``(n_critics, batch, 1)``) is unchanged so ``WSRLPolicy`` and
-    the polyak target update need no modifications.
+    ``critic_impl="vmap"`` uses the fused ``torch.func.vmap`` implementation.
+    ``critic_impl="legacy"`` keeps the pre-vmap ``nn.ModuleList`` layout for
+    training-regression ablations while preserving the same public API.
 
     Each critic is initialized independently before stacking — the diverse
-    random init across the ensemble is preserved.
+    random init across the ensemble is preserved in both modes.
 
-    Checkpoint state_dict keys:
+    Vmap checkpoint state_dict keys:
         ``ens_p_<dotted_path>``  (e.g. ``ens_p_trunk__0__weight``, shape
         ``(n_critics, *original_shape)``).
     Legacy checkpoints with ``q_nets.<i>.<dotted_path>`` keys are migrated
-    transparently via ``_load_from_state_dict`` (see below).
+    transparently when loading into vmap mode.
     """
 
     def __init__(
@@ -373,12 +370,18 @@ class EnsembleQCritic(nn.Module):
         dropout_rate: Optional[float] = None,
         kernel_init: Optional[KernelInit] = None,
         backbone_type: BackboneType = "mlp",
+        critic_impl: CriticImpl = "vmap",
     ) -> None:
         super().__init__()
         if n_critics < 1:
             raise ValueError(f"n_critics must be >= 1, got {n_critics}")
+        if critic_impl not in ("vmap", "legacy"):
+            raise ValueError(
+                f"critic_impl must be 'vmap' or 'legacy', got {critic_impl!r}"
+            )
 
         self.n_critics = n_critics
+        self.critic_impl = critic_impl
         act_dim = int(np.prod(action_space.shape))
         self._head_kwargs = dict(
             features_dim=features_dim,
@@ -391,6 +394,14 @@ class EnsembleQCritic(nn.Module):
             dropout_rate=dropout_rate,
             kernel_init=kernel_init,
         )
+
+        if critic_impl == "legacy":
+            self.q_nets = nn.ModuleList(
+                [_QHead(**self._head_kwargs) for _ in range(n_critics)]
+            )
+            self._dotted_param_names = []
+            self._dotted_buffer_names = []
+            return
 
         # 1) Initialize N independent critics so each has diverse random init.
         critics = [_QHead(**self._head_kwargs) for _ in range(n_critics)]
@@ -418,19 +429,27 @@ class EnsembleQCritic(nn.Module):
         # 5) Prototype carries the forward() structure for functional_call.
         #    Stored via object.__setattr__ to bypass nn.Module's submodule
         #    tracking — we don't want prototype params in ``self.parameters()``.
+        #    Save/restore CPU RNG state so prototype init doesn't shift
+        #    downstream random ops such as replay-buffer sampling.
+        _cpu_rng = torch.get_rng_state()
         prototype = _QHead(**self._head_kwargs)
+        torch.set_rng_state(_cpu_rng)
         # Move prototype to meta device so its parameters take no memory and
         # cannot be accidentally trained. functional_call replaces all params.
         prototype.to("meta")
         object.__setattr__(self, "_prototype", prototype)
 
     def _gather_params(self) -> dict[str, torch.Tensor]:
+        if self.critic_impl != "vmap":
+            raise RuntimeError("_gather_params is only valid for critic_impl='vmap'.")
         return {
             dotted: getattr(self, _safe_name(dotted, _PARAM_PREFIX))
             for dotted in self._dotted_param_names
         }
 
     def _gather_buffers(self) -> dict[str, torch.Tensor]:
+        if self.critic_impl != "vmap":
+            raise RuntimeError("_gather_buffers is only valid for critic_impl='vmap'.")
         return {
             dotted: getattr(self, _safe_name(dotted, _BUFFER_PREFIX))
             for dotted in self._dotted_buffer_names
@@ -440,6 +459,8 @@ class EnsembleQCritic(nn.Module):
         self, features: torch.Tensor, actions: torch.Tensor
     ) -> torch.Tensor:
         """Run all N critics in one fused pass; returns ``(n_critics, batch, 1)``."""
+        if self.critic_impl != "vmap":
+            raise RuntimeError("_vmapped_forward is only valid for critic_impl='vmap'.")
         prototype = self._prototype
 
         def single(params, buffers, f, a):
@@ -452,11 +473,15 @@ class EnsembleQCritic(nn.Module):
     def forward(
         self, features: torch.Tensor, actions: torch.Tensor
     ) -> tuple[torch.Tensor, ...]:
+        if self.critic_impl == "legacy":
+            return tuple(q(features, actions) for q in self.q_nets)
         return tuple(self._vmapped_forward(features, actions).unbind(0))
 
     def forward_all(
         self, features: torch.Tensor, actions: torch.Tensor
     ) -> torch.Tensor:
+        if self.critic_impl == "legacy":
+            return torch.stack(self.forward(features, actions), dim=0)
         return self._vmapped_forward(features, actions)
 
     # ------------------------------------------------------------------
@@ -473,6 +498,17 @@ class EnsembleQCritic(nn.Module):
         unexpected_keys,
         error_msgs,
     ):
+        if getattr(self, "critic_impl", "vmap") == "legacy":
+            return super()._load_from_state_dict(
+                state_dict,
+                prefix,
+                local_metadata,
+                strict,
+                missing_keys,
+                unexpected_keys,
+                error_msgs,
+            )
+
         # Detect legacy ``q_nets.<i>.<...>`` layout in the keys that target
         # this module and convert them in-place to the new ``ens_p_<...>``
         # stacked layout before delegating to the base implementation.

--- a/rl_garden/policies/sac_policy.py
+++ b/rl_garden/policies/sac_policy.py
@@ -26,6 +26,7 @@ from rl_garden.common.types import Obs
 from rl_garden.encoders.base import BaseFeaturesExtractor
 from rl_garden.networks import (
     BackboneType,
+    CriticImpl,
     EnsembleQCritic,
     KernelInit,
     SpatialEmbQEnsemble,
@@ -130,6 +131,7 @@ class SACPolicy(BasePolicy):
         critic_dropout_rate: Optional[float] = None,
         kernel_init: Optional[KernelInit] = None,
         backbone_type: BackboneType = "mlp",
+        critic_impl: CriticImpl = "vmap",
         std_parameterization: Literal["exp", "uniform"] = "exp",
         log_std_mode: Literal["clamp", "tanh"] = "tanh",
         log_std_min: float = LOG_STD_MIN,
@@ -220,6 +222,7 @@ class SACPolicy(BasePolicy):
                 dropout_rate=critic_dropout_rate,
                 kernel_init=kernel_init,
                 backbone_type=backbone_type,
+                critic_impl=critic_impl,
             )
             self.critic_target = ContinuousCritic(
                 fd,
@@ -232,6 +235,7 @@ class SACPolicy(BasePolicy):
                 dropout_rate=critic_dropout_rate,
                 kernel_init=kernel_init,
                 backbone_type=backbone_type,
+                critic_impl=critic_impl,
             )
         else:
             raise ValueError(

--- a/scripts/train_sac_rgbd.sh
+++ b/scripts/train_sac_rgbd.sh
@@ -58,6 +58,28 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+ENCODER="plain_conv"
+HAS_Q_LR=0
+for ((i = 0; i < ${#FORWARD_ARGS[@]}; i++)); do
+    arg="${FORWARD_ARGS[$i]}"
+    case "$arg" in
+        --encoder)
+            if (( i + 1 < ${#FORWARD_ARGS[@]} )); then
+                ENCODER="${FORWARD_ARGS[$((i + 1))]}"
+            fi
+            ;;
+        --encoder=*)
+            ENCODER="${arg#*=}"
+            ;;
+        --q_lr|--q-lr|--q_lr=*|--q-lr=*)
+            HAS_Q_LR=1
+            ;;
+    esac
+done
+if [[ "$ENCODER" == resnet* && "$HAS_Q_LR" -eq 0 ]]; then
+    FORWARD_ARGS+=(--q_lr 1e-4)
+fi
+
 exec env RLG_STD_LOG="$STD_LOG" RLG_LOG_TYPE="$LOG_TYPE" RLG_LOG_KEYWORDS="$LOG_KEYWORDS" "$PYTHON_BIN" -u "$REPO_DIR/examples/train_sac_rgbd.py" \
     --env_id PickCube-v1 \
     --obs_mode rgb \

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -111,6 +111,48 @@ def test_ensemble_q_critic_forward_all_shape():
     assert q_all.shape == (5, 9, 1)
 
 
+def test_ensemble_legacy_impl_forward_shape_and_grad():
+    critic = EnsembleQCritic(
+        features_dim=11,
+        action_space=_action_space(),
+        hidden_dims=[32, 32],
+        n_critics=7,
+        critic_impl="legacy",
+    )
+    features = torch.randn(5, 11)
+    actions = torch.randn(5, 3)
+    q_all = critic.forward_all(features, actions)
+    assert q_all.shape == (7, 5, 1)
+    assert hasattr(critic, "q_nets")
+
+    q_all.sum().backward()
+    assert all(
+        any(param.grad is not None for param in q_net.parameters())
+        for q_net in critic.q_nets
+    )
+
+
+def test_ensemble_vmap_prototype_does_not_shift_cpu_rng():
+    def construct_and_sample(critic_impl: str) -> tuple[torch.Tensor, torch.Tensor]:
+        torch.manual_seed(123)
+        EnsembleQCritic(
+            features_dim=11,
+            action_space=_action_space(),
+            hidden_dims=[32, 32],
+            n_critics=7,
+            critic_impl=critic_impl,
+        )
+        rng_after_construct = torch.get_rng_state().clone()
+        replay_like_sample = torch.randint(0, 100000, (32,))
+        return rng_after_construct, replay_like_sample
+
+    vmap_rng, vmap_sample = construct_and_sample("vmap")
+    legacy_rng, legacy_sample = construct_and_sample("legacy")
+
+    assert torch.equal(vmap_rng, legacy_rng)
+    assert torch.equal(vmap_sample, legacy_sample)
+
+
 # --- New: GroupNorm / Dropout / kernel_init / MLPResNet ---
 
 

--- a/tests/test_sac_vmap_parity.py
+++ b/tests/test_sac_vmap_parity.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.algorithms import SAC
+from rl_garden.common.types import ReplayBufferSample
+from rl_garden.encoders import BaseFeaturesExtractor
+from rl_garden.networks.actor_critic import _PARAM_PREFIX, _safe_name
+
+
+class DummyVecEnv:
+    def __init__(self, observation_space: spaces.Space, action_space: spaces.Box) -> None:
+        self.num_envs = 1
+        self.single_observation_space = observation_space
+        self.single_action_space = action_space
+        self.action_space = action_space
+
+
+class TrainableBoxExtractor(BaseFeaturesExtractor):
+    def __init__(self, observation_space: spaces.Box, features_dim: int = 7) -> None:
+        super().__init__(observation_space, features_dim)
+        self.proj = torch.nn.Linear(int(np.prod(observation_space.shape)), features_dim)
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        return torch.tanh(self.proj(obs.float().flatten(start_dim=1)))
+
+
+class TrainableDictExtractor(BaseFeaturesExtractor):
+    def __init__(self, observation_space: spaces.Dict, features_dim: int = 7) -> None:
+        super().__init__(observation_space, features_dim)
+        self.state_proj = torch.nn.Linear(5, features_dim)
+        self.rgb_proj = torch.nn.Linear(3, features_dim)
+
+    def forward(self, obs: dict[str, torch.Tensor]) -> torch.Tensor:
+        state = obs["state"].float()
+        rgb = obs["rgb"].float().mean(dim=(1, 2)) / 255.0
+        return torch.tanh(self.state_proj(state) + self.rgb_proj(rgb))
+
+
+def _box_env() -> DummyVecEnv:
+    return DummyVecEnv(
+        spaces.Box(low=-10.0, high=10.0, shape=(5,), dtype=np.float32),
+        spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32),
+    )
+
+
+def _dict_env() -> DummyVecEnv:
+    return DummyVecEnv(
+        spaces.Dict(
+            {
+                "state": spaces.Box(low=-10.0, high=10.0, shape=(5,), dtype=np.float32),
+                "rgb": spaces.Box(low=0, high=255, shape=(8, 8, 3), dtype=np.uint8),
+            }
+        ),
+        spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32),
+    )
+
+
+def _make_agent(
+    env: DummyVecEnv,
+    critic_impl: str,
+    extractor_cls: type[BaseFeaturesExtractor],
+    *,
+    device: str = "cpu",
+) -> SAC:
+    torch.manual_seed(123)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(123)
+    return SAC(
+        env=env,
+        device=device,
+        buffer_device=device,
+        buffer_size=32,
+        batch_size=8,
+        learning_starts=0,
+        gamma=0.8,
+        tau=0.01,
+        training_freq=1,
+        utd=1.0,
+        policy_lr=3e-4,
+        q_lr=3e-4,
+        ent_coef="auto",
+        target_entropy="auto",
+        net_arch={"pi": [16, 16], "qf": [16, 16]},
+        n_critics=2,
+        critic_impl=critic_impl,
+        policy_kwargs={
+            "features_extractor_class": extractor_cls,
+            "features_extractor_kwargs": {"features_dim": 7},
+        },
+        eval_freq=0,
+        save_final_checkpoint=False,
+    )
+
+
+def _legacy_q_state_as_stacked(legacy_critic, dotted: str) -> torch.Tensor:
+    return torch.stack([q.state_dict()[dotted] for q in legacy_critic.q_nets], dim=0)
+
+
+def _assert_critic_close(vmap_critic, legacy_critic, *, atol: float, rtol: float) -> None:
+    for dotted in vmap_critic._dotted_param_names:
+        vmap_value = getattr(vmap_critic, _safe_name(dotted, _PARAM_PREFIX)).detach()
+        legacy_value = _legacy_q_state_as_stacked(legacy_critic, dotted).to(vmap_value.device)
+        torch.testing.assert_close(vmap_value, legacy_value, atol=atol, rtol=rtol)
+
+
+def _assert_module_params_close(
+    lhs: torch.nn.Module, rhs: torch.nn.Module, *, atol: float, rtol: float
+) -> None:
+    for lp, rp in zip(lhs.parameters(), rhs.parameters()):
+        torch.testing.assert_close(lp.detach(), rp.detach(), atol=atol, rtol=rtol)
+
+
+def _assert_agents_close(vmap: SAC, legacy: SAC, *, atol: float = 1e-6, rtol: float = 1e-6) -> None:
+    _assert_module_params_close(
+        vmap.policy.features_extractor,
+        legacy.policy.features_extractor,
+        atol=atol,
+        rtol=rtol,
+    )
+    _assert_module_params_close(vmap.policy.actor, legacy.policy.actor, atol=atol, rtol=rtol)
+    _assert_critic_close(vmap.policy.critic, legacy.policy.critic, atol=atol, rtol=rtol)
+    _assert_critic_close(
+        vmap.policy.critic_target,
+        legacy.policy.critic_target,
+        atol=atol,
+        rtol=rtol,
+    )
+    if vmap.log_alpha is not None:
+        torch.testing.assert_close(vmap.log_alpha, legacy.log_alpha, atol=atol, rtol=rtol)
+
+
+def _box_batch(device: str) -> ReplayBufferSample:
+    gen = torch.Generator(device=device)
+    gen.manual_seed(456)
+    obs = torch.randn(8, 5, generator=gen, device=device)
+    next_obs = torch.randn(8, 5, generator=gen, device=device)
+    actions = torch.randn(8, 2, generator=gen, device=device).clamp(-0.9, 0.9)
+    rewards = torch.randn(8, generator=gen, device=device)
+    dones = torch.randint(0, 2, (8,), generator=gen, device=device).float()
+    return ReplayBufferSample(obs, next_obs, actions, rewards, dones)
+
+
+def _dict_batch(device: str) -> ReplayBufferSample:
+    gen = torch.Generator(device=device)
+    gen.manual_seed(789)
+    obs = {
+        "state": torch.randn(8, 5, generator=gen, device=device),
+        "rgb": torch.randint(0, 256, (8, 8, 8, 3), generator=gen, device=device, dtype=torch.uint8),
+    }
+    next_obs = {
+        "state": torch.randn(8, 5, generator=gen, device=device),
+        "rgb": torch.randint(0, 256, (8, 8, 8, 3), generator=gen, device=device, dtype=torch.uint8),
+    }
+    actions = torch.randn(8, 2, generator=gen, device=device).clamp(-0.9, 0.9)
+    rewards = torch.randn(8, generator=gen, device=device)
+    dones = torch.randint(0, 2, (8,), generator=gen, device=device).float()
+    return ReplayBufferSample(obs, next_obs, actions, rewards, dones)
+
+
+def _install_fixed_sampler(agent: SAC, batch: ReplayBufferSample) -> None:
+    def _sample_train_batch(self, batch_size: int) -> ReplayBufferSample:
+        assert batch_size == 8
+        return batch
+
+    agent._sample_train_batch = types.MethodType(_sample_train_batch, agent)
+
+
+def _get_cuda_rng(device: str) -> torch.Tensor | None:
+    if not str(device).startswith("cuda"):
+        return None
+    return torch.cuda.get_rng_state(torch.device(device))
+
+
+def _set_cuda_rng(device: str, rng: torch.Tensor | None) -> None:
+    if rng is not None:
+        torch.cuda.set_rng_state(rng, torch.device(device))
+
+
+def _run_matched_train_step(
+    vmap: SAC,
+    legacy: SAC,
+    cpu_rng: torch.Tensor,
+    cuda_rng: torch.Tensor | None,
+    *,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    torch.set_rng_state(cpu_rng)
+    _set_cuda_rng(device, cuda_rng)
+    legacy_info = legacy.train(1, compute_info=True)
+    legacy_rng_after = torch.get_rng_state().clone()
+    legacy_cuda_rng_after = _get_cuda_rng(device)
+
+    torch.set_rng_state(cpu_rng)
+    _set_cuda_rng(device, cuda_rng)
+    vmap_info = vmap.train(1, compute_info=True)
+    vmap_rng_after = torch.get_rng_state().clone()
+    vmap_cuda_rng_after = _get_cuda_rng(device)
+
+    assert legacy_info.keys() == vmap_info.keys()
+    for key in legacy_info:
+        assert legacy_info[key] == pytest.approx(vmap_info[key], abs=1e-6, rel=1e-6)
+    assert torch.equal(legacy_rng_after, vmap_rng_after)
+    if legacy_cuda_rng_after is not None:
+        assert vmap_cuda_rng_after is not None
+        assert torch.equal(legacy_cuda_rng_after, vmap_cuda_rng_after)
+    return legacy_rng_after, legacy_cuda_rng_after
+
+
+@pytest.mark.parametrize(
+    "env_factory,extractor_cls",
+    [(_box_env, TrainableBoxExtractor), (_dict_env, TrainableDictExtractor)],
+)
+def test_sac_policy_init_vmap_matches_legacy(env_factory, extractor_cls):
+    legacy = _make_agent(env_factory(), "legacy", extractor_cls)
+    legacy_rng = torch.get_rng_state().clone()
+    legacy_sample = torch.randint(0, 100000, (16,))
+
+    vmap = _make_agent(env_factory(), "vmap", extractor_cls)
+    vmap_rng = torch.get_rng_state().clone()
+    vmap_sample = torch.randint(0, 100000, (16,))
+
+    assert torch.equal(vmap_rng, legacy_rng)
+    assert torch.equal(vmap_sample, legacy_sample)
+    _assert_agents_close(vmap, legacy)
+
+
+@pytest.mark.parametrize(
+    "env_factory,extractor_cls,batch_factory",
+    [
+        (_box_env, TrainableBoxExtractor, _box_batch),
+        (_dict_env, TrainableDictExtractor, _dict_batch),
+    ],
+)
+def test_sac_update_vmap_matches_legacy_on_fixed_batch(env_factory, extractor_cls, batch_factory):
+    legacy = _make_agent(env_factory(), "legacy", extractor_cls)
+    vmap = _make_agent(env_factory(), "vmap", extractor_cls)
+    _install_fixed_sampler(legacy, batch_factory("cpu"))
+    _install_fixed_sampler(vmap, batch_factory("cpu"))
+
+    _assert_agents_close(vmap, legacy)
+    cpu_rng = torch.manual_seed(2026).get_state()
+    cuda_rng = None
+    for _ in range(8):
+        cpu_rng, cuda_rng = _run_matched_train_step(
+            vmap, legacy, cpu_rng, cuda_rng, device="cpu"
+        )
+        _assert_agents_close(vmap, legacy, atol=2e-6, rtol=2e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_sac_update_vmap_matches_legacy_on_fixed_batch_cuda():
+    legacy = _make_agent(_box_env(), "legacy", TrainableBoxExtractor, device="cuda")
+    vmap = _make_agent(_box_env(), "vmap", TrainableBoxExtractor, device="cuda")
+    _install_fixed_sampler(legacy, _box_batch("cuda"))
+    _install_fixed_sampler(vmap, _box_batch("cuda"))
+
+    _assert_agents_close(vmap, legacy)
+    cpu_rng = torch.manual_seed(2026).get_state()
+    torch.cuda.manual_seed_all(2026)
+    cuda_rng = _get_cuda_rng("cuda")
+    for _ in range(8):
+        cpu_rng, cuda_rng = _run_matched_train_step(
+            vmap, legacy, cpu_rng, cuda_rng, device="cuda"
+        )
+        _assert_agents_close(vmap, legacy, atol=2e-6, rtol=2e-6)


### PR DESCRIPTION
## Summary

- Preserve CPU RNG state around the vmap critic prototype so replay sampling is not shifted by throwaway weight initialization.
- Add a `critic_impl` switch (`vmap` default, `legacy` fallback) for SAC critic ablations and recovery runs.
- Use `q_lr=1e-4` by default only for ResNet RGB runs launched through `scripts/train_sac_rgbd.sh`, unless the caller passes an explicit q_lr.

## Notes

- This intentionally does not include the alpha_min or target-entropy probes; those did not validate as fixes.
- The ViT/structured critic path from main is preserved; `critic_impl` only affects the normal EnsembleQCritic path.

## Validation

- `pytest -q tests/test_networks.py tests/test_sac_vmap_parity.py tests/test_sac_core.py`
- CLI check confirmed `--critic-impl` is exposed and discarded alpha options are absent.
- Launcher dry-runs confirmed ResNet gets `--q_lr 1e-4`, explicit q_lr is preserved, and plain_conv is unchanged.
