### PR TITLE
Fix/vit debug

### DIFF
--- a/rl_garden/algorithms/residual.py
+++ b/rl_garden/algorithms/residual.py
@@ -157,7 +157,7 @@ class ResidualSAC(SAC):
         min_q = self.policy.min_q_value(features, action, subsample_size=None, target=False)
         return (alpha * log_prob - min_q).mean(), log_prob.detach()
 
-    def _actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
+    def _compute_actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
         return self.policy.actor_diagnostics(data.obs, data.base_actions)
 
     def _reset_base_action_provider(self, env_ids: Optional[torch.Tensor] = None) -> None:

--- a/rl_garden/algorithms/residual.py
+++ b/rl_garden/algorithms/residual.py
@@ -98,6 +98,7 @@ class ResidualSAC(SAC):
             critic_subsample_size=self.critic_subsample_size,
             actor_feature_dim=self.actor_feature_dim,
             critic_spatial_emb_dim=self.critic_spatial_emb_dim,
+            critic_use_layer_norm=True,
         )
 
     def _setup_model(self) -> None:
@@ -155,6 +156,9 @@ class ResidualSAC(SAC):
         )
         min_q = self.policy.min_q_value(features, action, subsample_size=None, target=False)
         return (alpha * log_prob - min_q).mean(), log_prob.detach()
+
+    def _actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
+        return self.policy.actor_diagnostics(data.obs, data.base_actions)
 
     def _reset_base_action_provider(self, env_ids: Optional[torch.Tensor] = None) -> None:
         self.base_action_provider.reset(env_ids=env_ids)

--- a/rl_garden/algorithms/sac_core.py
+++ b/rl_garden/algorithms/sac_core.py
@@ -64,13 +64,13 @@ class SACCore:
     def _post_actor_update(self, data) -> dict[str, torch.Tensor]:
         return {}
 
-    def _actor_diagnostics(self, obs) -> dict[str, torch.Tensor]:
+    def _actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
         device = torch.device(getattr(self, "device", "cpu"))
         devices: list[int] = []
         if device.type == "cuda" and torch.cuda.is_available():
             devices = [torch.cuda.current_device() if device.index is None else device.index]
         with torch.random.fork_rng(devices=devices):
-            return self.policy.actor_diagnostics(obs)
+            return self.policy.actor_diagnostics(data.obs)
 
     def _target_update(self) -> None:
         polyak_update(
@@ -234,7 +234,7 @@ class SACCore:
                 if compute_info:
                     actor_losses_t.append(actor_loss.detach())
                     info_accum.setdefault("entropy", []).append(-log_prob_detached.mean())
-                    for key, value in self._actor_diagnostics(data.obs).items():
+                    for key, value in self._actor_diagnostics(data).items():
                         info_accum.setdefault(key, []).append(value)
                     for key, value in post_info.items():
                         info_accum.setdefault(key, []).append(value)
@@ -327,7 +327,7 @@ class SACCore:
             return {}
 
         post_info["entropy"] = -log_prob_detached.mean()
-        post_info.update(self._actor_diagnostics(full_batch.obs))
+        post_info.update(self._actor_diagnostics(full_batch))
 
         critic_mean = self._reduce_tensor_lists({"critic_loss": critic_losses_t})
         info_mean = self._reduce_tensor_lists(info_accum)

--- a/rl_garden/algorithms/sac_core.py
+++ b/rl_garden/algorithms/sac_core.py
@@ -65,12 +65,25 @@ class SACCore:
         return {}
 
     def _actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
+        """Run actor diagnostics without perturbing training RNG.
+
+        Subclasses should override ``_compute_actor_diagnostics`` instead of
+        this method so the RNG isolation invariant is preserved.
+        """
         device = torch.device(getattr(self, "device", "cpu"))
         devices: list[int] = []
         if device.type == "cuda" and torch.cuda.is_available():
             devices = [torch.cuda.current_device() if device.index is None else device.index]
         with torch.random.fork_rng(devices=devices):
-            return self.policy.actor_diagnostics(data.obs)
+            return self._compute_actor_diagnostics(data)
+
+    def _compute_actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
+        """Compute actor diagnostics for a sampled replay batch.
+
+        Subclasses may override this to pass algorithm-specific batch fields to
+        policy diagnostics.
+        """
+        return self.policy.actor_diagnostics(data.obs)
 
     def _target_update(self) -> None:
         polyak_update(

--- a/rl_garden/envs/custom/tasks/peg_insertion_side.py
+++ b/rl_garden/envs/custom/tasks/peg_insertion_side.py
@@ -99,9 +99,13 @@ class PegInsertionSideEnv(BaseEnv):
         num_envs=1,
         reconfiguration_freq=None,
         debug_pose_vis: bool = False,
+        include_reaching_reward: bool = True,
+        include_grasp_reward: bool = True,
         **kwargs,
     ):
         self.debug_pose_vis = debug_pose_vis
+        self.include_reaching_reward = include_reaching_reward
+        self.include_grasp_reward = include_grasp_reward
         if reconfiguration_freq is None:
             if num_envs == 1:
                 reconfiguration_freq = 1
@@ -379,7 +383,11 @@ class PegInsertionSideEnv(BaseEnv):
 
         # check with max_angle=20 to ensure gripper isn't grasping peg at an awkward pose
         is_grasped = self.agent.is_grasping(self.peg, max_angle=20)
-        reward = reaching_reward + is_grasped
+        reward = torch.zeros_like(reaching_reward)
+        if self.include_reaching_reward:
+            reward = reward + reaching_reward
+        if self.include_grasp_reward:
+            reward = reward + is_grasped
 
         # Stage 3: Orient the grasped peg properly towards the hole
 

--- a/rl_garden/envs/custom/tasks/peg_insertion_side_pegonly.py
+++ b/rl_garden/envs/custom/tasks/peg_insertion_side_pegonly.py
@@ -159,6 +159,8 @@ class PegInsertionSidePegOnlyEnv(PegInsertionSideEnv):
         fixed_peg_z_rot_deg: Optional[float] = None,
         debug_pose_vis: bool = False,
         peg_density: float = 1000.0, ## default 1000
+        include_reaching_reward: bool = False,
+        include_grasp_reward: bool = False,
         **kwargs,
     ):
         self.fix_box = fix_box  # set before super() since parent's __init__ calls reset()
