### PR TITLE
feat(sac): add Q-MC eval diagnostics

### DIFF
--- a/examples/train_residual_sac_rgbd.py
+++ b/examples/train_residual_sac_rgbd.py
@@ -145,6 +145,7 @@ def run_residual_rgbd_training(
             critic_subsample_size=args.critic_subsample_size,
             critic_impl=args.critic_impl,
             alpha_tuning=args.alpha_tuning,
+            q_mc_diagnostics=args.q_mc_diagnostics,
             seed=args.seed,
             logger=logger,
             std_log=args.std_log,

--- a/examples/train_residual_sac_rgbd.py
+++ b/examples/train_residual_sac_rgbd.py
@@ -33,6 +33,8 @@ from rl_garden.policies.base_policies import make_base_policy
 @dataclass
 class ResidualRGBDArgs(VisionSACTrainingArgs):
     residual_action_scale: float = 0.1
+    n_critics: int = 2
+    critic_subsample_size: Optional[int] = None
     debug: bool = False
     base_policy: Literal["act", "sac", "zero"] = "act"
     base_ckpt_path: Optional[str] = "act-peg-only"
@@ -139,6 +141,10 @@ def run_residual_rgbd_training(
             utd=args.utd,
             policy_lr=args.policy_lr,
             q_lr=args.q_lr,
+            n_critics=args.n_critics,
+            critic_subsample_size=args.critic_subsample_size,
+            critic_impl=args.critic_impl,
+            alpha_tuning=args.alpha_tuning,
             seed=args.seed,
             logger=logger,
             std_log=args.std_log,

--- a/examples/train_residual_sac_state_peg.py
+++ b/examples/train_residual_sac_state_peg.py
@@ -185,6 +185,7 @@ def main() -> None:
             critic_subsample_size=args.critic_subsample_size,
             critic_impl=args.critic_impl,
             alpha_tuning=args.alpha_tuning,
+            q_mc_diagnostics=args.q_mc_diagnostics,
             seed=args.seed,
             logger=logger,
             std_log=args.std_log,

--- a/examples/train_residual_sac_state_peg.py
+++ b/examples/train_residual_sac_state_peg.py
@@ -38,6 +38,8 @@ class Args(SACTrainingArgs):
     fixed_peg_z_rot_deg: float = 67.5
 
     residual_action_scale: float = 0.1
+    n_critics: int = 2
+    critic_subsample_size: Optional[int] = None
     debug: bool = False
     base_policy: Literal["act", "sac", "zero"] = "act"
     base_ckpt_path: Optional[str] = "act-peg-only"
@@ -179,6 +181,10 @@ def main() -> None:
             utd=args.utd,
             policy_lr=args.policy_lr,
             q_lr=args.q_lr,
+            n_critics=args.n_critics,
+            critic_subsample_size=args.critic_subsample_size,
+            critic_impl=args.critic_impl,
+            alpha_tuning=args.alpha_tuning,
             seed=args.seed,
             logger=logger,
             std_log=args.std_log,

--- a/examples/train_sac_rgbd.py
+++ b/examples/train_sac_rgbd.py
@@ -118,6 +118,7 @@ def main() -> None:
         q_landscape_diagnostics=args.q_landscape_diagnostics,
         q_landscape_num_actions=args.q_landscape_num_actions,
         q_landscape_batch_size=args.q_landscape_batch_size,
+        q_mc_diagnostics=args.q_mc_diagnostics,
         initial_training_phase=sac_initial_training_phase_from_args(args),
         critic_impl=args.critic_impl,
         n_critics=args.n_critics,

--- a/examples/train_sac_rgbd_peg.py
+++ b/examples/train_sac_rgbd_peg.py
@@ -147,6 +147,7 @@ def main() -> None:
         q_landscape_diagnostics=args.q_landscape_diagnostics,
         q_landscape_num_actions=args.q_landscape_num_actions,
         q_landscape_batch_size=args.q_landscape_batch_size,
+        q_mc_diagnostics=args.q_mc_diagnostics,
         initial_training_phase=sac_initial_training_phase_from_args(args),
         n_critics=args.n_critics,
         critic_subsample_size=args.critic_subsample_size,

--- a/examples/train_sac_robotwin_rgbd.py
+++ b/examples/train_sac_robotwin_rgbd.py
@@ -173,6 +173,7 @@ def main() -> None:
         q_landscape_diagnostics=args.q_landscape_diagnostics,
         q_landscape_num_actions=args.q_landscape_num_actions,
         q_landscape_batch_size=args.q_landscape_batch_size,
+        q_mc_diagnostics=args.q_mc_diagnostics,
         initial_training_phase=sac_initial_training_phase_from_args(args),
         n_critics=args.n_critics,
         critic_subsample_size=args.critic_subsample_size,

--- a/examples/train_sac_state.py
+++ b/examples/train_sac_state.py
@@ -102,6 +102,7 @@ def main() -> None:
         q_landscape_diagnostics=args.q_landscape_diagnostics,
         q_landscape_num_actions=args.q_landscape_num_actions,
         q_landscape_batch_size=args.q_landscape_batch_size,
+        q_mc_diagnostics=args.q_mc_diagnostics,
         initial_training_phase=sac_initial_training_phase_from_args(args),
         critic_impl=args.critic_impl,
         n_critics=args.n_critics,

--- a/rl_garden/algorithms/off_policy.py
+++ b/rl_garden/algorithms/off_policy.py
@@ -130,6 +130,16 @@ class OffPolicyAlgorithm(BaseAlgorithm):
                 self._obs_to_policy_device(obs), deterministic=True
             )
 
+    def _eval_action_and_critic_action(self, obs) -> tuple[torch.Tensor, torch.Tensor]:
+        action = self._eval_action(obs)
+        return action, action
+
+    def _eval_q_mc_enabled(self) -> bool:
+        return False
+
+    def _eval_q_values(self, obs, actions) -> torch.Tensor:
+        raise NotImplementedError
+
     def _on_env_reset(self, obs) -> None:
         del obs
 
@@ -333,15 +343,88 @@ class OffPolicyAlgorithm(BaseAlgorithm):
 
     # --- evaluation ---
 
+    def _finish_eval_q_mc_episode(
+        self,
+        q_values: list[torch.Tensor],
+        rewards: list[torch.Tensor],
+        completed_q_values: list[torch.Tensor],
+        completed_mc_returns: list[torch.Tensor],
+        completed_errors: list[torch.Tensor],
+    ) -> None:
+        q_ep = torch.stack(q_values).reshape(-1)
+        rewards_ep = torch.stack(rewards).reshape(-1).to(q_ep.device)
+        returns = torch.empty_like(rewards_ep)
+        running = torch.zeros((), dtype=rewards_ep.dtype, device=rewards_ep.device)
+        for idx in range(rewards_ep.shape[0] - 1, -1, -1):
+            running = rewards_ep[idx] + self.gamma * running
+            returns[idx] = running
+        errors = q_ep - returns
+        completed_q_values.append(q_ep)
+        completed_mc_returns.append(returns)
+        completed_errors.append(errors)
+
+    @staticmethod
+    def _reduce_eval_q_mc_metrics(
+        completed_q_values: list[torch.Tensor],
+        completed_mc_returns: list[torch.Tensor],
+        completed_errors: list[torch.Tensor],
+    ) -> dict[str, float]:
+        if not completed_errors:
+            return {}
+        q_values = torch.cat(completed_q_values)
+        mc_returns = torch.cat(completed_mc_returns)
+        errors = torch.cat(completed_errors)
+        mse = errors.square().mean()
+        return {
+            "q_mc/mean_error": float(errors.mean().item()),
+            "q_mc/abs_error": float(errors.abs().mean().item()),
+            "q_mc/rmse": float(torch.sqrt(mse).item()),
+            "q_mc/q_mean": float(q_values.mean().item()),
+            "q_mc/mc_return_mean": float(mc_returns.mean().item()),
+            "q_mc/num_steps": float(errors.numel()),
+        }
+
     def _evaluate(self) -> dict[str, float]:
         if self.eval_env is None:
             return {}
         self.policy.eval()
         obs, _ = self.eval_env.reset()
         metrics: dict[str, list[torch.Tensor]] = defaultdict(list)
+        q_mc_enabled = self._eval_q_mc_enabled()
+        num_eval_envs = self.eval_env.num_envs
+        pending_q_values: list[list[torch.Tensor]] = [[] for _ in range(num_eval_envs)]
+        pending_rewards: list[list[torch.Tensor]] = [[] for _ in range(num_eval_envs)]
+        completed_q_values: list[torch.Tensor] = []
+        completed_mc_returns: list[torch.Tensor] = []
+        completed_errors: list[torch.Tensor] = []
         for _ in range(self.num_eval_steps):
             with torch.no_grad():
-                obs, _, _, _, infos = self.eval_env.step(self._eval_action(obs))
+                env_action, critic_action = self._eval_action_and_critic_action(obs)
+                q_values: torch.Tensor | None = None
+                if q_mc_enabled:
+                    q_values = self._eval_q_values(
+                        self._obs_to_policy_device(obs), critic_action
+                    ).reshape(-1).detach()
+                obs, rewards, terminations, truncations, infos = self.eval_env.step(
+                    env_action
+                )
+                if q_mc_enabled:
+                    assert q_values is not None
+                    step_rewards = rewards.reshape(-1).to(q_values.device).detach()
+                    dones = (terminations | truncations).reshape(-1)
+                    for env_idx in range(num_eval_envs):
+                        pending_q_values[env_idx].append(q_values[env_idx])
+                        pending_rewards[env_idx].append(step_rewards[env_idx])
+                    for env_idx in torch.where(dones)[0].detach().cpu().tolist():
+                        self._finish_eval_q_mc_episode(
+                            pending_q_values[env_idx],
+                            pending_rewards[env_idx],
+                            completed_q_values,
+                            completed_mc_returns,
+                            completed_errors,
+                        )
+                        pending_q_values[env_idx] = []
+                        pending_rewards[env_idx] = []
                 if "final_info" in infos:
                     for k, v in infos["final_info"]["episode"].items():
                         metrics[k].append(v)
@@ -349,6 +432,12 @@ class OffPolicyAlgorithm(BaseAlgorithm):
         out: dict[str, float] = {}
         for k, vs in metrics.items():
             out[k] = float(torch.stack(vs).float().mean().item())
+        if q_mc_enabled:
+            out.update(
+                self._reduce_eval_q_mc_metrics(
+                    completed_q_values, completed_mc_returns, completed_errors
+                )
+            )
         return out
 
     # --- main loop ---

--- a/rl_garden/algorithms/off_policy.py
+++ b/rl_garden/algorithms/off_policy.py
@@ -134,11 +134,22 @@ class OffPolicyAlgorithm(BaseAlgorithm):
         action = self._eval_action(obs)
         return action, action
 
-    def _eval_q_mc_enabled(self) -> bool:
-        return False
+    def _eval_start_hook(self) -> None:
+        pass
 
-    def _eval_q_values(self, obs, actions) -> torch.Tensor:
-        raise NotImplementedError
+    def _eval_step_hook(
+        self,
+        obs_before,
+        critic_action: torch.Tensor,
+        rewards: torch.Tensor,
+        terminations: torch.Tensor,
+        truncations: torch.Tensor,
+        infos: dict,
+    ) -> None:
+        pass
+
+    def _eval_finalize_hook(self) -> dict[str, float]:
+        return {}
 
     def _on_env_reset(self, obs) -> None:
         del obs
@@ -343,88 +354,23 @@ class OffPolicyAlgorithm(BaseAlgorithm):
 
     # --- evaluation ---
 
-    def _finish_eval_q_mc_episode(
-        self,
-        q_values: list[torch.Tensor],
-        rewards: list[torch.Tensor],
-        completed_q_values: list[torch.Tensor],
-        completed_mc_returns: list[torch.Tensor],
-        completed_errors: list[torch.Tensor],
-    ) -> None:
-        q_ep = torch.stack(q_values).reshape(-1)
-        rewards_ep = torch.stack(rewards).reshape(-1).to(q_ep.device)
-        returns = torch.empty_like(rewards_ep)
-        running = torch.zeros((), dtype=rewards_ep.dtype, device=rewards_ep.device)
-        for idx in range(rewards_ep.shape[0] - 1, -1, -1):
-            running = rewards_ep[idx] + self.gamma * running
-            returns[idx] = running
-        errors = q_ep - returns
-        completed_q_values.append(q_ep)
-        completed_mc_returns.append(returns)
-        completed_errors.append(errors)
-
-    @staticmethod
-    def _reduce_eval_q_mc_metrics(
-        completed_q_values: list[torch.Tensor],
-        completed_mc_returns: list[torch.Tensor],
-        completed_errors: list[torch.Tensor],
-    ) -> dict[str, float]:
-        if not completed_errors:
-            return {}
-        q_values = torch.cat(completed_q_values)
-        mc_returns = torch.cat(completed_mc_returns)
-        errors = torch.cat(completed_errors)
-        mse = errors.square().mean()
-        return {
-            "q_mc/mean_error": float(errors.mean().item()),
-            "q_mc/abs_error": float(errors.abs().mean().item()),
-            "q_mc/rmse": float(torch.sqrt(mse).item()),
-            "q_mc/q_mean": float(q_values.mean().item()),
-            "q_mc/mc_return_mean": float(mc_returns.mean().item()),
-            "q_mc/num_steps": float(errors.numel()),
-        }
-
     def _evaluate(self) -> dict[str, float]:
         if self.eval_env is None:
             return {}
         self.policy.eval()
         obs, _ = self.eval_env.reset()
+        self._eval_start_hook()
         metrics: dict[str, list[torch.Tensor]] = defaultdict(list)
-        q_mc_enabled = self._eval_q_mc_enabled()
-        num_eval_envs = self.eval_env.num_envs
-        pending_q_values: list[list[torch.Tensor]] = [[] for _ in range(num_eval_envs)]
-        pending_rewards: list[list[torch.Tensor]] = [[] for _ in range(num_eval_envs)]
-        completed_q_values: list[torch.Tensor] = []
-        completed_mc_returns: list[torch.Tensor] = []
-        completed_errors: list[torch.Tensor] = []
         for _ in range(self.num_eval_steps):
             with torch.no_grad():
                 env_action, critic_action = self._eval_action_and_critic_action(obs)
-                q_values: torch.Tensor | None = None
-                if q_mc_enabled:
-                    q_values = self._eval_q_values(
-                        self._obs_to_policy_device(obs), critic_action
-                    ).reshape(-1).detach()
+                obs_before = obs
                 obs, rewards, terminations, truncations, infos = self.eval_env.step(
                     env_action
                 )
-                if q_mc_enabled:
-                    assert q_values is not None
-                    step_rewards = rewards.reshape(-1).to(q_values.device).detach()
-                    dones = (terminations | truncations).reshape(-1)
-                    for env_idx in range(num_eval_envs):
-                        pending_q_values[env_idx].append(q_values[env_idx])
-                        pending_rewards[env_idx].append(step_rewards[env_idx])
-                    for env_idx in torch.where(dones)[0].detach().cpu().tolist():
-                        self._finish_eval_q_mc_episode(
-                            pending_q_values[env_idx],
-                            pending_rewards[env_idx],
-                            completed_q_values,
-                            completed_mc_returns,
-                            completed_errors,
-                        )
-                        pending_q_values[env_idx] = []
-                        pending_rewards[env_idx] = []
+                self._eval_step_hook(
+                    obs_before, critic_action, rewards, terminations, truncations, infos
+                )
                 if "final_info" in infos:
                     for k, v in infos["final_info"]["episode"].items():
                         metrics[k].append(v)
@@ -432,12 +378,7 @@ class OffPolicyAlgorithm(BaseAlgorithm):
         out: dict[str, float] = {}
         for k, vs in metrics.items():
             out[k] = float(torch.stack(vs).float().mean().item())
-        if q_mc_enabled:
-            out.update(
-                self._reduce_eval_q_mc_metrics(
-                    completed_q_values, completed_mc_returns, completed_errors
-                )
-            )
+        out.update(self._eval_finalize_hook())
         return out
 
     # --- main loop ---

--- a/rl_garden/algorithms/residual.py
+++ b/rl_garden/algorithms/residual.py
@@ -96,6 +96,7 @@ class ResidualSAC(SAC):
             net_arch=self.net_arch,
             n_critics=self.n_critics,
             critic_subsample_size=self.critic_subsample_size,
+            critic_impl=self.critic_impl,
             actor_feature_dim=self.actor_feature_dim,
             critic_spatial_emb_dim=self.critic_spatial_emb_dim,
             critic_use_layer_norm=True,
@@ -252,6 +253,10 @@ class ResidualSAC(SAC):
 
     def _eval_action(self, obs) -> torch.Tensor:
         return self.get_action(obs, deterministic=True, return_info=False)
+
+    def _eval_action_and_critic_action(self, obs) -> tuple[torch.Tensor, torch.Tensor]:
+        env_action, info = self.get_action(obs, deterministic=True, return_info=True)
+        return env_action, info["final_actions"]
 
     def _evaluate(self) -> dict[str, float]:
         self._reset_base_action_provider()

--- a/rl_garden/algorithms/sac.py
+++ b/rl_garden/algorithms/sac.py
@@ -70,6 +70,7 @@ class SAC(SACCore, OffPolicyAlgorithm):
         q_landscape_diagnostics: bool = False,
         q_landscape_num_actions: int = 8,
         q_landscape_batch_size: int = 64,
+        q_mc_diagnostics: bool = False,
         net_arch: Optional[Sequence[int] | dict[str, Sequence[int]]] = None,
         actor_hidden_dims: Optional[Sequence[int]] = None,
         critic_hidden_dims: Optional[Sequence[int]] = None,
@@ -154,6 +155,7 @@ class SAC(SACCore, OffPolicyAlgorithm):
         self.q_landscape_diagnostics = q_landscape_diagnostics
         self.q_landscape_num_actions = q_landscape_num_actions
         self.q_landscape_batch_size = q_landscape_batch_size
+        self.q_mc_diagnostics = q_mc_diagnostics
         if self.q_landscape_num_actions <= 0:
             raise ValueError(
                 "q_landscape_num_actions must be positive, "

--- a/rl_garden/algorithms/sac_core.py
+++ b/rl_garden/algorithms/sac_core.py
@@ -41,6 +41,20 @@ class SACCore:
     def _target_critic_subsample_size(self) -> Optional[int]:
         return getattr(self, "critic_subsample_size", None)
 
+    def _eval_q_mc_enabled(self) -> bool:
+        return True
+
+    def _eval_q_values(self, obs, actions) -> torch.Tensor:
+        if hasattr(actions, "device") and actions.device != self.device:
+            actions = actions.to(self.device)
+        features = self.policy.extract_features(obs, stop_gradient=True)
+        return self.policy.min_q_value(
+            features,
+            actions,
+            subsample_size=None,
+            target=False,
+        )
+
     def _step_critic_scheduler(self) -> None:
         return None
 

--- a/rl_garden/algorithms/sac_core.py
+++ b/rl_garden/algorithms/sac_core.py
@@ -41,9 +41,6 @@ class SACCore:
     def _target_critic_subsample_size(self) -> Optional[int]:
         return getattr(self, "critic_subsample_size", None)
 
-    def _eval_q_mc_enabled(self) -> bool:
-        return True
-
     def _eval_q_values(self, obs, actions) -> torch.Tensor:
         if hasattr(actions, "device") and actions.device != self.device:
             actions = actions.to(self.device)
@@ -54,6 +51,87 @@ class SACCore:
             subsample_size=None,
             target=False,
         )
+
+    def _eval_start_hook(self) -> None:
+        if not getattr(self, "q_mc_diagnostics", False):
+            return
+        n = self.eval_env.num_envs
+        self._q_mc_pending_q: list[list] = [[] for _ in range(n)]
+        self._q_mc_pending_r: list[list] = [[] for _ in range(n)]
+        self._q_mc_completed_q: list[torch.Tensor] = []
+        self._q_mc_completed_mc: list[torch.Tensor] = []
+        self._q_mc_completed_err: list[torch.Tensor] = []
+
+    def _eval_step_hook(
+        self,
+        obs_before,
+        critic_action: torch.Tensor,
+        rewards: torch.Tensor,
+        terminations: torch.Tensor,
+        truncations: torch.Tensor,
+        infos: dict,
+    ) -> None:
+        if not getattr(self, "q_mc_diagnostics", False):
+            return
+        q_values = self._eval_q_values(
+            self._obs_to_policy_device(obs_before), critic_action
+        ).reshape(-1).detach()
+        step_rewards = rewards.reshape(-1).to(q_values.device).detach()
+        for env_idx in range(len(self._q_mc_pending_q)):
+            self._q_mc_pending_q[env_idx].append(q_values[env_idx])
+            self._q_mc_pending_r[env_idx].append(step_rewards[env_idx])
+        dones = (terminations | truncations).reshape(-1)
+        for env_idx in torch.where(dones)[0].cpu().tolist():
+            is_trunc = bool(truncations.reshape(-1)[env_idx].item())
+            bootstrap_v = self._q_mc_bootstrap_value(infos, env_idx) if is_trunc else None
+            self._q_mc_finish_episode(env_idx, bootstrap_v)
+
+    def _q_mc_bootstrap_value(self, infos: dict, env_idx: int) -> torch.Tensor | None:
+        final_obs = infos.get("final_observation")
+        if final_obs is None:
+            return None
+        if isinstance(final_obs, dict):
+            obs_i = {k: v[env_idx : env_idx + 1] for k, v in final_obs.items()}
+        else:
+            obs_i = final_obs[env_idx : env_idx + 1]
+        obs_i = self._obs_to_policy_device(obs_i)
+        a_i = self._eval_action(obs_i)
+        return self._eval_q_values(obs_i, a_i).reshape(())
+
+    def _q_mc_finish_episode(
+        self, env_idx: int, bootstrap_v: torch.Tensor | None
+    ) -> None:
+        q_ep = torch.stack(self._q_mc_pending_q[env_idx]).reshape(-1)
+        rewards_ep = torch.stack(self._q_mc_pending_r[env_idx]).reshape(-1).to(q_ep.device)
+        returns = torch.empty_like(rewards_ep)
+        if bootstrap_v is not None:
+            running = bootstrap_v.to(dtype=rewards_ep.dtype, device=q_ep.device).detach()
+        else:
+            running = torch.zeros((), dtype=rewards_ep.dtype, device=q_ep.device)
+        for idx in range(len(rewards_ep) - 1, -1, -1):
+            running = rewards_ep[idx] + self.gamma * running
+            returns[idx] = running
+        self._q_mc_completed_q.append(q_ep)
+        self._q_mc_completed_mc.append(returns)
+        self._q_mc_completed_err.append(q_ep - returns)
+        self._q_mc_pending_q[env_idx] = []
+        self._q_mc_pending_r[env_idx] = []
+
+    def _eval_finalize_hook(self) -> dict[str, float]:
+        if not getattr(self, "q_mc_diagnostics", False) or not self._q_mc_completed_err:
+            return {}
+        errors = torch.cat(self._q_mc_completed_err)
+        q_vals = torch.cat(self._q_mc_completed_q)
+        mc_rets = torch.cat(self._q_mc_completed_mc)
+        mse = errors.square().mean()
+        return {
+            "q_mc/mean_error": float(errors.mean().item()),
+            "q_mc/abs_error": float(errors.abs().mean().item()),
+            "q_mc/rmse": float(torch.sqrt(mse).item()),
+            "q_mc/q_mean": float(q_vals.mean().item()),
+            "q_mc/mc_return_mean": float(mc_rets.mean().item()),
+            "q_mc/num_steps": float(errors.numel()),
+        }
 
     def _step_critic_scheduler(self) -> None:
         return None

--- a/rl_garden/common/cli_args.py
+++ b/rl_garden/common/cli_args.py
@@ -81,6 +81,7 @@ class SACTrainingArgs(ManiSkillRunArgs, CheckpointArgs):
     q_landscape_diagnostics: bool = False
     q_landscape_num_actions: int = 8
     q_landscape_batch_size: int = 64
+    q_mc_diagnostics: bool = False
     critic_only_steps: int = 0
     critic_only_freeze_encoder: bool = True
     critic_only_random_action_prob: float = 0.0

--- a/rl_garden/policies/residual_policy.py
+++ b/rl_garden/policies/residual_policy.py
@@ -12,8 +12,11 @@ import torch
 from gymnasium import spaces
 
 from rl_garden.encoders.base import BaseFeaturesExtractor
-from rl_garden.networks import SquashedGaussianActor as Actor
-from rl_garden.networks import get_actor_critic_arch
+from rl_garden.networks.actor_critic import (
+    CriticImpl,
+    SquashedGaussianActor as Actor,
+    get_actor_critic_arch,
+)
 from rl_garden.policies.sac_policy import LOG_STD_MAX, LOG_STD_MIN, SACPolicy
 
 
@@ -26,6 +29,7 @@ class ResidualSACPolicy(SACPolicy):
         net_arch: Sequence[int] | dict[str, Sequence[int]] = (256, 256, 256),
         n_critics: int = 2,
         critic_subsample_size: Optional[int] = None,
+        critic_impl: CriticImpl = "vmap",
         actor_feature_dim: Optional[int] = None,
         critic_spatial_emb_dim: int = 1024,
         critic_use_layer_norm: bool = False,
@@ -37,6 +41,7 @@ class ResidualSACPolicy(SACPolicy):
             net_arch=net_arch,
             n_critics=n_critics,
             critic_subsample_size=critic_subsample_size,
+            critic_impl=critic_impl,
             actor_feature_dim=actor_feature_dim,
             critic_spatial_emb_dim=critic_spatial_emb_dim,
             critic_use_layer_norm=critic_use_layer_norm,

--- a/tests/test_residual_sac.py
+++ b/tests/test_residual_sac.py
@@ -199,6 +199,29 @@ def test_residual_update_hooks_combine_base_and_residual_actions():
     assert torch.isfinite(torch.tensor(train_info["critic_loss"]))
 
 
+def test_residual_critic_configuration_is_forwarded_to_policy():
+    agent = _agent(n_critics=4, critic_subsample_size=2, critic_impl="legacy")
+
+    assert agent.n_critics == 4
+    assert agent.critic_subsample_size == 2
+    assert agent.critic_impl == "legacy"
+    assert agent.policy.n_critics == 4
+    assert agent.policy.critic_subsample_size == 2
+    assert agent.policy.critic.critic_impl == "legacy"
+
+
+def test_residual_eval_q_mc_uses_normalized_final_action_for_critic():
+    agent = _agent(residual_action_scale=0.0)
+    obs, _ = agent.env.reset()
+
+    env_action, critic_action = agent._eval_action_and_critic_action(obs)
+
+    expected_env_action = torch.tensor([[0.05, -0.05], [0.05, -0.05]])
+    expected_critic_action = torch.tensor([[0.5, -0.5], [0.5, -0.5]])
+    torch.testing.assert_close(env_action, expected_env_action)
+    torch.testing.assert_close(critic_action, expected_critic_action)
+
+
 def test_residual_actor_diagnostics_use_base_actions_without_advancing_rng():
     agent = _agent()
     env = agent.env

--- a/tests/test_sac_core.py
+++ b/tests/test_sac_core.py
@@ -213,12 +213,24 @@ def test_sac_actor_loss_uses_all_critics():
     assert log_prob.shape == (agent.batch_size, 1)
 
 
-def test_eval_q_mc_metrics_use_complete_episode_returns():
+def test_eval_q_mc_disabled_by_default():
     eval_env = FixedRewardEvalEnv(
         rewards=[1.0, 2.0, 3.0],
         dones=[False, False, True],
     )
     agent = _agent(eval_env=eval_env, num_eval_steps=3, gamma=0.5)
+    # q_mc_diagnostics defaults to False — no q_mc/* keys expected
+    metrics = agent._evaluate()
+
+    assert not any(k.startswith("q_mc/") for k in metrics)
+
+
+def test_eval_q_mc_metrics_use_complete_episode_returns():
+    eval_env = FixedRewardEvalEnv(
+        rewards=[1.0, 2.0, 3.0],
+        dones=[False, False, True],
+    )
+    agent = _agent(eval_env=eval_env, num_eval_steps=3, gamma=0.5, q_mc_diagnostics=True)
     q_values = iter(
         [
             torch.tensor([2.0]),
@@ -253,13 +265,52 @@ def test_eval_q_mc_metrics_skip_incomplete_episodes():
         rewards=[1.0, 2.0, 3.0],
         dones=[False, False, False],
     )
-    agent = _agent(eval_env=eval_env, num_eval_steps=3)
+    agent = _agent(eval_env=eval_env, num_eval_steps=3, q_mc_diagnostics=True)
     agent._eval_q_values = lambda obs, actions: torch.tensor([1.0])  # type: ignore[method-assign]
 
     metrics = agent._evaluate()
 
     assert "q_mc/abs_error" not in metrics
     assert "q_mc/num_steps" not in metrics
+
+
+class TruncatingEvalEnv(FixedRewardEvalEnv):
+    """Like FixedRewardEvalEnv but fires truncations instead of terminations."""
+
+    def step(self, actions):
+        obs, reward, terminations, _, infos = super().step(actions)
+        truncations = terminations.clone()
+        terminations = torch.zeros_like(terminations)
+        if truncations.any():
+            infos["final_observation"] = torch.full(
+                (1, *self.single_observation_space.shape), 99.0
+            )
+        return obs, reward, terminations, truncations, infos
+
+
+def test_eval_q_mc_bootstrap_at_truncation():
+    # Episode: rewards=[1,2,3], truncated at step 3, bootstrap V(s_final)=4.0
+    # gamma=0.5: G_2=3+0.5*4=5, G_1=2+0.5*5=4.5, G_0=1+0.5*4.5=3.25
+    eval_env = TruncatingEvalEnv(
+        rewards=[1.0, 2.0, 3.0],
+        dones=[False, False, True],
+    )
+    agent = _agent(eval_env=eval_env, num_eval_steps=3, gamma=0.5, q_mc_diagnostics=True)
+    # Steps 0-2: Q=2.0; step 2 also triggers bootstrap call: Q(s_final)=4.0
+    q_vals = iter([
+        torch.tensor([2.0]),
+        torch.tensor([2.0]),
+        torch.tensor([2.0]),
+        torch.tensor([4.0]),  # bootstrap V(s_final)
+    ])
+    agent._eval_q_values = lambda obs, actions: next(q_vals)  # type: ignore[method-assign]
+
+    metrics = agent._evaluate()
+
+    expected_returns = torch.tensor([3.25, 4.5, 5.0])
+    assert metrics["q_mc/mc_return_mean"] == pytest.approx(
+        float(expected_returns.mean().item())
+    )
 
 
 def test_actor_diagnostics_preserves_cpu_rng_state():

--- a/tests/test_sac_core.py
+++ b/tests/test_sac_core.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytest
 import torch
@@ -37,6 +39,35 @@ class DummyDictVecEnv:
         self.single_action_space = spaces.Box(
             low=-1.0, high=1.0, shape=(2,), dtype=np.float32
         )
+
+
+class FixedRewardEvalEnv(DummyVecEnv):
+    def __init__(self, rewards: list[float], dones: list[bool]) -> None:
+        super().__init__()
+        self.num_envs = 1
+        self.rewards = rewards
+        self.dones = dones
+        self.step_idx = 0
+
+    def reset(self, seed: int | None = None):
+        del seed
+        self.step_idx = 0
+        return torch.zeros(1, *self.single_observation_space.shape), {}
+
+    def step(self, actions):
+        del actions
+        reward = torch.tensor([self.rewards[self.step_idx]], dtype=torch.float32)
+        done = torch.tensor([self.dones[self.step_idx]], dtype=torch.bool)
+        obs = torch.full(
+            (1, *self.single_observation_space.shape),
+            float(self.step_idx + 1),
+        )
+        infos = {}
+        if done.any():
+            episode_return = torch.tensor([sum(self.rewards[: self.step_idx + 1])])
+            infos = {"final_info": {"episode": {"return": episode_return}}}
+        self.step_idx += 1
+        return obs, reward, done, torch.zeros_like(done), infos
 
 
 def _agent(**kwargs) -> SAC:
@@ -180,6 +211,55 @@ def test_sac_actor_loss_uses_all_critics():
     assert q_all.shape[0] == 5
     assert loss.shape == ()
     assert log_prob.shape == (agent.batch_size, 1)
+
+
+def test_eval_q_mc_metrics_use_complete_episode_returns():
+    eval_env = FixedRewardEvalEnv(
+        rewards=[1.0, 2.0, 3.0],
+        dones=[False, False, True],
+    )
+    agent = _agent(eval_env=eval_env, num_eval_steps=3, gamma=0.5)
+    q_values = iter(
+        [
+            torch.tensor([2.0]),
+            torch.tensor([2.0]),
+            torch.tensor([2.0]),
+        ]
+    )
+    agent._eval_q_values = lambda obs, actions: next(q_values)  # type: ignore[method-assign]
+
+    metrics = agent._evaluate()
+
+    expected_returns = torch.tensor([2.75, 3.5, 3.0])
+    expected_errors = torch.tensor([2.0, 2.0, 2.0]) - expected_returns
+    assert metrics["q_mc/num_steps"] == 3.0
+    assert metrics["q_mc/q_mean"] == 2.0
+    assert metrics["q_mc/mc_return_mean"] == pytest.approx(
+        float(expected_returns.mean().item())
+    )
+    assert metrics["q_mc/mean_error"] == pytest.approx(
+        float(expected_errors.mean().item())
+    )
+    assert metrics["q_mc/abs_error"] == pytest.approx(
+        float(expected_errors.abs().mean().item())
+    )
+    assert metrics["q_mc/rmse"] == pytest.approx(
+        math.sqrt(float(expected_errors.square().mean().item()))
+    )
+
+
+def test_eval_q_mc_metrics_skip_incomplete_episodes():
+    eval_env = FixedRewardEvalEnv(
+        rewards=[1.0, 2.0, 3.0],
+        dones=[False, False, False],
+    )
+    agent = _agent(eval_env=eval_env, num_eval_steps=3)
+    agent._eval_q_values = lambda obs, actions: torch.tensor([1.0])  # type: ignore[method-assign]
+
+    metrics = agent._evaluate()
+
+    assert "q_mc/abs_error" not in metrics
+    assert "q_mc/num_steps" not in metrics
 
 
 def test_actor_diagnostics_preserves_cpu_rng_state():


### PR DESCRIPTION
Track evaluation-time Q estimates against completed Monte Carlo returns and expose the metrics through SACCore.

Forward ResidualSAC critic configuration from examples into the residual policy, including critic implementation selection.