@@ -185,6 +187,8 @@ class PegInsertionSidePegOnlyEnv(PegInsertionSideEnv):
             *args,
             robot_uids=robot_uids,
             debug_pose_vis=debug_pose_vis,
+            include_reaching_reward=include_reaching_reward,
+            include_grasp_reward=include_grasp_reward,
             **kwargs,
         )
 
@@ -232,7 +236,9 @@ class PegInsertionSidePegOnlyEnv(PegInsertionSideEnv):
     # Camera config for visualization (modify eye/target to change viewing angle)
     # _human_render_camera_eye = [0.5, -0.5, 0.2]
     # _human_render_camera_target = [0, 0, 0.1]
-    _human_render_camera_eye = [0.4, -0.2, 0.2]
+    # _human_render_camera_eye = [0.4, -0.2, 0.2]
+    # _human_render_camera_target = [0, 0, 0.1]
+    _human_render_camera_eye = [0., -0.8, 0.1] 
     _human_render_camera_target = [0, 0, 0.1]
 
     @property

--- a/rl_garden/policies/residual_policy.py
+++ b/rl_garden/policies/residual_policy.py
@@ -28,6 +28,7 @@ class ResidualSACPolicy(SACPolicy):
         critic_subsample_size: Optional[int] = None,
         actor_feature_dim: Optional[int] = None,
         critic_spatial_emb_dim: int = 1024,
+        critic_use_layer_norm: bool = False,
     ) -> None:
         super().__init__(
             observation_space=observation_space,
@@ -38,6 +39,7 @@ class ResidualSACPolicy(SACPolicy):
             critic_subsample_size=critic_subsample_size,
             actor_feature_dim=actor_feature_dim,
             critic_spatial_emb_dim=critic_spatial_emb_dim,
+            critic_use_layer_norm=critic_use_layer_norm,
         )
         # Rebuild actor: base_actions are appended after the adapter (if any).
         actor_arch, _ = get_actor_critic_arch(net_arch)
@@ -82,3 +84,26 @@ class ResidualSACPolicy(SACPolicy):
         actor_input = torch.cat([adapted, base_actions], dim=-1)
         unit_residual_action, log_prob = self.actor.action_log_prob(actor_input)
         return unit_residual_action, log_prob, features
+
+    def actor_diagnostics(
+        self, obs, base_actions: torch.Tensor
+    ) -> dict[str, torch.Tensor]:
+        with torch.no_grad():
+            features = self.extract_features(obs, stop_gradient=True)
+            adapted = self._transform_features_for_actor(features)
+            actor_input = torch.cat([adapted, base_actions], dim=-1)
+            mean, log_std = self.actor(actor_input)
+            std = log_std.exp()
+            normal = torch.distributions.Normal(mean, std)
+            x_t = normal.rsample()
+            y_t = torch.tanh(x_t)
+            gaussian_term = normal.log_prob(x_t).sum(-1)
+            tanh_correction = torch.log(
+                self.actor.action_scale * (1 - y_t.pow(2)) + 1e-6
+            ).sum(-1)
+            return {
+                "policy_std": std.mean(),
+                "action_saturation": torch.tanh(mean).abs().mean(),
+                "entropy_gaussian": -gaussian_term.mean(),
+                "tanh_correction": tanh_correction.mean(),
+            }

--- a/tests/test_residual_sac.py
+++ b/tests/test_residual_sac.py
@@ -197,3 +197,35 @@ def test_residual_update_hooks_combine_base_and_residual_actions():
     assert actor_loss.shape == ()
     assert log_prob.shape == (agent.batch_size, 1)
     assert torch.isfinite(torch.tensor(train_info["critic_loss"]))
+
+
+def test_residual_actor_diagnostics_use_base_actions_without_advancing_rng():
+    agent = _agent()
+    env = agent.env
+    for _ in range(4):
+        obs = torch.randn(env.num_envs, *env.single_observation_space.shape)
+        next_obs = torch.randn_like(obs)
+        base = torch.full((env.num_envs, 2), 0.25)
+        next_base = torch.full((env.num_envs, 2), -0.25)
+        agent.replay_buffer.add(
+            obs,
+            next_obs,
+            base,
+            torch.ones(env.num_envs),
+            torch.zeros(env.num_envs),
+            base_actions=base,
+            next_base_actions=next_base,
+        )
+
+    data = agent.replay_buffer.sample(agent.batch_size)
+
+    torch.manual_seed(123)
+    expected = torch.rand(4)
+
+    torch.manual_seed(123)
+    diagnostics = agent._actor_diagnostics(data)
+    actual = torch.rand(4)
+
+    assert "action_saturation" in diagnostics
+    assert "entropy_gaussian" in diagnostics
+    torch.testing.assert_close(actual, expected)

--- a/tests/test_sac_core.py
+++ b/tests/test_sac_core.py
@@ -96,13 +96,14 @@ def test_sac_actor_loss_uses_all_critics():
 
 def test_actor_diagnostics_preserves_cpu_rng_state():
     agent = _agent()
-    obs = torch.randn(agent.batch_size, *agent.env.single_observation_space.shape)
+    _fill(agent)
+    data = agent.replay_buffer.sample(agent.batch_size)
 
     torch.manual_seed(123)
     expected = torch.rand(4)
 
     torch.manual_seed(123)
-    diagnostics = agent._actor_diagnostics(obs)
+    diagnostics = agent._actor_diagnostics(data)
     actual = torch.rand(4)
 
     assert "action_saturation" in diagnostics
@@ -114,17 +115,14 @@ def test_actor_diagnostics_preserves_cuda_rng_state():
         pytest.skip("CUDA is not available")
 
     agent = _agent(device="cuda", buffer_device="cuda")
-    obs = torch.randn(
-        agent.batch_size,
-        *agent.env.single_observation_space.shape,
-        device="cuda",
-    )
+    _fill(agent)
+    data = agent.replay_buffer.sample(agent.batch_size)
 
     torch.cuda.manual_seed_all(123)
     expected = torch.rand(4, device="cuda")
 
     torch.cuda.manual_seed_all(123)
-    diagnostics = agent._actor_diagnostics(obs)
+    diagnostics = agent._actor_diagnostics(data)
     actual = torch.rand(4, device="cuda")
 
     assert "action_saturation" in diagnostics


### PR DESCRIPTION
- Add reward-term switches for peg insertion envs and update peg-only camera view.
- Fix SAC actor diagnostics for `ResidualSAC` by passing the sampled batch through a hook, so residual policies can use
  `base_actions`.
- Add residual actor diagnostics over `[features, base_actions]`.
- Enable `critic_use_layer_norm=True` for `ResidualSACPolicy`.