### PR TITLE
Add recurrent/transformer RL algorithms and TD3

### DIFF
--- a/rl_garden/algorithms/__init__.py
+++ b/rl_garden/algorithms/__init__.py
@@ -23,6 +23,7 @@ from rl_garden.algorithms.residual import ResidualSAC
 from rl_garden.algorithms.sac import SAC
 from rl_garden.algorithms.sequence_ppo import SequencePPO
 from rl_garden.algorithms.sequence_sac import SequenceSAC
+from rl_garden.algorithms.td3 import TD3
 from rl_garden.algorithms.transformer_ppo import TransformerPPO
 from rl_garden.algorithms.transformer_sac import TransformerSAC
 from rl_garden.algorithms.wsrl import WSRL
@@ -48,6 +49,7 @@ __all__ = [
     "SAC",
     "SequencePPO",
     "SequenceSAC",
+    "TD3",
     "TransformerPPO",
     "TransformerSAC",
     "WSRL",

--- a/rl_garden/algorithms/__init__.py
+++ b/rl_garden/algorithms/__init__.py
@@ -22,7 +22,9 @@ from rl_garden.algorithms.recurrent_sac import RecurrentSAC
 from rl_garden.algorithms.residual import ResidualSAC
 from rl_garden.algorithms.sac import SAC
 from rl_garden.algorithms.sequence_ppo import SequencePPO
+from rl_garden.algorithms.sequence_sac import SequenceSAC
 from rl_garden.algorithms.transformer_ppo import TransformerPPO
+from rl_garden.algorithms.transformer_sac import TransformerSAC
 from rl_garden.algorithms.wsrl import WSRL
 
 __all__ = [
@@ -45,7 +47,9 @@ __all__ = [
     "ResidualSAC",
     "SAC",
     "SequencePPO",
+    "SequenceSAC",
     "TransformerPPO",
+    "TransformerSAC",
     "WSRL",
     "infer_box_specs_from_h5",
     "infer_specs_from_h5",

--- a/rl_garden/algorithms/__init__.py
+++ b/rl_garden/algorithms/__init__.py
@@ -18,6 +18,7 @@ from rl_garden.algorithms.off_policy import OffPolicyAlgorithm
 from rl_garden.algorithms.offline_sac import OfflineSAC
 from rl_garden.algorithms.ppo import PPO
 from rl_garden.algorithms.recurrent_ppo import RecurrentPPO
+from rl_garden.algorithms.recurrent_sac import RecurrentSAC
 from rl_garden.algorithms.residual import ResidualSAC
 from rl_garden.algorithms.sac import SAC
 from rl_garden.algorithms.wsrl import WSRL
@@ -38,6 +39,7 @@ __all__ = [
     "OnPolicyAlgorithm",
     "PPO",
     "RecurrentPPO",
+    "RecurrentSAC",
     "ResidualSAC",
     "SAC",
     "WSRL",

--- a/rl_garden/algorithms/__init__.py
+++ b/rl_garden/algorithms/__init__.py
@@ -17,6 +17,7 @@ from rl_garden.algorithms.on_policy import OnPolicyAlgorithm
 from rl_garden.algorithms.off_policy import OffPolicyAlgorithm
 from rl_garden.algorithms.offline_sac import OfflineSAC
 from rl_garden.algorithms.ppo import PPO
+from rl_garden.algorithms.recurrent_ppo import RecurrentPPO
 from rl_garden.algorithms.residual import ResidualSAC
 from rl_garden.algorithms.sac import SAC
 from rl_garden.algorithms.wsrl import WSRL
@@ -36,6 +37,7 @@ __all__ = [
     "OffPolicyAlgorithm",
     "OnPolicyAlgorithm",
     "PPO",
+    "RecurrentPPO",
     "ResidualSAC",
     "SAC",
     "WSRL",

--- a/rl_garden/algorithms/__init__.py
+++ b/rl_garden/algorithms/__init__.py
@@ -21,6 +21,8 @@ from rl_garden.algorithms.recurrent_ppo import RecurrentPPO
 from rl_garden.algorithms.recurrent_sac import RecurrentSAC
 from rl_garden.algorithms.residual import ResidualSAC
 from rl_garden.algorithms.sac import SAC
+from rl_garden.algorithms.sequence_ppo import SequencePPO
+from rl_garden.algorithms.transformer_ppo import TransformerPPO
 from rl_garden.algorithms.wsrl import WSRL
 
 __all__ = [
@@ -42,6 +44,8 @@ __all__ = [
     "RecurrentSAC",
     "ResidualSAC",
     "SAC",
+    "SequencePPO",
+    "TransformerPPO",
     "WSRL",
     "infer_box_specs_from_h5",
     "infer_specs_from_h5",

--- a/rl_garden/algorithms/ddpg.py
+++ b/rl_garden/algorithms/ddpg.py
@@ -373,6 +373,31 @@ class DDPG(OffPolicyAlgorithm):
     def _current_stddev(self) -> float:
         return schedule(self.stddev_schedule, self._global_step)
 
+    def _target_action_noise(self) -> tuple[float, float]:
+        """(std, clip) for the noise added when sampling the target action.
+
+        Default: reuse the exploration noise schedule (current DDPG/DrQ-v2
+        behavior). TD3 overrides this with a fixed pair decoupled from the
+        exploration schedule (target policy smoothing).
+        """
+        return self._current_stddev(), self.stddev_clip
+
+    def _should_update_actor_and_target(self) -> bool:
+        """Whether to update the actor and polyak-average the target network
+        this gradient step. Default: always (current DDPG behavior). TD3
+        overrides this to delay updates by ``policy_freq`` steps.
+        """
+        return True
+
+    def _actor_q_value(self, q_actor_all: torch.Tensor) -> torch.Tensor:
+        """Reduce twin-Q values to the scalar used for the actor loss.
+
+        Default: min over both critics (current DDPG/DrQ-v2 behavior). TD3
+        overrides this to use the first critic only (canonical TD3 actor
+        loss).
+        """
+        return q_actor_all.min(dim=0).values
+
     def train(
         self, gradient_steps: int, compute_info: bool = False
     ) -> dict[str, float]:
@@ -389,9 +414,9 @@ class DDPG(OffPolicyAlgorithm):
             obs_features = self.policy.extract_features(data.obs)
             with torch.no_grad():
                 next_features = self.policy.extract_features(data.next_obs)
-                stddev = self._current_stddev()
-                dist = self.policy.actor(next_features, stddev)
-                next_action = dist.sample(clip=self.stddev_clip)
+                target_std, target_clip = self._target_action_noise()
+                dist = self.policy.actor(next_features, target_std)
+                next_action = dist.sample(clip=target_clip)
                 target_q_all = self.policy.q_values_all(
                     next_features, next_action, target=True
                 )
@@ -414,45 +439,48 @@ class DDPG(OffPolicyAlgorithm):
             if self._lr_schedulers and self._lr_schedulers[0] is not None:
                 self._lr_schedulers[0].step()
 
-            # --- Actor update ---
-            stddev = self._current_stddev()
-            features_detached = obs_features.detach()
-            action = self.policy.actor_action_from_features(
-                features_detached,
-                stddev,
-                noise_clip=self.stddev_clip,
-            )
-            q_actor_all = self.policy.q_values_all(
-                features_detached, action, target=False
-            )
-            actor_loss = -q_actor_all.min(dim=0).values.mean()
-
-            self.actor_optimizer.zero_grad(set_to_none=True)
-            actor_loss.backward()
-            if self.grad_clip_norm is not None:
-                torch.nn.utils.clip_grad_norm_(
-                    list(self.policy.actor_parameters()),
-                    self.grad_clip_norm,
-                )
-            self.actor_optimizer.step()
-            if len(self._lr_schedulers) >= 2 and self._lr_schedulers[1] is not None:
-                self._lr_schedulers[1].step()
-
-            # --- Target update ---
-            polyak_update(
-                self.policy.critic.parameters(),
-                self.policy.critic_target.parameters(),
-                self.tau,
-            )
-
             if compute_info:
                 critic_losses.append(critic_loss.detach())
-                actor_losses.append(actor_loss.detach())
                 info_accum.setdefault("target_q", []).append(target_q.mean().detach())
                 info_accum.setdefault("predicted_q", []).append(q_all.mean().detach())
-                info_accum.setdefault("stddev", []).append(
-                    torch.tensor(stddev, device=self.device)
+
+            if self._should_update_actor_and_target():
+                # --- Actor update ---
+                stddev = self._current_stddev()
+                features_detached = obs_features.detach()
+                action = self.policy.actor_action_from_features(
+                    features_detached,
+                    stddev,
+                    noise_clip=self.stddev_clip,
                 )
+                q_actor_all = self.policy.q_values_all(
+                    features_detached, action, target=False
+                )
+                actor_loss = -self._actor_q_value(q_actor_all).mean()
+
+                self.actor_optimizer.zero_grad(set_to_none=True)
+                actor_loss.backward()
+                if self.grad_clip_norm is not None:
+                    torch.nn.utils.clip_grad_norm_(
+                        list(self.policy.actor_parameters()),
+                        self.grad_clip_norm,
+                    )
+                self.actor_optimizer.step()
+                if len(self._lr_schedulers) >= 2 and self._lr_schedulers[1] is not None:
+                    self._lr_schedulers[1].step()
+
+                # --- Target update ---
+                polyak_update(
+                    self.policy.critic.parameters(),
+                    self.policy.critic_target.parameters(),
+                    self.tau,
+                )
+
+                if compute_info:
+                    actor_losses.append(actor_loss.detach())
+                    info_accum.setdefault("stddev", []).append(
+                        torch.tensor(stddev, device=self.device)
+                    )
 
         if not compute_info:
             return {}
@@ -460,12 +488,10 @@ class DDPG(OffPolicyAlgorithm):
         def _mean(vals: list[torch.Tensor]) -> float:
             return float(torch.stack(vals).mean().item())
 
-        out: dict[str, float] = {
-            "critic_loss": _mean(critic_losses),
-            "actor_loss": _mean(actor_losses),
-            "stddev": _mean(info_accum.get("stddev", [])),
-        }
-        for key in ("target_q", "predicted_q"):
+        out: dict[str, float] = {"critic_loss": _mean(critic_losses)}
+        if actor_losses:
+            out["actor_loss"] = _mean(actor_losses)
+        for key in ("target_q", "predicted_q", "stddev"):
             if key in info_accum:
                 out[key] = _mean(info_accum[key])
         return out

--- a/rl_garden/algorithms/on_policy.py
+++ b/rl_garden/algorithms/on_policy.py
@@ -144,7 +144,14 @@ class OnPolicyAlgorithm(BaseAlgorithm):
     def _env_action(self, raw_action: torch.Tensor) -> torch.Tensor:
         return self.policy.clamp_action(raw_action).detach()
 
-    def _compute_final_values(self, infos, done_mask: torch.Tensor) -> torch.Tensor:
+    def _compute_final_values(self, infos, done_mask: torch.Tensor, hidden) -> torch.Tensor:
+        """Bootstrap value for envs that just finished this step.
+
+        ``hidden`` is unused by this stateless default; recurrent subclasses
+        override this method to bootstrap from the POST-step, UNMASKED hidden
+        state (``final_observation`` continues the same episode, it is not a
+        fresh start).
+        """
         final_values = torch.zeros(self.num_envs, device=self.device)
         if "final_observation" not in infos or not done_mask.any():
             return final_values
@@ -159,6 +166,36 @@ class OnPolicyAlgorithm(BaseAlgorithm):
             ).view(-1)
         final_values[done_mask] = values
         return final_values
+
+    # ------------------------------------------------------------------
+    # Recurrent-state hooks. Trivial, hidden-agnostic defaults so subclasses
+    # that never carry a recurrent hidden state are completely unaffected;
+    # recurrent subclasses (e.g. RecurrentPPO) override these directly rather
+    # than the base class branching on any "is this recurrent" flag.
+    # ------------------------------------------------------------------
+
+    def _initial_hidden_state(self, batch_size: int):
+        """Opaque recurrent state carried across rollout steps, or None for
+        stateless policies."""
+        return None
+
+    def _snapshot_window_initial_hidden(self, hidden, next_done: torch.Tensor):
+        """Hidden-state snapshot to use as the BPTT initial state for the
+        upcoming rollout window. Default: pass through unchanged (irrelevant
+        when hidden is None)."""
+        return hidden
+
+    def _rollout_step(self, obs, hidden, episode_starts: torch.Tensor):
+        """Single rollout step. Returns (actions, values, log_probs, entropy,
+        new_hidden). Default: stateless _rollout_policy(obs), hidden passed
+        through unchanged."""
+        actions, values, log_probs, entropy = self._rollout_policy(obs)
+        return actions, values, log_probs, entropy, hidden
+
+    def _predict_last_values(self, obs, hidden) -> torch.Tensor:
+        """Bootstrap value for GAE at the end of a rollout window. Default:
+        stateless policy.predict_values(obs)."""
+        return self.policy.predict_values(obs).view(-1)
 
     def _evaluate(self) -> dict[str, float]:
         if self.eval_env is None:
@@ -181,6 +218,7 @@ class OnPolicyAlgorithm(BaseAlgorithm):
         obs, _ = self.env.reset(seed=self.seed)
         next_done = torch.zeros(self.num_envs, device=self.device)
         cumulative = defaultdict(float)
+        hidden = self._initial_hidden_state(self.num_envs)
 
         while self._global_step < total_timesteps:
             previous_step = self._global_step
@@ -206,18 +244,27 @@ class OnPolicyAlgorithm(BaseAlgorithm):
                     )
 
             self.rollout_buffer.reset()
+            # Fold the episode-boundary reset from the END of the previous
+            # rollout window into the snapshot BEFORE this window starts. This
+            # is what lets RolloutBuffer.get_sequences() reconstruct BPTT
+            # windows without needing to store dones[-1] anywhere -- see
+            # rollout_buffer.py::get_sequences() docstring. No-op (hidden is
+            # None) for stateless policies.
+            window_initial_hidden = self._snapshot_window_initial_hidden(hidden, next_done)
             rollout_t = time.perf_counter()
             rollout_reward_sum = 0.0
             rollout_reward_count = 0
             rollout_episode_metrics: dict[str, list[float]] = defaultdict(list)
             for _ in range(self.num_steps):
                 self._global_step += self.num_envs
-                actions, values, log_probs, _ = self._rollout_policy(obs)
+                actions, values, log_probs, _, hidden = self._rollout_step(
+                    obs, hidden, next_done
+                )
                 next_obs, rewards, terminations, truncations, infos = self.env.step(
                     self._env_action(actions)
                 )
                 next_done = torch.logical_or(terminations, truncations).to(self.device)
-                final_values = self._compute_final_values(infos, next_done.bool())
+                final_values = self._compute_final_values(infos, next_done.bool(), hidden)
                 self.rollout_buffer.add(
                     obs,
                     actions,
@@ -245,14 +292,15 @@ class OnPolicyAlgorithm(BaseAlgorithm):
             cumulative["rollout_time"] += rollout_time
 
             with torch.no_grad():
-                last_values = self.policy.predict_values(
-                    self._obs_to_policy_device(obs)
-                ).view(-1)
+                last_values = self._predict_last_values(
+                    self._obs_to_policy_device(obs), hidden
+                )
             self.rollout_buffer.compute_returns_and_advantage(
                 last_values,
                 next_done,
                 finite_horizon_gae=self.finite_horizon_gae,
             )
+            self._rollout_initial_hidden = window_initial_hidden
 
             update_t = time.perf_counter()
             losses = self.train()

--- a/rl_garden/algorithms/ppo.py
+++ b/rl_garden/algorithms/ppo.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Literal, Optional, Sequence
+from typing import Any, Iterator, Literal, Optional, Sequence
 
 import numpy as np
 import torch
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from gymnasium import spaces
 
 from rl_garden.algorithms.on_policy import OnPolicyAlgorithm
-from rl_garden.buffers.rollout_buffer import DictRolloutBuffer, RolloutBuffer
+from rl_garden.buffers.rollout_buffer import DictRolloutBuffer, RolloutBuffer, RolloutBufferSample
 from rl_garden.common.logger import Logger
 from rl_garden.common.optim import ScheduleType, make_lr_scheduler, make_optimizer
 from rl_garden.encoders.base import BaseFeaturesExtractor
@@ -27,6 +27,7 @@ from rl_garden.policies.ppo_policy import PPOPolicy
 class PPO(OnPolicyAlgorithm):
     """SB3/ManiSkill-style PPO with rl-garden feature extractors."""
 
+    _compatible_checkpoint_algorithms = ("PPO",)
     _SUPPORTED_POLICY_KWARGS = frozenset(
         {"features_extractor_class", "features_extractor_kwargs"}
     )
@@ -457,6 +458,76 @@ class PPO(OnPolicyAlgorithm):
         pg_loss2 = -advantages * torch.clamp(ratio, 1 - clip_coef, 1 + clip_coef)
         return torch.max(pg_loss1, pg_loss2).mean()
 
+    def _ppo_minibatch_update(
+        self,
+        *,
+        values: torch.Tensor,
+        log_prob: torch.Tensor,
+        entropy: torch.Tensor,
+        old_values: torch.Tensor,
+        old_log_prob: torch.Tensor,
+        advantages: torch.Tensor,
+        returns: torch.Tensor,
+        clip_coef: float,
+    ) -> dict[str, float | bool]:
+        """One PPO minibatch gradient step on 1-D tensors. ``result["stop"]`` is
+        True if target_kl triggered an early stop (caller should break after
+        recording ``clipfrac``, matching the pre-refactor loop's behavior of
+        recording clipfrac for the aborting minibatch but no other metric)."""
+        if self.norm_adv and len(advantages) > 1:
+            advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+
+        logratio = log_prob - old_log_prob
+        ratio = logratio.exp()
+        with torch.no_grad():
+            old_approx_kl = (-logratio).mean()
+            approx_kl = ((ratio - 1.0) - logratio).mean()
+            clipfrac = ((ratio - 1.0).abs() > clip_coef).float().mean().item()
+        if self.target_kl is not None and approx_kl > self.target_kl:
+            return {"stop": True, "clipfrac": clipfrac}
+
+        policy_loss = self._policy_loss(advantages=advantages, ratio=ratio, clip_coef=clip_coef)
+        if self.clip_vloss:
+            v_loss_unclipped = (values - returns) ** 2
+            values_clipped = old_values + torch.clamp(values - old_values, -clip_coef, clip_coef)
+            v_loss_clipped = (values_clipped - returns) ** 2
+            value_loss = 0.5 * torch.max(v_loss_unclipped, v_loss_clipped).mean()
+        else:
+            value_loss = 0.5 * F.mse_loss(values, returns)
+        entropy_loss = entropy.mean()
+        loss = policy_loss - self.ent_coef * entropy_loss + self.vf_coef * value_loss
+
+        self.policy_optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+        self.policy_optimizer.step()
+
+        return {
+            "stop": False,
+            "policy_loss": float(policy_loss.detach().item()),
+            "value_loss": float(value_loss.detach().item()),
+            "entropy_loss": float(entropy_loss.detach().item()),
+            "approx_kl": float(approx_kl.detach().item()),
+            "old_approx_kl": float(old_approx_kl.detach().item()),
+            "clipfrac": clipfrac,
+            "loss": float(loss.detach().item()),
+        }
+
+    def _iter_minibatches(self) -> Iterator[RolloutBufferSample]:
+        return self.rollout_buffer.get(self.minibatch_size)
+
+    def _evaluate_minibatch(
+        self, data: RolloutBufferSample
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Returns 1-D (values, log_prob, entropy, old_values, old_log_prob, advantages, returns)."""
+        values, log_prob, entropy = self.policy.evaluate_actions(
+            data.obs, data.actions, stop_gradient_actor=self._actor_stop_gradient()
+        )
+        return (
+            values.flatten(), log_prob.flatten(), entropy.flatten(),
+            data.old_values, data.old_log_prob, data.advantages, data.returns,
+        )
+
     def train(self) -> dict[str, float]:
         self.policy.train()
         self._global_update += 1
@@ -475,71 +546,32 @@ class PPO(OnPolicyAlgorithm):
         continue_training = True
 
         for _ in range(self.update_epochs):
-            for data in self.rollout_buffer.get(self.minibatch_size):
-                values, log_prob, entropy = self.policy.evaluate_actions(
-                    data.obs,
-                    data.actions,
-                    stop_gradient_actor=self._actor_stop_gradient(),
+            for data in self._iter_minibatches():
+                values, log_prob, entropy, old_values, old_log_prob, advantages, returns = (
+                    self._evaluate_minibatch(data)
                 )
-                values = values.flatten()
-                log_prob = log_prob.flatten()
-                entropy = entropy.flatten()
-                advantages = data.advantages
-                if self.norm_adv and len(advantages) > 1:
-                    advantages = (advantages - advantages.mean()) / (
-                        advantages.std() + 1e-8
-                    )
+                result = self._ppo_minibatch_update(
+                    values=values,
+                    log_prob=log_prob,
+                    entropy=entropy,
+                    old_values=old_values,
+                    old_log_prob=old_log_prob,
+                    advantages=advantages,
+                    returns=returns,
+                    clip_coef=clip_coef,
+                )
 
-                logratio = log_prob - data.old_log_prob
-                ratio = logratio.exp()
-                with torch.no_grad():
-                    old_approx_kl = (-logratio).mean()
-                    approx_kl = ((ratio - 1.0) - logratio).mean()
-                    clipfracs.append(
-                        ((ratio - 1.0).abs() > clip_coef).float().mean().item()
-                    )
-                if self.target_kl is not None and approx_kl > self.target_kl:
+                clipfracs.append(result["clipfrac"])
+                if result["stop"]:
                     continue_training = False
                     break
 
-                policy_loss = self._policy_loss(
-                    advantages=advantages,
-                    ratio=ratio,
-                    clip_coef=clip_coef,
-                )
-                if self.clip_vloss:
-                    v_loss_unclipped = (values - data.returns) ** 2
-                    values_clipped = data.old_values + torch.clamp(
-                        values - data.old_values,
-                        -clip_coef,
-                        clip_coef,
-                    )
-                    v_loss_clipped = (values_clipped - data.returns) ** 2
-                    value_loss = (
-                        0.5 * torch.max(v_loss_unclipped, v_loss_clipped).mean()
-                    )
-                else:
-                    value_loss = 0.5 * F.mse_loss(values, data.returns)
-                entropy_loss = entropy.mean()
-                loss = (
-                    policy_loss
-                    - self.ent_coef * entropy_loss
-                    + self.vf_coef * value_loss
-                )
-
-                self.policy_optimizer.zero_grad(set_to_none=True)
-                loss.backward()
-                torch.nn.utils.clip_grad_norm_(
-                    self.policy.parameters(), self.max_grad_norm
-                )
-                self.policy_optimizer.step()
-
-                policy_losses.append(float(policy_loss.detach().item()))
-                value_losses.append(float(value_loss.detach().item()))
-                entropy_losses.append(float(entropy_loss.detach().item()))
-                approx_kls.append(float(approx_kl.detach().item()))
-                old_approx_kls.append(float(old_approx_kl.detach().item()))
-                losses.append(float(loss.detach().item()))
+                policy_losses.append(result["policy_loss"])
+                value_losses.append(result["value_loss"])
+                entropy_losses.append(result["entropy_loss"])
+                approx_kls.append(result["approx_kl"])
+                old_approx_kls.append(result["old_approx_kl"])
+                losses.append(result["loss"])
             if not continue_training:
                 break
 

--- a/rl_garden/algorithms/recurrent_ppo.py
+++ b/rl_garden/algorithms/recurrent_ppo.py
@@ -1,0 +1,194 @@
+"""PPO with an LSTM/GRU latent stage between the encoder and actor/critic heads."""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+import torch
+
+from rl_garden.algorithms.ppo import PPO
+from rl_garden.buffers.recurrent_rollout_buffer import (
+    RecurrentDictRolloutBuffer,
+    RecurrentRolloutBuffer,
+    RecurrentRolloutBufferSample,
+)
+from rl_garden.common.optim import make_lr_scheduler, make_optimizer
+from rl_garden.networks.recurrent import RecurrentLatentEncoder, RNNType
+from rl_garden.policies.recurrent_ppo_policy import RecurrentPPOPolicy
+
+
+class RecurrentPPO(PPO):
+    """PPO whose policy carries a persistent LSTM/GRU hidden state across rollout
+    steps and trains it via BPTT over sequence-preserving minibatches.
+
+    See ``rl_garden.networks.recurrent.RecurrentLatentEncoder`` for why this is
+    on-policy-only (off-policy/replay-based recurrence needs stored hidden state
+    and burn-in, neither of which exists here)."""
+
+    _compatible_checkpoint_algorithms = ("RecurrentPPO",)
+
+    def __init__(
+        self,
+        env: Any,
+        *,
+        rnn_type: RNNType = "lstm",
+        rnn_hidden_size: int = 256,
+        rnn_num_layers: int = 1,
+        **ppo_kwargs: Any,
+    ) -> None:
+        # Must be set before super().__init__(), which ends by calling
+        # self._setup_model() -- our override below reads these attributes.
+        self.rnn_type: RNNType = rnn_type
+        self.rnn_hidden_size = rnn_hidden_size
+        self.rnn_num_layers = rnn_num_layers
+        super().__init__(env, **ppo_kwargs)
+
+    def _setup_model(self) -> None:
+        # num_envs/num_minibatches are set earlier in PPO.__init__ (via
+        # OnPolicyAlgorithm.__init__), before this method runs -- safe to
+        # validate here, before any recurrent module gets constructed.
+        if self.num_envs % self.num_minibatches != 0:
+            raise ValueError(
+                f"RecurrentPPO requires num_envs ({self.num_envs}) to be divisible "
+                f"by num_minibatches ({self.num_minibatches}) for env-axis minibatching."
+            )
+        features_extractor = self._build_features_extractor()
+        if features_extractor.structured_feature_config() is not None:
+            raise NotImplementedError(
+                "RecurrentPPO only supports flat-latent feature extractors this "
+                "round (ViT token_and_prop layouts untested)."
+            )
+        recurrent_encoder = RecurrentLatentEncoder(
+            input_dim=features_extractor.features_dim,
+            hidden_size=self.rnn_hidden_size,
+            rnn_type=self.rnn_type,
+            num_layers=self.rnn_num_layers,
+        )
+        self.policy = RecurrentPPOPolicy(
+            observation_space=self.env.single_observation_space,
+            action_space=self.env.single_action_space,
+            features_extractor=features_extractor,
+            recurrent_encoder=recurrent_encoder,
+            net_arch=self.net_arch,
+            log_std_init=self.log_std_init,
+            actor_use_layer_norm=self.actor_use_layer_norm,
+            value_use_layer_norm=self.value_use_layer_norm,
+            actor_use_group_norm=self.actor_use_group_norm,
+            value_use_group_norm=self.value_use_group_norm,
+            num_groups=self.num_groups,
+            actor_dropout_rate=self.actor_dropout_rate,
+            value_dropout_rate=self.value_dropout_rate,
+            kernel_init=self.kernel_init,
+            backbone_type=self.backbone_type,
+        ).to(self.device)
+        self.policy_optimizer = make_optimizer(
+            self.policy.parameters(),
+            lr=self.learning_rate,
+            weight_decay=self.weight_decay,
+            use_adamw=self.use_adamw,
+        )
+        self._lr_scheduler = make_lr_scheduler(
+            self.policy_optimizer,
+            schedule_type=self.lr_schedule,
+            warmup_steps=self.lr_warmup_steps,
+            decay_steps=self.lr_decay_steps,
+            min_lr_ratio=self.lr_min_ratio,
+        )
+        buffer_cls = RecurrentDictRolloutBuffer if self._is_dict_obs else RecurrentRolloutBuffer
+        self.rollout_buffer = buffer_cls(
+            observation_space=self.env.single_observation_space,
+            action_space=self.env.single_action_space,
+            num_steps=self.num_steps,
+            num_envs=self.num_envs,
+            device=self.device,
+            gamma=self.gamma,
+            gae_lambda=self.gae_lambda,
+        )
+
+    def _initial_hidden_state(self, batch_size: int):
+        return self.policy.recurrent_encoder.get_initial_state(batch_size, self.device)
+
+    def _snapshot_window_initial_hidden(self, hidden, next_done: torch.Tensor):
+        return self.policy.recurrent_encoder.mask_state(hidden, 1.0 - next_done.float())
+
+    def _rollout_step(self, obs, hidden, episode_starts: torch.Tensor):
+        with torch.no_grad():
+            return self.policy.act_recurrent(
+                self._obs_to_policy_device(obs),
+                hidden,
+                episode_starts,
+                deterministic=False,
+                stop_gradient_actor=self._actor_stop_gradient(),
+            )
+
+    def _compute_final_values(self, infos, done_mask: torch.Tensor, hidden) -> torch.Tensor:
+        """Bootstrap value for envs that just finished, using the POST-step,
+        UNMASKED hidden state (``final_observation`` continues the same episode,
+        it is not a fresh start)."""
+        final_values = torch.zeros(self.num_envs, device=self.device)
+        if "final_observation" not in infos or not done_mask.any():
+            return final_values
+        final_obs = infos["final_observation"]
+        if isinstance(final_obs, dict):
+            final_obs = {k: v[done_mask] for k, v in final_obs.items()}
+        else:
+            final_obs = final_obs[done_mask]
+        done_hidden = self.policy.recurrent_encoder.index_state(hidden, done_mask)
+        episode_starts = torch.zeros(int(done_mask.sum().item()), device=self.device)
+        with torch.no_grad():
+            values, _ = self._predict_values_recurrent(
+                self._obs_to_policy_device(final_obs), done_hidden, episode_starts
+            )
+        final_values[done_mask] = values.view(-1)
+        return final_values
+
+    def _predict_last_values(self, obs, hidden) -> torch.Tensor:
+        episode_starts = torch.zeros(self.num_envs, device=self.device)
+        last_values, _ = self._predict_values_recurrent(obs, hidden, episode_starts)
+        return last_values.view(-1)
+
+    def _predict_values_recurrent(self, obs, hidden, episode_starts: torch.Tensor):
+        """Private helper reused by _compute_final_values and _predict_last_values."""
+        with torch.no_grad():
+            return self.policy.predict_values_recurrent(obs, hidden, episode_starts)
+
+    def _iter_minibatches(self) -> Iterator[RecurrentRolloutBufferSample]:
+        return self.rollout_buffer.get_sequences(
+            self.num_minibatches, initial_hidden=self._rollout_initial_hidden
+        )
+
+    def _evaluate_minibatch(self, data: RecurrentRolloutBufferSample):
+        values, log_prob, entropy = self.policy.evaluate_actions_sequence(
+            data.obs,
+            data.actions,
+            data.initial_hidden,
+            data.episode_starts,
+            stop_gradient_actor=self._actor_stop_gradient(),
+        )
+        # (T,B,1) tensors; T-major flatten so index [t,b] lands at the same flat
+        # offset across all seven tensors below.
+        return (
+            values.flatten(),
+            log_prob.flatten(),
+            entropy.flatten(),
+            data.old_values.reshape(-1),
+            data.old_log_prob.reshape(-1),
+            data.advantages.reshape(-1),
+            data.returns.reshape(-1),
+        )
+
+    def _checkpoint_metadata(self) -> dict[str, Any]:
+        return {
+            **super()._checkpoint_metadata(),
+            "rnn_type": self.rnn_type,
+            "rnn_hidden_size": self.rnn_hidden_size,
+            "rnn_num_layers": self.rnn_num_layers,
+        }
+
+    def _extra_checkpoint_state(self) -> dict[str, Any]:
+        # NOTE: the live rollout hidden state (self.learn()'s local `hidden`
+        # variable) is intentionally NOT persisted here. A resumed run
+        # re-zero-initializes it at the start of learn(); episode-boundary
+        # masking self-heals within one episode length. Accepted limitation,
+        # not a defect.
+        return super()._extra_checkpoint_state()

--- a/rl_garden/algorithms/recurrent_ppo.py
+++ b/rl_garden/algorithms/recurrent_ppo.py
@@ -2,28 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterator
+from typing import Any
 
-import torch
-
-from rl_garden.algorithms.ppo import PPO
-from rl_garden.buffers.recurrent_rollout_buffer import (
-    RecurrentDictRolloutBuffer,
-    RecurrentRolloutBuffer,
-    RecurrentRolloutBufferSample,
-)
-from rl_garden.common.optim import make_lr_scheduler, make_optimizer
+from rl_garden.algorithms.sequence_ppo import SequencePPO
 from rl_garden.networks.recurrent import RecurrentLatentEncoder, RNNType
-from rl_garden.policies.recurrent_ppo_policy import RecurrentPPOPolicy
 
 
-class RecurrentPPO(PPO):
+class RecurrentPPO(SequencePPO):
     """PPO whose policy carries a persistent LSTM/GRU hidden state across rollout
     steps and trains it via BPTT over sequence-preserving minibatches.
 
     See ``rl_garden.networks.recurrent.RecurrentLatentEncoder`` for why this is
     on-policy-only (off-policy/replay-based recurrence needs stored hidden state
-    and burn-in, neither of which exists here)."""
+    and burn-in, neither of which exists here). Encoder-agnostic rollout/BPTT
+    logic lives in ``SequencePPO``; this class only adds RNN-specific
+    construction (``TransformerPPO`` is the GTrXL-based sibling)."""
 
     _compatible_checkpoint_algorithms = ("RecurrentPPO",)
 
@@ -37,144 +30,19 @@ class RecurrentPPO(PPO):
         **ppo_kwargs: Any,
     ) -> None:
         # Must be set before super().__init__(), which ends by calling
-        # self._setup_model() -- our override below reads these attributes.
+        # self._setup_model() -- our _build_sequence_encoder() override below
+        # reads these attributes.
         self.rnn_type: RNNType = rnn_type
         self.rnn_hidden_size = rnn_hidden_size
         self.rnn_num_layers = rnn_num_layers
         super().__init__(env, **ppo_kwargs)
 
-    def _setup_model(self) -> None:
-        # num_envs/num_minibatches are set earlier in PPO.__init__ (via
-        # OnPolicyAlgorithm.__init__), before this method runs -- safe to
-        # validate here, before any recurrent module gets constructed.
-        if self.num_envs % self.num_minibatches != 0:
-            raise ValueError(
-                f"RecurrentPPO requires num_envs ({self.num_envs}) to be divisible "
-                f"by num_minibatches ({self.num_minibatches}) for env-axis minibatching."
-            )
-        features_extractor = self._build_features_extractor()
-        if features_extractor.structured_feature_config() is not None:
-            raise NotImplementedError(
-                "RecurrentPPO only supports flat-latent feature extractors this "
-                "round (ViT token_and_prop layouts untested)."
-            )
-        recurrent_encoder = RecurrentLatentEncoder(
+    def _build_sequence_encoder(self, features_extractor) -> RecurrentLatentEncoder:
+        return RecurrentLatentEncoder(
             input_dim=features_extractor.features_dim,
             hidden_size=self.rnn_hidden_size,
             rnn_type=self.rnn_type,
             num_layers=self.rnn_num_layers,
-        )
-        self.policy = RecurrentPPOPolicy(
-            observation_space=self.env.single_observation_space,
-            action_space=self.env.single_action_space,
-            features_extractor=features_extractor,
-            recurrent_encoder=recurrent_encoder,
-            net_arch=self.net_arch,
-            log_std_init=self.log_std_init,
-            actor_use_layer_norm=self.actor_use_layer_norm,
-            value_use_layer_norm=self.value_use_layer_norm,
-            actor_use_group_norm=self.actor_use_group_norm,
-            value_use_group_norm=self.value_use_group_norm,
-            num_groups=self.num_groups,
-            actor_dropout_rate=self.actor_dropout_rate,
-            value_dropout_rate=self.value_dropout_rate,
-            kernel_init=self.kernel_init,
-            backbone_type=self.backbone_type,
-        ).to(self.device)
-        self.policy_optimizer = make_optimizer(
-            self.policy.parameters(),
-            lr=self.learning_rate,
-            weight_decay=self.weight_decay,
-            use_adamw=self.use_adamw,
-        )
-        self._lr_scheduler = make_lr_scheduler(
-            self.policy_optimizer,
-            schedule_type=self.lr_schedule,
-            warmup_steps=self.lr_warmup_steps,
-            decay_steps=self.lr_decay_steps,
-            min_lr_ratio=self.lr_min_ratio,
-        )
-        buffer_cls = RecurrentDictRolloutBuffer if self._is_dict_obs else RecurrentRolloutBuffer
-        self.rollout_buffer = buffer_cls(
-            observation_space=self.env.single_observation_space,
-            action_space=self.env.single_action_space,
-            num_steps=self.num_steps,
-            num_envs=self.num_envs,
-            device=self.device,
-            gamma=self.gamma,
-            gae_lambda=self.gae_lambda,
-        )
-
-    def _initial_hidden_state(self, batch_size: int):
-        return self.policy.recurrent_encoder.get_initial_state(batch_size, self.device)
-
-    def _snapshot_window_initial_hidden(self, hidden, next_done: torch.Tensor):
-        return self.policy.recurrent_encoder.mask_state(hidden, 1.0 - next_done.float())
-
-    def _rollout_step(self, obs, hidden, episode_starts: torch.Tensor):
-        with torch.no_grad():
-            return self.policy.act_recurrent(
-                self._obs_to_policy_device(obs),
-                hidden,
-                episode_starts,
-                deterministic=False,
-                stop_gradient_actor=self._actor_stop_gradient(),
-            )
-
-    def _compute_final_values(self, infos, done_mask: torch.Tensor, hidden) -> torch.Tensor:
-        """Bootstrap value for envs that just finished, using the POST-step,
-        UNMASKED hidden state (``final_observation`` continues the same episode,
-        it is not a fresh start)."""
-        final_values = torch.zeros(self.num_envs, device=self.device)
-        if "final_observation" not in infos or not done_mask.any():
-            return final_values
-        final_obs = infos["final_observation"]
-        if isinstance(final_obs, dict):
-            final_obs = {k: v[done_mask] for k, v in final_obs.items()}
-        else:
-            final_obs = final_obs[done_mask]
-        done_hidden = self.policy.recurrent_encoder.index_state(hidden, done_mask)
-        episode_starts = torch.zeros(int(done_mask.sum().item()), device=self.device)
-        with torch.no_grad():
-            values, _ = self._predict_values_recurrent(
-                self._obs_to_policy_device(final_obs), done_hidden, episode_starts
-            )
-        final_values[done_mask] = values.view(-1)
-        return final_values
-
-    def _predict_last_values(self, obs, hidden) -> torch.Tensor:
-        episode_starts = torch.zeros(self.num_envs, device=self.device)
-        last_values, _ = self._predict_values_recurrent(obs, hidden, episode_starts)
-        return last_values.view(-1)
-
-    def _predict_values_recurrent(self, obs, hidden, episode_starts: torch.Tensor):
-        """Private helper reused by _compute_final_values and _predict_last_values."""
-        with torch.no_grad():
-            return self.policy.predict_values_recurrent(obs, hidden, episode_starts)
-
-    def _iter_minibatches(self) -> Iterator[RecurrentRolloutBufferSample]:
-        return self.rollout_buffer.get_sequences(
-            self.num_minibatches, initial_hidden=self._rollout_initial_hidden
-        )
-
-    def _evaluate_minibatch(self, data: RecurrentRolloutBufferSample):
-        values, log_prob, entropy = self.policy.evaluate_actions_sequence(
-            data.obs,
-            data.actions,
-            data.initial_hidden,
-            data.episode_starts,
-            stop_gradient_actor=self._actor_stop_gradient(),
-        )
-        # (T,B,1) tensors; T-major flatten so index [t,b] lands at the same flat
-        # offset across all seven tensors below.
-        return (
-            values.flatten(),
-            log_prob.flatten(),
-            entropy.flatten(),
-            data.old_values.reshape(-1),
-            data.old_log_prob.reshape(-1),
-            data.advantages.reshape(-1),
-            data.returns.reshape(-1),
         )
 
     def _checkpoint_metadata(self) -> dict[str, Any]:
@@ -184,11 +52,3 @@ class RecurrentPPO(PPO):
             "rnn_hidden_size": self.rnn_hidden_size,
             "rnn_num_layers": self.rnn_num_layers,
         }
-
-    def _extra_checkpoint_state(self) -> dict[str, Any]:
-        # NOTE: the live rollout hidden state (self.learn()'s local `hidden`
-        # variable) is intentionally NOT persisted here. A resumed run
-        # re-zero-initializes it at the start of learn(); episode-boundary
-        # masking self-heals within one episode length. Accepted limitation,
-        # not a defect.
-        return super()._extra_checkpoint_state()

--- a/rl_garden/algorithms/recurrent_sac.py
+++ b/rl_garden/algorithms/recurrent_sac.py
@@ -1,0 +1,351 @@
+"""SAC with an LSTM/GRU latent stage and an R2D2-style (stored hidden state +
+burn-in + n-step + priority replay) recurrent replay buffer.
+
+See ``rl_garden.networks.recurrent.RecurrentLatentEncoder`` for the original
+on-policy-only rationale this buffer removes, and
+``rl_garden.buffers.recurrent_replay_buffer`` for the buffer's checkpoint-
+aligned sampling design.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from rl_garden.algorithms.sac import SAC
+from rl_garden.buffers.recurrent_replay_buffer import (
+    RecurrentReplayBuffer,
+    RecurrentReplayBufferSample,
+)
+from rl_garden.networks.recurrent import RecurrentLatentEncoder, RNNType
+from rl_garden.policies.recurrent_sac_policy import RecurrentSACPolicy
+
+
+class RecurrentSAC(SAC):
+    """SAC whose policy carries a persistent LSTM/GRU hidden state across
+    rollout steps and trains it via burn-in-refreshed BPTT over
+    checkpoint-aligned, priority-sampled replay windows.
+
+    Built with minimal changes to ``OffPolicyAlgorithm``/``SACCore``/``SAC``:
+    all recurrent-specific behavior lives here and in ``RecurrentSACPolicy``/
+    ``RecurrentReplayBuffer``, reached entirely through existing override
+    points (``_build_policy``, ``_build_replay_buffer``, the rollout hooks on
+    ``OffPolicyAlgorithm``, and the one new ``_post_critic_update`` hook added
+    to ``SACCore``)."""
+
+    _compatible_checkpoint_algorithms = ("RecurrentSAC",)
+
+    def __init__(
+        self,
+        env: Any,
+        *,
+        rnn_type: RNNType = "lstm",
+        rnn_hidden_size: int = 256,
+        rnn_num_layers: int = 1,
+        burn_in_len: int = 40,
+        learning_len: int = 40,
+        forward_len: int = 5,
+        prio_exponent: float = 0.9,
+        importance_sampling_exponent: float = 0.6,
+        **sac_kwargs: Any,
+    ) -> None:
+        if sac_kwargs.get("nstep", 1) != 1:
+            raise ValueError(
+                "RecurrentSAC uses forward_len for n-step bootstrapping "
+                "(integrated with burn-in), not the flat nstep kwarg."
+            )
+        utd = sac_kwargs.get("utd", 0.5)
+        # Matches SACCore.train()'s own test for entering train_high_utd() --
+        # an integer-valued float (e.g. utd=2.0) must be rejected too, not just
+        # a Python int, or it silently slips into _slice_batch()'s generic
+        # x[start:end] slicing, which would slice (learning_len, B)-shaped
+        # fields along the wrong axis instead of the batch axis.
+        if float(utd).is_integer() and utd > 1:
+            raise ValueError(
+                "RecurrentSAC v1 does not support integer-valued utd > 1 -- "
+                "train_high_utd()'s minibatch splitting is not wired up for "
+                "(learning_len, B)-shaped replay fields yet."
+            )
+        # Must be set before super().__init__(), which ends by calling
+        # self._setup_model() -- our _build_policy/_build_replay_buffer
+        # overrides below read these attributes.
+        self.rnn_type: RNNType = rnn_type
+        self.rnn_hidden_size = rnn_hidden_size
+        self.rnn_num_layers = rnn_num_layers
+        self.burn_in_len = burn_in_len
+        self.learning_len = learning_len
+        self.forward_len = forward_len
+        self.prio_exponent = prio_exponent
+        self.importance_sampling_exponent = importance_sampling_exponent
+        super().__init__(env, **sac_kwargs)
+
+    # --- model construction (override existing SAC hooks, no _setup_model rewrite) ---
+
+    def _build_policy(self, features_extractor) -> RecurrentSACPolicy:
+        if features_extractor.structured_feature_config() is not None:
+            raise NotImplementedError(
+                "RecurrentSAC only supports flat-latent feature extractors this "
+                "round (ViT token_and_prop layouts untested)."
+            )
+        recurrent_encoder = RecurrentLatentEncoder(
+            input_dim=features_extractor.features_dim,
+            hidden_size=self.rnn_hidden_size,
+            rnn_type=self.rnn_type,
+            num_layers=self.rnn_num_layers,
+        )
+        return RecurrentSACPolicy(
+            observation_space=self.env.single_observation_space,
+            action_space=self._policy_action_space(),
+            features_extractor=features_extractor,
+            recurrent_encoder=recurrent_encoder,
+            net_arch=self.net_arch,
+            n_critics=self.n_critics,
+            critic_subsample_size=self.critic_subsample_size,
+            critic_impl=self.critic_impl,
+            actor_use_layer_norm=self.actor_use_layer_norm,
+            critic_use_layer_norm=self.critic_use_layer_norm,
+            log_std_min=self.actor_log_std_min,
+            log_std_mode=self.actor_log_std_mode,
+        )
+
+    def _build_replay_buffer(self) -> RecurrentReplayBuffer:
+        return RecurrentReplayBuffer(
+            observation_space=self.env.single_observation_space,
+            action_space=self.env.single_action_space,
+            num_envs=self.num_envs,
+            buffer_size=self.buffer_size,
+            burn_in_len=self.burn_in_len,
+            learning_len=self.learning_len,
+            forward_len=self.forward_len,
+            rnn_type=self.rnn_type,
+            rnn_hidden_size=self.rnn_hidden_size,
+            rnn_num_layers=self.rnn_num_layers,
+            gamma=self.gamma,
+            prio_exponent=self.prio_exponent,
+            importance_sampling_exponent=self.importance_sampling_exponent,
+            storage_device=self.buffer_device,
+            sample_device=self.device,
+        )
+
+    # --- rollout hidden-state carry (pure subclass overrides of existing hooks) ---
+
+    def _on_env_reset(self, obs) -> None:
+        self._rollout_hidden = self.policy.recurrent_encoder.get_initial_state(
+            self.num_envs, self.device
+        )
+        self._rollout_episode_start = torch.ones(self.num_envs, device=self.device)
+
+    def _rollout_action(self, obs, learning_has_started: bool):
+        del learning_has_started  # recurrent hidden state advances regardless of phase
+        with torch.no_grad():
+            action, new_hidden = self.policy.act_recurrent_step(
+                self._obs_to_policy_device(obs),
+                self._rollout_hidden,
+                self._rollout_episode_start,
+                deterministic=False,
+            )
+        action_context = {"hidden_pre_step": self._rollout_hidden, "new_hidden": new_hidden}
+        return action, action, action_context
+
+    def _replay_buffer_add_kwargs(
+        self, action_context, obs, next_obs, real_next_obs, infos, need_final_obs
+    ) -> dict[str, Any]:
+        del obs, next_obs, real_next_obs, infos, need_final_obs
+        return {"hidden": action_context["hidden_pre_step"]}
+
+    def _replay_buffer_step_kwargs(self, terminations, truncations) -> dict[str, Any]:
+        return {"episode_end": terminations | truncations}
+
+    def _post_rollout_step(self, action_context, terminations, truncations, infos) -> None:
+        del infos
+        self._rollout_hidden = action_context["new_hidden"]
+        self._rollout_episode_start = (terminations | truncations).float()
+
+    def _eval_start_hook(self) -> None:
+        # NOTE: deliberately does NOT call super()._eval_start_hook() (SACCore's
+        # q_mc_diagnostics setup) -- SACCore._eval_q_values() assumes a flat
+        # features->Q pipeline and calls policy.extract_features() directly,
+        # bypassing the RNN entirely, so its Q values would be computed from
+        # the wrong (pre-RNN, wrong-dimensioned) features. q_mc_diagnostics is
+        # unsupported for RecurrentSAC v1 -- silently absent, not silently
+        # wrong, matching _compute_actor_diagnostics' identical scope decision.
+        self._eval_hidden = self.policy.recurrent_encoder.get_initial_state(
+            self.eval_env.num_envs, self.device
+        )
+        self._eval_episode_start = torch.ones(self.eval_env.num_envs, device=self.device)
+
+    def _eval_action_and_critic_action(self, obs):
+        with torch.no_grad():
+            action, new_hidden = self.policy.act_recurrent_step(
+                self._obs_to_policy_device(obs),
+                self._eval_hidden,
+                self._eval_episode_start,
+                deterministic=True,
+            )
+        self._eval_hidden = new_hidden
+        return action, action
+
+    def _eval_step_hook(self, obs_before, critic_action, rewards, terminations, truncations, infos) -> None:
+        # Reset exactly at a genuine episode boundary (this hook is the only
+        # one in the eval loop that actually receives terminations/truncations
+        # -- _eval_action_and_critic_action does not, so resetting there was
+        # never correct: it would either never reset, or reset every step).
+        del obs_before, critic_action, rewards, infos
+        self._eval_episode_start = (terminations | truncations).float()
+
+    # --- training-side overrides ---
+    # NOTE: _extra_batch_slice_keys (SACCore's _slice_batch() extension point)
+    # is intentionally NOT declared here. It exists only to support
+    # train_high_utd()'s mid-batch _slice_batch() splitting, which this class
+    # permanently rejects at construction (integer-valued utd > 1) precisely
+    # because _slice_batch()'s generic x[start:end] slicing would slice
+    # (learning_len, B)-shaped fields along the wrong axis -- so the
+    # declaration would be dead code with no reachable call site.
+
+    def _critic_loss(self, data: RecurrentReplayBufferSample):
+        stop_gradient = not self._training_update_mask().update_encoder
+        initial_hidden = self._to_encoder_state(data.initial_hidden_h, data.initial_hidden_c)
+        tail = self.policy.windowed_features(
+            data.obs, initial_hidden, data.episode_starts, self.burn_in_len,
+            stop_gradient=stop_gradient,
+        )
+        online = tail[: self.learning_len]
+        # Explicit .detach() (NOT a torch.no_grad() around the whole unroll --
+        # that would also kill the online slice's gradient to the encoder/RNN,
+        # since both slices come from the SAME differentiable unroll).
+        target = tail[self.forward_len : self.forward_len + self.learning_len].detach()
+
+        hidden_size = online.shape[-1]
+        online_flat = online.reshape(-1, hidden_size)
+        actions_flat = data.actions.reshape(-1, data.actions.shape[-1])
+        q_pred = self.policy.q_values_all(online_flat, actions_flat, target=False)
+
+        alpha = self._current_alpha().detach()
+        target_flat = target.reshape(-1, hidden_size)
+        with torch.no_grad():
+            next_action, next_log_prob = self.policy.actor.action_log_prob(target_flat)
+            min_q_next = self.policy.min_q_value(
+                target_flat, next_action,
+                subsample_size=self._target_critic_subsample_size(), target=True,
+            )
+            if self._backup_entropy_enabled():
+                min_q_next = min_q_next - alpha * next_log_prob
+            target_q = data.rewards.reshape(-1, 1) + data.discounts.reshape(-1, 1) * min_q_next
+
+        # Flatten order is row-major over (learning_len, B): position t*B+b.
+        # Broadcast each window's IS weight across its learning_len positions
+        # and all critics accordingly.
+        is_weights_flat = (
+            data.is_weights.unsqueeze(0).expand(self.learning_len, -1).reshape(-1)
+        )
+        is_weights_bc = is_weights_flat.reshape(1, -1, 1)
+        target_q_expanded = target_q.unsqueeze(0).expand_as(q_pred)
+        td_loss = (is_weights_bc * (q_pred - target_q_expanded).pow(2)).mean()
+
+        # R2D2-style mixed priority: 0.9*max + 0.1*mean of |td_error| over the
+        # learning axis, per sampled window (worker.py's calculate_mixed_td_errors).
+        with torch.no_grad():
+            batch_size = data.is_weights.shape[0]
+            per_position_error = (
+                (q_pred.mean(dim=0) - target_q).abs().reshape(self.learning_len, batch_size)
+            )
+            td_error_priority = (
+                0.9 * per_position_error.max(dim=0).values + 0.1 * per_position_error.mean(dim=0)
+            )
+
+        info = {
+            "td_loss": td_loss.detach(),
+            "target_q": target_q.mean().detach(),
+            "critic_loss": td_loss.detach(),
+            "predicted_q": q_pred.mean().detach(),
+            "td_error_priority": td_error_priority,
+        }
+        return td_loss, info
+
+    def _actor_loss_from_batch(self, data: RecurrentReplayBufferSample):
+        initial_hidden = self._to_encoder_state(data.initial_hidden_h, data.initial_hidden_c)
+        # Shorter unroll than the critic's: actor loss never needs the
+        # n-step-ahead bootstrap tail.
+        actor_window_len = self.burn_in_len + self.learning_len
+        obs_window = self._slice_obs_window(data.obs, actor_window_len)
+        episode_starts_window = data.episode_starts[:actor_window_len]
+        features = self.policy.windowed_features(
+            obs_window, initial_hidden, episode_starts_window, self.burn_in_len,
+            stop_gradient=False,
+        )
+        # Detach the RNN's OUTPUT here, not the pre-RNN raw features -- passing
+        # stop_gradient into windowed_features would only cut gradient into the
+        # encoder (detaching an upstream tensor never blocks gradient to a
+        # downstream layer's own parameters), leaving the RNN itself still
+        # trained by the actor loss. Matches RecurrentPPOPolicy's identical
+        # "detach latent, not raw features" fix for the same shared-trunk
+        # problem.
+        if self._actor_stop_gradient():
+            features = features.detach()
+        hidden_size = features.shape[-1]
+        flat_features = features.reshape(-1, hidden_size)
+
+        alpha = self._current_alpha().detach()
+        action, log_prob = self.policy.actor.action_log_prob(flat_features)
+        min_q = self.policy.min_q_value(flat_features, action, subsample_size=None, target=False)
+        actor_loss = (alpha * log_prob - min_q).mean()
+        return actor_loss, log_prob.detach()
+
+    def _post_critic_update(self, data: RecurrentReplayBufferSample, critic_info) -> None:
+        self.replay_buffer.update_priorities(
+            data.priority_indices, critic_info["td_error_priority"]
+        )
+
+    def _compute_actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
+        # The default (SACCore._compute_actor_diagnostics) assumes flat
+        # per-transition obs; data.obs here is a (window_len, B, ...) window.
+        # No-op for v1 -- a documented diagnostics gap, not a correctness gap.
+        return {}
+
+    def _q_landscape_diagnostics(self, data) -> dict[str, torch.Tensor]:
+        # Same flat-obs assumption as _compute_actor_diagnostics above --
+        # SACPolicy.q_landscape_diagnostics() calls extract_features(obs, ...)
+        # directly, bypassing the RNN, so it would misinterpret data.obs's
+        # window shape. No-op for v1 (q_landscape_diagnostics defaults to
+        # False, so this only matters if a caller explicitly opts in).
+        return {}
+
+    @staticmethod
+    def _slice_obs_window(obs, length: int):
+        if isinstance(obs, dict):
+            return {k: v[:length] for k, v in obs.items()}
+        return obs[:length]
+
+    def _to_encoder_state(self, hidden_h: torch.Tensor, hidden_c):
+        """Sample dataclasses store hidden state batch-dim-first (B, num_layers,
+        H) so _slice_batch needs no override; transpose to the encoder's native
+        (num_layers, B, H) here, right before the one call site that needs it."""
+        h = hidden_h.transpose(0, 1).contiguous()
+        if hidden_c is None:
+            return h
+        c = hidden_c.transpose(0, 1).contiguous()
+        return h, c
+
+    # --- checkpointing ---
+
+    def _checkpoint_metadata(self) -> dict[str, Any]:
+        return {
+            **super()._checkpoint_metadata(),
+            "rnn_type": self.rnn_type,
+            "rnn_hidden_size": self.rnn_hidden_size,
+            "rnn_num_layers": self.rnn_num_layers,
+            "burn_in_len": self.burn_in_len,
+            "learning_len": self.learning_len,
+            "forward_len": self.forward_len,
+            "prio_exponent": self.prio_exponent,
+            "importance_sampling_exponent": self.importance_sampling_exponent,
+        }
+
+    def _extra_checkpoint_state(self) -> dict[str, Any]:
+        # NOTE: the live rollout hidden state (self._rollout_hidden) is
+        # intentionally NOT persisted here, matching RecurrentPPO's identical
+        # precedent -- a resumed run re-zero-initializes it in _on_env_reset().
+        # The replay buffer's priority tree / checkpoint side-buffer / episode
+        # bookkeeping are also not persisted, matching the pre-existing gap in
+        # NStepDictReplayBuffer's checkpoint support.
+        return super()._extra_checkpoint_state()

--- a/rl_garden/algorithms/recurrent_sac.py
+++ b/rl_garden/algorithms/recurrent_sac.py
@@ -4,35 +4,21 @@ burn-in + n-step + priority replay) recurrent replay buffer.
 See ``rl_garden.networks.recurrent.RecurrentLatentEncoder`` for the original
 on-policy-only rationale this buffer removes, and
 ``rl_garden.buffers.recurrent_replay_buffer`` for the buffer's checkpoint-
-aligned sampling design.
-"""
+aligned sampling design. Encoder-agnostic off-policy-sequence logic (rollout
+hidden-state carry, burn-in BPTT critic/actor loss, diagnostics no-ops,
+checkpoint-aligned priority replay hyperparameters) lives in ``SequenceSAC``;
+this class only adds RNN-specific construction (a future ``TransformerSAC``
+would be the GTrXL-based sibling)."""
 from __future__ import annotations
 
 from typing import Any
 
-import torch
-
-from rl_garden.algorithms.sac import SAC
-from rl_garden.buffers.recurrent_replay_buffer import (
-    RecurrentReplayBuffer,
-    RecurrentReplayBufferSample,
-)
-from rl_garden.networks.recurrent import RecurrentLatentEncoder, RNNType
-from rl_garden.policies.recurrent_sac_policy import RecurrentSACPolicy
+from rl_garden.algorithms.sequence_sac import SequenceSAC
+from rl_garden.buffers.recurrent_replay_buffer import RecurrentReplayBuffer
+from rl_garden.networks.recurrent import RecurrentLatentEncoder, RecurrentState, RNNType
 
 
-class RecurrentSAC(SAC):
-    """SAC whose policy carries a persistent LSTM/GRU hidden state across
-    rollout steps and trains it via burn-in-refreshed BPTT over
-    checkpoint-aligned, priority-sampled replay windows.
-
-    Built with minimal changes to ``OffPolicyAlgorithm``/``SACCore``/``SAC``:
-    all recurrent-specific behavior lives here and in ``RecurrentSACPolicy``/
-    ``RecurrentReplayBuffer``, reached entirely through existing override
-    points (``_build_policy``, ``_build_replay_buffer``, the rollout hooks on
-    ``OffPolicyAlgorithm``, and the one new ``_post_critic_update`` hook added
-    to ``SACCore``)."""
-
+class RecurrentSAC(SequenceSAC):
     _compatible_checkpoint_algorithms = ("RecurrentSAC",)
 
     def __init__(
@@ -42,70 +28,22 @@ class RecurrentSAC(SAC):
         rnn_type: RNNType = "lstm",
         rnn_hidden_size: int = 256,
         rnn_num_layers: int = 1,
-        burn_in_len: int = 40,
-        learning_len: int = 40,
-        forward_len: int = 5,
-        prio_exponent: float = 0.9,
-        importance_sampling_exponent: float = 0.6,
-        **sac_kwargs: Any,
+        **sequence_sac_kwargs: Any,
     ) -> None:
-        if sac_kwargs.get("nstep", 1) != 1:
-            raise ValueError(
-                "RecurrentSAC uses forward_len for n-step bootstrapping "
-                "(integrated with burn-in), not the flat nstep kwarg."
-            )
-        utd = sac_kwargs.get("utd", 0.5)
-        # Matches SACCore.train()'s own test for entering train_high_utd() --
-        # an integer-valued float (e.g. utd=2.0) must be rejected too, not just
-        # a Python int, or it silently slips into _slice_batch()'s generic
-        # x[start:end] slicing, which would slice (learning_len, B)-shaped
-        # fields along the wrong axis instead of the batch axis.
-        if float(utd).is_integer() and utd > 1:
-            raise ValueError(
-                "RecurrentSAC v1 does not support integer-valued utd > 1 -- "
-                "train_high_utd()'s minibatch splitting is not wired up for "
-                "(learning_len, B)-shaped replay fields yet."
-            )
         # Must be set before super().__init__(), which ends by calling
-        # self._setup_model() -- our _build_policy/_build_replay_buffer
+        # self._setup_model() -- our _build_sequence_encoder/_build_replay_buffer
         # overrides below read these attributes.
         self.rnn_type: RNNType = rnn_type
         self.rnn_hidden_size = rnn_hidden_size
         self.rnn_num_layers = rnn_num_layers
-        self.burn_in_len = burn_in_len
-        self.learning_len = learning_len
-        self.forward_len = forward_len
-        self.prio_exponent = prio_exponent
-        self.importance_sampling_exponent = importance_sampling_exponent
-        super().__init__(env, **sac_kwargs)
+        super().__init__(env, **sequence_sac_kwargs)
 
-    # --- model construction (override existing SAC hooks, no _setup_model rewrite) ---
-
-    def _build_policy(self, features_extractor) -> RecurrentSACPolicy:
-        if features_extractor.structured_feature_config() is not None:
-            raise NotImplementedError(
-                "RecurrentSAC only supports flat-latent feature extractors this "
-                "round (ViT token_and_prop layouts untested)."
-            )
-        recurrent_encoder = RecurrentLatentEncoder(
+    def _build_sequence_encoder(self, features_extractor) -> RecurrentLatentEncoder:
+        return RecurrentLatentEncoder(
             input_dim=features_extractor.features_dim,
             hidden_size=self.rnn_hidden_size,
             rnn_type=self.rnn_type,
             num_layers=self.rnn_num_layers,
-        )
-        return RecurrentSACPolicy(
-            observation_space=self.env.single_observation_space,
-            action_space=self._policy_action_space(),
-            features_extractor=features_extractor,
-            recurrent_encoder=recurrent_encoder,
-            net_arch=self.net_arch,
-            n_critics=self.n_critics,
-            critic_subsample_size=self.critic_subsample_size,
-            critic_impl=self.critic_impl,
-            actor_use_layer_norm=self.actor_use_layer_norm,
-            critic_use_layer_norm=self.critic_use_layer_norm,
-            log_std_min=self.actor_log_std_min,
-            log_std_mode=self.actor_log_std_mode,
         )
 
     def _build_replay_buffer(self) -> RecurrentReplayBuffer:
@@ -127,203 +65,14 @@ class RecurrentSAC(SAC):
             sample_device=self.device,
         )
 
-    # --- rollout hidden-state carry (pure subclass overrides of existing hooks) ---
-
-    def _on_env_reset(self, obs) -> None:
-        self._rollout_hidden = self.policy.recurrent_encoder.get_initial_state(
-            self.num_envs, self.device
-        )
-        self._rollout_episode_start = torch.ones(self.num_envs, device=self.device)
-
-    def _rollout_action(self, obs, learning_has_started: bool):
-        del learning_has_started  # recurrent hidden state advances regardless of phase
-        with torch.no_grad():
-            action, new_hidden = self.policy.act_recurrent_step(
-                self._obs_to_policy_device(obs),
-                self._rollout_hidden,
-                self._rollout_episode_start,
-                deterministic=False,
-            )
-        action_context = {"hidden_pre_step": self._rollout_hidden, "new_hidden": new_hidden}
-        return action, action, action_context
-
-    def _replay_buffer_add_kwargs(
-        self, action_context, obs, next_obs, real_next_obs, infos, need_final_obs
-    ) -> dict[str, Any]:
-        del obs, next_obs, real_next_obs, infos, need_final_obs
-        return {"hidden": action_context["hidden_pre_step"]}
-
-    def _replay_buffer_step_kwargs(self, terminations, truncations) -> dict[str, Any]:
-        return {"episode_end": terminations | truncations}
-
-    def _post_rollout_step(self, action_context, terminations, truncations, infos) -> None:
-        del infos
-        self._rollout_hidden = action_context["new_hidden"]
-        self._rollout_episode_start = (terminations | truncations).float()
-
-    def _eval_start_hook(self) -> None:
-        # NOTE: deliberately does NOT call super()._eval_start_hook() (SACCore's
-        # q_mc_diagnostics setup) -- SACCore._eval_q_values() assumes a flat
-        # features->Q pipeline and calls policy.extract_features() directly,
-        # bypassing the RNN entirely, so its Q values would be computed from
-        # the wrong (pre-RNN, wrong-dimensioned) features. q_mc_diagnostics is
-        # unsupported for RecurrentSAC v1 -- silently absent, not silently
-        # wrong, matching _compute_actor_diagnostics' identical scope decision.
-        self._eval_hidden = self.policy.recurrent_encoder.get_initial_state(
-            self.eval_env.num_envs, self.device
-        )
-        self._eval_episode_start = torch.ones(self.eval_env.num_envs, device=self.device)
-
-    def _eval_action_and_critic_action(self, obs):
-        with torch.no_grad():
-            action, new_hidden = self.policy.act_recurrent_step(
-                self._obs_to_policy_device(obs),
-                self._eval_hidden,
-                self._eval_episode_start,
-                deterministic=True,
-            )
-        self._eval_hidden = new_hidden
-        return action, action
-
-    def _eval_step_hook(self, obs_before, critic_action, rewards, terminations, truncations, infos) -> None:
-        # Reset exactly at a genuine episode boundary (this hook is the only
-        # one in the eval loop that actually receives terminations/truncations
-        # -- _eval_action_and_critic_action does not, so resetting there was
-        # never correct: it would either never reset, or reset every step).
-        del obs_before, critic_action, rewards, infos
-        self._eval_episode_start = (terminations | truncations).float()
-
-    # --- training-side overrides ---
-    # NOTE: _extra_batch_slice_keys (SACCore's _slice_batch() extension point)
-    # is intentionally NOT declared here. It exists only to support
-    # train_high_utd()'s mid-batch _slice_batch() splitting, which this class
-    # permanently rejects at construction (integer-valued utd > 1) precisely
-    # because _slice_batch()'s generic x[start:end] slicing would slice
-    # (learning_len, B)-shaped fields along the wrong axis -- so the
-    # declaration would be dead code with no reachable call site.
-
-    def _critic_loss(self, data: RecurrentReplayBufferSample):
-        stop_gradient = not self._training_update_mask().update_encoder
-        initial_hidden = self._to_encoder_state(data.initial_hidden_h, data.initial_hidden_c)
-        tail = self.policy.windowed_features(
-            data.obs, initial_hidden, data.episode_starts, self.burn_in_len,
-            stop_gradient=stop_gradient,
-        )
-        online = tail[: self.learning_len]
-        # Explicit .detach() (NOT a torch.no_grad() around the whole unroll --
-        # that would also kill the online slice's gradient to the encoder/RNN,
-        # since both slices come from the SAME differentiable unroll).
-        target = tail[self.forward_len : self.forward_len + self.learning_len].detach()
-
-        hidden_size = online.shape[-1]
-        online_flat = online.reshape(-1, hidden_size)
-        actions_flat = data.actions.reshape(-1, data.actions.shape[-1])
-        q_pred = self.policy.q_values_all(online_flat, actions_flat, target=False)
-
-        alpha = self._current_alpha().detach()
-        target_flat = target.reshape(-1, hidden_size)
-        with torch.no_grad():
-            next_action, next_log_prob = self.policy.actor.action_log_prob(target_flat)
-            min_q_next = self.policy.min_q_value(
-                target_flat, next_action,
-                subsample_size=self._target_critic_subsample_size(), target=True,
-            )
-            if self._backup_entropy_enabled():
-                min_q_next = min_q_next - alpha * next_log_prob
-            target_q = data.rewards.reshape(-1, 1) + data.discounts.reshape(-1, 1) * min_q_next
-
-        # Flatten order is row-major over (learning_len, B): position t*B+b.
-        # Broadcast each window's IS weight across its learning_len positions
-        # and all critics accordingly.
-        is_weights_flat = (
-            data.is_weights.unsqueeze(0).expand(self.learning_len, -1).reshape(-1)
-        )
-        is_weights_bc = is_weights_flat.reshape(1, -1, 1)
-        target_q_expanded = target_q.unsqueeze(0).expand_as(q_pred)
-        td_loss = (is_weights_bc * (q_pred - target_q_expanded).pow(2)).mean()
-
-        # R2D2-style mixed priority: 0.9*max + 0.1*mean of |td_error| over the
-        # learning axis, per sampled window (worker.py's calculate_mixed_td_errors).
-        with torch.no_grad():
-            batch_size = data.is_weights.shape[0]
-            per_position_error = (
-                (q_pred.mean(dim=0) - target_q).abs().reshape(self.learning_len, batch_size)
-            )
-            td_error_priority = (
-                0.9 * per_position_error.max(dim=0).values + 0.1 * per_position_error.mean(dim=0)
-            )
-
-        info = {
-            "td_loss": td_loss.detach(),
-            "target_q": target_q.mean().detach(),
-            "critic_loss": td_loss.detach(),
-            "predicted_q": q_pred.mean().detach(),
-            "td_error_priority": td_error_priority,
-        }
-        return td_loss, info
-
-    def _actor_loss_from_batch(self, data: RecurrentReplayBufferSample):
-        initial_hidden = self._to_encoder_state(data.initial_hidden_h, data.initial_hidden_c)
-        # Shorter unroll than the critic's: actor loss never needs the
-        # n-step-ahead bootstrap tail.
-        actor_window_len = self.burn_in_len + self.learning_len
-        obs_window = self._slice_obs_window(data.obs, actor_window_len)
-        episode_starts_window = data.episode_starts[:actor_window_len]
-        features = self.policy.windowed_features(
-            obs_window, initial_hidden, episode_starts_window, self.burn_in_len,
-            stop_gradient=False,
-        )
-        # Detach the RNN's OUTPUT here, not the pre-RNN raw features -- passing
-        # stop_gradient into windowed_features would only cut gradient into the
-        # encoder (detaching an upstream tensor never blocks gradient to a
-        # downstream layer's own parameters), leaving the RNN itself still
-        # trained by the actor loss. Matches RecurrentPPOPolicy's identical
-        # "detach latent, not raw features" fix for the same shared-trunk
-        # problem.
-        if self._actor_stop_gradient():
-            features = features.detach()
-        hidden_size = features.shape[-1]
-        flat_features = features.reshape(-1, hidden_size)
-
-        alpha = self._current_alpha().detach()
-        action, log_prob = self.policy.actor.action_log_prob(flat_features)
-        min_q = self.policy.min_q_value(flat_features, action, subsample_size=None, target=False)
-        actor_loss = (alpha * log_prob - min_q).mean()
-        return actor_loss, log_prob.detach()
-
-    def _post_critic_update(self, data: RecurrentReplayBufferSample, critic_info) -> None:
-        self.replay_buffer.update_priorities(
-            data.priority_indices, critic_info["td_error_priority"]
-        )
-
-    def _compute_actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
-        # The default (SACCore._compute_actor_diagnostics) assumes flat
-        # per-transition obs; data.obs here is a (window_len, B, ...) window.
-        # No-op for v1 -- a documented diagnostics gap, not a correctness gap.
-        return {}
-
-    def _q_landscape_diagnostics(self, data) -> dict[str, torch.Tensor]:
-        # Same flat-obs assumption as _compute_actor_diagnostics above --
-        # SACPolicy.q_landscape_diagnostics() calls extract_features(obs, ...)
-        # directly, bypassing the RNN, so it would misinterpret data.obs's
-        # window shape. No-op for v1 (q_landscape_diagnostics defaults to
-        # False, so this only matters if a caller explicitly opts in).
-        return {}
-
-    @staticmethod
-    def _slice_obs_window(obs, length: int):
-        if isinstance(obs, dict):
-            return {k: v[:length] for k, v in obs.items()}
-        return obs[:length]
-
-    def _to_encoder_state(self, hidden_h: torch.Tensor, hidden_c):
+    def _initial_state_from_sample(self, data) -> RecurrentState:
         """Sample dataclasses store hidden state batch-dim-first (B, num_layers,
         H) so _slice_batch needs no override; transpose to the encoder's native
         (num_layers, B, H) here, right before the one call site that needs it."""
-        h = hidden_h.transpose(0, 1).contiguous()
-        if hidden_c is None:
+        h = data.initial_hidden_h.transpose(0, 1).contiguous()
+        if data.initial_hidden_c is None:
             return h
-        c = hidden_c.transpose(0, 1).contiguous()
+        c = data.initial_hidden_c.transpose(0, 1).contiguous()
         return h, c
 
     # --- checkpointing ---
@@ -334,18 +83,4 @@ class RecurrentSAC(SAC):
             "rnn_type": self.rnn_type,
             "rnn_hidden_size": self.rnn_hidden_size,
             "rnn_num_layers": self.rnn_num_layers,
-            "burn_in_len": self.burn_in_len,
-            "learning_len": self.learning_len,
-            "forward_len": self.forward_len,
-            "prio_exponent": self.prio_exponent,
-            "importance_sampling_exponent": self.importance_sampling_exponent,
         }
-
-    def _extra_checkpoint_state(self) -> dict[str, Any]:
-        # NOTE: the live rollout hidden state (self._rollout_hidden) is
-        # intentionally NOT persisted here, matching RecurrentPPO's identical
-        # precedent -- a resumed run re-zero-initializes it in _on_env_reset().
-        # The replay buffer's priority tree / checkpoint side-buffer / episode
-        # bookkeeping are also not persisted, matching the pre-existing gap in
-        # NStepDictReplayBuffer's checkpoint support.
-        return super()._extra_checkpoint_state()

--- a/rl_garden/algorithms/sac_core.py
+++ b/rl_garden/algorithms/sac_core.py
@@ -163,6 +163,12 @@ class SACCore:
     def _post_actor_update(self, data) -> dict[str, torch.Tensor]:
         return {}
 
+    def _post_critic_update(self, data, critic_info: dict[str, torch.Tensor]) -> None:
+        """Hook run unconditionally right after each critic optimizer step.
+        Default: no-op. Recurrent/priority-replay subclasses use this to push
+        per-sample TD-error priorities back into the replay buffer."""
+        return None
+
     def _actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
         """Run actor diagnostics without perturbing training RNG.
 
@@ -356,6 +362,7 @@ class SACCore:
                 self._clip_grad_norm(self.policy.critic_and_encoder_parameters())
                 self.q_optimizer.step()
                 self._step_critic_scheduler()
+                self._post_critic_update(data, critic_info)
 
                 if compute_info:
                     critic_losses_t.append(critic_loss.detach())
@@ -457,6 +464,7 @@ class SACCore:
                 self._clip_grad_norm(self.policy.critic_and_encoder_parameters())
                 self.q_optimizer.step()
                 self._step_critic_scheduler()
+                self._post_critic_update(mb, critic_info)
 
                 if compute_info:
                     critic_losses_t.append(critic_loss.detach())

--- a/rl_garden/algorithms/sequence_ppo.py
+++ b/rl_garden/algorithms/sequence_ppo.py
@@ -1,0 +1,170 @@
+"""Encoder-agnostic base for PPO variants with a stateful sequence-latent stage
+(RNN, GTrXL, ...) between the encoder and actor/critic heads.
+
+Split out of what was originally all of ``RecurrentPPO`` -- every method here
+only ever calls the ``SequenceLatentEncoder`` duck-typed API
+(``get_initial_state``/``mask_state``/``index_state``/``step``/
+``forward_sequence``) or ``self.policy``/``self.rollout_buffer`` methods that
+are themselves encoder-agnostic (see ``RecurrentPPOPolicy``,
+``RecurrentRolloutBuffer``). Concrete subclasses (``RecurrentPPO``,
+``TransformerPPO``) differ only in their constructor's encoder hyperparameters
+and in ``_build_sequence_encoder()``.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+import torch
+
+from rl_garden.algorithms.ppo import PPO
+from rl_garden.buffers.recurrent_rollout_buffer import (
+    RecurrentDictRolloutBuffer,
+    RecurrentRolloutBuffer,
+    RecurrentRolloutBufferSample,
+)
+from rl_garden.common.optim import make_lr_scheduler, make_optimizer
+from rl_garden.networks.sequence_encoder import SequenceLatentEncoder
+from rl_garden.policies.recurrent_ppo_policy import RecurrentPPOPolicy
+
+
+class SequencePPO(PPO):
+    def _build_sequence_encoder(self, features_extractor) -> SequenceLatentEncoder:
+        raise NotImplementedError
+
+    def _setup_model(self) -> None:
+        # num_envs/num_minibatches are set earlier in PPO.__init__ (via
+        # OnPolicyAlgorithm.__init__), before this method runs -- safe to
+        # validate here, before any sequence-encoder module gets constructed.
+        if self.num_envs % self.num_minibatches != 0:
+            raise ValueError(
+                f"{type(self).__name__} requires num_envs ({self.num_envs}) to be "
+                f"divisible by num_minibatches ({self.num_minibatches}) for "
+                "env-axis minibatching."
+            )
+        features_extractor = self._build_features_extractor()
+        if features_extractor.structured_feature_config() is not None:
+            raise NotImplementedError(
+                f"{type(self).__name__} only supports flat-latent feature "
+                "extractors this round (ViT token_and_prop layouts untested)."
+            )
+        sequence_encoder = self._build_sequence_encoder(features_extractor)
+        self.policy = RecurrentPPOPolicy(
+            observation_space=self.env.single_observation_space,
+            action_space=self.env.single_action_space,
+            features_extractor=features_extractor,
+            recurrent_encoder=sequence_encoder,
+            net_arch=self.net_arch,
+            log_std_init=self.log_std_init,
+            actor_use_layer_norm=self.actor_use_layer_norm,
+            value_use_layer_norm=self.value_use_layer_norm,
+            actor_use_group_norm=self.actor_use_group_norm,
+            value_use_group_norm=self.value_use_group_norm,
+            num_groups=self.num_groups,
+            actor_dropout_rate=self.actor_dropout_rate,
+            value_dropout_rate=self.value_dropout_rate,
+            kernel_init=self.kernel_init,
+            backbone_type=self.backbone_type,
+        ).to(self.device)
+        self.policy_optimizer = make_optimizer(
+            self.policy.parameters(),
+            lr=self.learning_rate,
+            weight_decay=self.weight_decay,
+            use_adamw=self.use_adamw,
+        )
+        self._lr_scheduler = make_lr_scheduler(
+            self.policy_optimizer,
+            schedule_type=self.lr_schedule,
+            warmup_steps=self.lr_warmup_steps,
+            decay_steps=self.lr_decay_steps,
+            min_lr_ratio=self.lr_min_ratio,
+        )
+        buffer_cls = RecurrentDictRolloutBuffer if self._is_dict_obs else RecurrentRolloutBuffer
+        self.rollout_buffer = buffer_cls(
+            observation_space=self.env.single_observation_space,
+            action_space=self.env.single_action_space,
+            num_steps=self.num_steps,
+            num_envs=self.num_envs,
+            device=self.device,
+            gamma=self.gamma,
+            gae_lambda=self.gae_lambda,
+        )
+
+    def _initial_hidden_state(self, batch_size: int):
+        return self.policy.recurrent_encoder.get_initial_state(batch_size, self.device)
+
+    def _snapshot_window_initial_hidden(self, hidden, next_done: torch.Tensor):
+        return self.policy.recurrent_encoder.mask_state(hidden, 1.0 - next_done.float())
+
+    def _rollout_step(self, obs, hidden, episode_starts: torch.Tensor):
+        with torch.no_grad():
+            return self.policy.act_recurrent(
+                self._obs_to_policy_device(obs),
+                hidden,
+                episode_starts,
+                deterministic=False,
+                stop_gradient_actor=self._actor_stop_gradient(),
+            )
+
+    def _compute_final_values(self, infos, done_mask: torch.Tensor, hidden) -> torch.Tensor:
+        """Bootstrap value for envs that just finished, using the POST-step,
+        UNMASKED hidden state (``final_observation`` continues the same episode,
+        it is not a fresh start)."""
+        final_values = torch.zeros(self.num_envs, device=self.device)
+        if "final_observation" not in infos or not done_mask.any():
+            return final_values
+        final_obs = infos["final_observation"]
+        if isinstance(final_obs, dict):
+            final_obs = {k: v[done_mask] for k, v in final_obs.items()}
+        else:
+            final_obs = final_obs[done_mask]
+        done_hidden = self.policy.recurrent_encoder.index_state(hidden, done_mask)
+        episode_starts = torch.zeros(int(done_mask.sum().item()), device=self.device)
+        with torch.no_grad():
+            values, _ = self._predict_values_recurrent(
+                self._obs_to_policy_device(final_obs), done_hidden, episode_starts
+            )
+        final_values[done_mask] = values.view(-1)
+        return final_values
+
+    def _predict_last_values(self, obs, hidden) -> torch.Tensor:
+        episode_starts = torch.zeros(self.num_envs, device=self.device)
+        last_values, _ = self._predict_values_recurrent(obs, hidden, episode_starts)
+        return last_values.view(-1)
+
+    def _predict_values_recurrent(self, obs, hidden, episode_starts: torch.Tensor):
+        """Private helper reused by _compute_final_values and _predict_last_values."""
+        with torch.no_grad():
+            return self.policy.predict_values_recurrent(obs, hidden, episode_starts)
+
+    def _iter_minibatches(self) -> Iterator[RecurrentRolloutBufferSample]:
+        return self.rollout_buffer.get_sequences(
+            self.num_minibatches, initial_hidden=self._rollout_initial_hidden
+        )
+
+    def _evaluate_minibatch(self, data: RecurrentRolloutBufferSample):
+        values, log_prob, entropy = self.policy.evaluate_actions_sequence(
+            data.obs,
+            data.actions,
+            data.initial_hidden,
+            data.episode_starts,
+            stop_gradient_actor=self._actor_stop_gradient(),
+        )
+        # (T,B,1) tensors; T-major flatten so index [t,b] lands at the same flat
+        # offset across all seven tensors below.
+        return (
+            values.flatten(),
+            log_prob.flatten(),
+            entropy.flatten(),
+            data.old_values.reshape(-1),
+            data.old_log_prob.reshape(-1),
+            data.advantages.reshape(-1),
+            data.returns.reshape(-1),
+        )
+
+    def _extra_checkpoint_state(self) -> dict[str, Any]:
+        # NOTE: the live rollout hidden state (self.learn()'s local `hidden`
+        # variable) is intentionally NOT persisted here. A resumed run
+        # re-zero-initializes it at the start of learn(); episode-boundary
+        # masking self-heals within one episode length. Accepted limitation,
+        # not a defect.
+        return super()._extra_checkpoint_state()

--- a/rl_garden/algorithms/sequence_sac.py
+++ b/rl_garden/algorithms/sequence_sac.py
@@ -1,0 +1,315 @@
+"""Encoder-agnostic base for SAC variants with a stateful sequence-latent stage
+(RNN, GTrXL, ...) between the encoder and actor/critic heads.
+
+Split out of what was originally all of ``RecurrentSAC`` -- every method here
+only ever calls the ``SequenceLatentEncoder`` duck-typed API
+(``get_initial_state``/``mask_state``/``step``/``forward_sequence_with_burn_in``)
+or ``self.policy``/``self.replay_buffer`` methods that are themselves
+encoder-agnostic (see ``RecurrentSACPolicy``). Concrete subclasses
+(``RecurrentSAC``, a future ``TransformerSAC``) differ only in their
+constructor's encoder hyperparameters, ``_build_sequence_encoder()``,
+``_build_replay_buffer()`` (buffer construction needs encoder-shape-specific
+parameters that intentionally stay out of this base), and
+``_initial_state_from_sample()`` (how a replay sample's stored state is
+unpacked into a ``SequenceState``).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from rl_garden.algorithms.sac import SAC
+from rl_garden.networks.sequence_encoder import SequenceLatentEncoder, SequenceState
+from rl_garden.policies.recurrent_sac_policy import RecurrentSACPolicy
+
+
+class SequenceSAC(SAC):
+    def __init__(
+        self,
+        env: Any,
+        *,
+        burn_in_len: int = 40,
+        learning_len: int = 40,
+        forward_len: int = 5,
+        prio_exponent: float = 0.9,
+        importance_sampling_exponent: float = 0.6,
+        **sac_kwargs: Any,
+    ) -> None:
+        if sac_kwargs.get("nstep", 1) != 1:
+            raise ValueError(
+                f"{type(self).__name__} uses forward_len for n-step bootstrapping "
+                "(integrated with burn-in), not the flat nstep kwarg."
+            )
+        utd = sac_kwargs.get("utd", 0.5)
+        # Matches SACCore.train()'s own test for entering train_high_utd() --
+        # an integer-valued float (e.g. utd=2.0) must be rejected too, not just
+        # a Python int, or it silently slips into _slice_batch()'s generic
+        # x[start:end] slicing, which would slice (learning_len, B)-shaped
+        # fields along the wrong axis instead of the batch axis.
+        if float(utd).is_integer() and utd > 1:
+            raise ValueError(
+                f"{type(self).__name__} v1 does not support integer-valued utd > 1 -- "
+                "train_high_utd()'s minibatch splitting is not wired up for "
+                "(learning_len, B)-shaped replay fields yet."
+            )
+        # Must be set before super().__init__(), which ends by calling
+        # self._setup_model() -- our _build_policy/_build_replay_buffer
+        # overrides below read these attributes.
+        self.burn_in_len = burn_in_len
+        self.learning_len = learning_len
+        self.forward_len = forward_len
+        self.prio_exponent = prio_exponent
+        self.importance_sampling_exponent = importance_sampling_exponent
+        super().__init__(env, **sac_kwargs)
+
+    # --- subclass hooks ---
+
+    def _build_sequence_encoder(self, features_extractor) -> SequenceLatentEncoder:
+        raise NotImplementedError
+
+    def _initial_state_from_sample(self, data) -> SequenceState:
+        raise NotImplementedError
+
+    # --- model construction (override existing SAC hooks, no _setup_model rewrite) ---
+
+    def _build_policy(self, features_extractor) -> RecurrentSACPolicy:
+        if features_extractor.structured_feature_config() is not None:
+            raise NotImplementedError(
+                f"{type(self).__name__} only supports flat-latent feature "
+                "extractors this round (ViT token_and_prop layouts untested)."
+            )
+        sequence_encoder = self._build_sequence_encoder(features_extractor)
+        return RecurrentSACPolicy(
+            observation_space=self.env.single_observation_space,
+            action_space=self._policy_action_space(),
+            features_extractor=features_extractor,
+            recurrent_encoder=sequence_encoder,
+            net_arch=self.net_arch,
+            n_critics=self.n_critics,
+            critic_subsample_size=self.critic_subsample_size,
+            critic_impl=self.critic_impl,
+            actor_use_layer_norm=self.actor_use_layer_norm,
+            critic_use_layer_norm=self.critic_use_layer_norm,
+            log_std_min=self.actor_log_std_min,
+            log_std_mode=self.actor_log_std_mode,
+        )
+
+    # --- rollout hidden-state carry (pure subclass overrides of existing hooks) ---
+
+    def _on_env_reset(self, obs) -> None:
+        self._rollout_hidden = self.policy.recurrent_encoder.get_initial_state(
+            self.num_envs, self.device
+        )
+        self._rollout_episode_start = torch.ones(self.num_envs, device=self.device)
+
+    def _rollout_action(self, obs, learning_has_started: bool):
+        del learning_has_started  # recurrent hidden state advances regardless of phase
+        with torch.no_grad():
+            action, new_hidden = self.policy.act_recurrent_step(
+                self._obs_to_policy_device(obs),
+                self._rollout_hidden,
+                self._rollout_episode_start,
+                deterministic=False,
+            )
+        action_context = {"hidden_pre_step": self._rollout_hidden, "new_hidden": new_hidden}
+        return action, action, action_context
+
+    def _replay_buffer_add_kwargs(
+        self, action_context, obs, next_obs, real_next_obs, infos, need_final_obs
+    ) -> dict[str, Any]:
+        del obs, next_obs, real_next_obs, infos, need_final_obs
+        return {"hidden": action_context["hidden_pre_step"]}
+
+    def _replay_buffer_step_kwargs(self, terminations, truncations) -> dict[str, Any]:
+        return {"episode_end": terminations | truncations}
+
+    def _post_rollout_step(self, action_context, terminations, truncations, infos) -> None:
+        del infos
+        self._rollout_hidden = action_context["new_hidden"]
+        self._rollout_episode_start = (terminations | truncations).float()
+
+    def _eval_start_hook(self) -> None:
+        # NOTE: deliberately does NOT call super()._eval_start_hook() (SACCore's
+        # q_mc_diagnostics setup) -- SACCore._eval_q_values() assumes a flat
+        # features->Q pipeline and calls policy.extract_features() directly,
+        # bypassing the sequence encoder entirely, so its Q values would be
+        # computed from the wrong (pre-encoder, wrong-dimensioned) features.
+        # q_mc_diagnostics is unsupported for sequence SAC variants v1 --
+        # silently absent, not silently wrong, matching
+        # _compute_actor_diagnostics/_compute_q_landscape_diagnostics' identical
+        # scope decision below.
+        self._eval_hidden = self.policy.recurrent_encoder.get_initial_state(
+            self.eval_env.num_envs, self.device
+        )
+        self._eval_episode_start = torch.ones(self.eval_env.num_envs, device=self.device)
+
+    def _eval_action_and_critic_action(self, obs):
+        with torch.no_grad():
+            action, new_hidden = self.policy.act_recurrent_step(
+                self._obs_to_policy_device(obs),
+                self._eval_hidden,
+                self._eval_episode_start,
+                deterministic=True,
+            )
+        self._eval_hidden = new_hidden
+        return action, action
+
+    def _eval_step_hook(
+        self, obs_before, critic_action, rewards, terminations, truncations, infos
+    ) -> None:
+        # Reset exactly at a genuine episode boundary (this hook is the only
+        # one in the eval loop that actually receives terminations/truncations
+        # -- _eval_action_and_critic_action does not, so resetting there was
+        # never correct: it would either never reset, or reset every step).
+        del obs_before, critic_action, rewards, infos
+        self._eval_episode_start = (terminations | truncations).float()
+
+    # --- training-side ---
+    # NOTE: _extra_batch_slice_keys (SACCore's _slice_batch() extension point)
+    # is intentionally NOT declared here. It exists only to support
+    # train_high_utd()'s mid-batch _slice_batch() splitting, which this class
+    # permanently rejects at construction (integer-valued utd > 1) precisely
+    # because _slice_batch()'s generic x[start:end] slicing would slice
+    # (learning_len, B)-shaped fields along the wrong axis -- so the
+    # declaration would be dead code with no reachable call site.
+
+    def _critic_loss(self, data):
+        stop_gradient = not self._training_update_mask().update_encoder
+        initial_hidden = self._initial_state_from_sample(data)
+        tail = self.policy.windowed_features(
+            data.obs, initial_hidden, data.episode_starts, self.burn_in_len,
+            stop_gradient=stop_gradient,
+        )
+        online = tail[: self.learning_len]
+        # Explicit .detach() (NOT a torch.no_grad() around the whole unroll --
+        # that would also kill the online slice's gradient to the encoder/RNN,
+        # since both slices come from the SAME differentiable unroll).
+        target = tail[self.forward_len : self.forward_len + self.learning_len].detach()
+
+        hidden_size = online.shape[-1]
+        online_flat = online.reshape(-1, hidden_size)
+        actions_flat = data.actions.reshape(-1, data.actions.shape[-1])
+        q_pred = self.policy.q_values_all(online_flat, actions_flat, target=False)
+
+        alpha = self._current_alpha().detach()
+        target_flat = target.reshape(-1, hidden_size)
+        with torch.no_grad():
+            next_action, next_log_prob = self.policy.actor.action_log_prob(target_flat)
+            min_q_next = self.policy.min_q_value(
+                target_flat, next_action,
+                subsample_size=self._target_critic_subsample_size(), target=True,
+            )
+            if self._backup_entropy_enabled():
+                min_q_next = min_q_next - alpha * next_log_prob
+            target_q = data.rewards.reshape(-1, 1) + data.discounts.reshape(-1, 1) * min_q_next
+
+        # Flatten order is row-major over (learning_len, B): position t*B+b.
+        # Broadcast each window's IS weight across its learning_len positions
+        # and all critics accordingly.
+        is_weights_flat = (
+            data.is_weights.unsqueeze(0).expand(self.learning_len, -1).reshape(-1)
+        )
+        is_weights_bc = is_weights_flat.reshape(1, -1, 1)
+        target_q_expanded = target_q.unsqueeze(0).expand_as(q_pred)
+        td_loss = (is_weights_bc * (q_pred - target_q_expanded).pow(2)).mean()
+
+        # R2D2-style mixed priority: 0.9*max + 0.1*mean of |td_error| over the
+        # learning axis, per sampled window (worker.py's calculate_mixed_td_errors).
+        with torch.no_grad():
+            batch_size = data.is_weights.shape[0]
+            per_position_error = (
+                (q_pred.mean(dim=0) - target_q).abs().reshape(self.learning_len, batch_size)
+            )
+            td_error_priority = (
+                0.9 * per_position_error.max(dim=0).values + 0.1 * per_position_error.mean(dim=0)
+            )
+
+        info = {
+            "td_loss": td_loss.detach(),
+            "target_q": target_q.mean().detach(),
+            "critic_loss": td_loss.detach(),
+            "predicted_q": q_pred.mean().detach(),
+            "td_error_priority": td_error_priority,
+        }
+        return td_loss, info
+
+    def _actor_loss_from_batch(self, data):
+        initial_hidden = self._initial_state_from_sample(data)
+        # Shorter unroll than the critic's: actor loss never needs the
+        # n-step-ahead bootstrap tail.
+        actor_window_len = self.burn_in_len + self.learning_len
+        obs_window = self._slice_obs_window(data.obs, actor_window_len)
+        episode_starts_window = data.episode_starts[:actor_window_len]
+        features = self.policy.windowed_features(
+            obs_window, initial_hidden, episode_starts_window, self.burn_in_len,
+            stop_gradient=False,
+        )
+        # Detach the encoder's OUTPUT here, not the pre-encoder raw features --
+        # passing stop_gradient into windowed_features would only cut gradient
+        # into the feature extractor (detaching an upstream tensor never blocks
+        # gradient to a downstream layer's own parameters), leaving the
+        # sequence encoder itself still trained by the actor loss. Matches
+        # RecurrentPPOPolicy's identical "detach latent, not raw features" fix
+        # for the same shared-trunk problem.
+        if self._actor_stop_gradient():
+            features = features.detach()
+        hidden_size = features.shape[-1]
+        flat_features = features.reshape(-1, hidden_size)
+
+        alpha = self._current_alpha().detach()
+        action, log_prob = self.policy.actor.action_log_prob(flat_features)
+        min_q = self.policy.min_q_value(flat_features, action, subsample_size=None, target=False)
+        actor_loss = (alpha * log_prob - min_q).mean()
+        return actor_loss, log_prob.detach()
+
+    def _post_critic_update(self, data, critic_info) -> None:
+        self.replay_buffer.update_priorities(
+            data.priority_indices, critic_info["td_error_priority"]
+        )
+
+    def _compute_actor_diagnostics(self, data) -> dict[str, torch.Tensor]:
+        # The default (SACCore._compute_actor_diagnostics) assumes flat
+        # per-transition obs; data.obs here is a (window_len, B, ...) window.
+        # No-op for v1 -- a documented diagnostics gap, not a correctness gap.
+        # Same reasoning applies to _q_landscape_diagnostics below and to
+        # _eval_start_hook's skipped q_mc_diagnostics setup above.
+        return {}
+
+    def _q_landscape_diagnostics(self, data) -> dict[str, torch.Tensor]:
+        # Override the full SACCore method (not just an inner hook) so this
+        # stays a pure-addition subclass -- SACCore.q_landscape_diagnostics's
+        # flag-check + RNG-fork wrapping assumes data.obs is flat per-transition
+        # obs (SACPolicy.q_landscape_diagnostics calls extract_features(obs,
+        # ...) directly, bypassing the sequence encoder), which would
+        # misinterpret data.obs's (window_len, B, ...) shape here regardless of
+        # what happens inside the wrapper. No-op for v1 (only matters if a
+        # caller explicitly opts in via q_landscape_diagnostics=True).
+        return {}
+
+    @staticmethod
+    def _slice_obs_window(obs, length: int):
+        if isinstance(obs, dict):
+            return {k: v[:length] for k, v in obs.items()}
+        return obs[:length]
+
+    # --- checkpointing ---
+
+    def _checkpoint_metadata(self) -> dict[str, Any]:
+        return {
+            **super()._checkpoint_metadata(),
+            "burn_in_len": self.burn_in_len,
+            "learning_len": self.learning_len,
+            "forward_len": self.forward_len,
+            "prio_exponent": self.prio_exponent,
+            "importance_sampling_exponent": self.importance_sampling_exponent,
+        }
+
+    def _extra_checkpoint_state(self) -> dict[str, Any]:
+        # NOTE: the live rollout hidden state (self._rollout_hidden) is
+        # intentionally NOT persisted here, matching RecurrentPPO's identical
+        # precedent -- a resumed run re-zero-initializes it in _on_env_reset().
+        # The replay buffer's priority tree / checkpoint side-buffer / episode
+        # bookkeeping are also not persisted, matching the pre-existing gap in
+        # NStepDictReplayBuffer's checkpoint support.
+        return super()._extra_checkpoint_state()

--- a/rl_garden/algorithms/td3.py
+++ b/rl_garden/algorithms/td3.py
@@ -1,0 +1,61 @@
+"""TD3 algorithm: DDPG + delayed policy updates + decoupled target policy
+smoothing + Q1-only actor loss.
+
+Clipped double-Q learning (twin critics, min-for-target) is already present in
+``DDPG`` via ``DrQv2Critic`` and does not need to be reimplemented here.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+from rl_garden.algorithms.ddpg import DDPG
+
+
+class TD3(DDPG):
+    """TD3 (Fujimoto et al. 2018) as a thin extension of ``DDPG``.
+
+    Overrides three hooks on top of ``DDPG``'s existing twin-Q critic:
+
+    * ``_target_action_noise``: fixed ``(target_noise_std, target_noise_clip)``
+      decoupled from the exploration schedule, instead of reusing it.
+    * ``_should_update_actor_and_target``: delays actor + target updates to
+      every ``policy_freq`` gradient steps.
+    * ``_actor_q_value``: uses the first critic only (canonical TD3 actor
+      loss), instead of DDPG's ``min(q1, q2)``.
+    """
+
+    _compatible_checkpoint_algorithms = ("TD3",)
+
+    def __init__(
+        self,
+        env: Any,
+        eval_env: Optional[Any] = None,
+        *,
+        policy_freq: int = 2,
+        target_noise_std: float = 0.2,
+        target_noise_clip: float = 0.5,
+        **ddpg_kwargs: Any,
+    ) -> None:
+        self.policy_freq = policy_freq
+        self.target_noise_std = target_noise_std
+        self.target_noise_clip = target_noise_clip
+        super().__init__(env, eval_env, **ddpg_kwargs)
+
+    def _target_action_noise(self) -> tuple[float, float]:
+        return self.target_noise_std, self.target_noise_clip
+
+    def _should_update_actor_and_target(self) -> bool:
+        return self._global_update % self.policy_freq == 0
+
+    def _actor_q_value(self, q_actor_all: torch.Tensor) -> torch.Tensor:
+        return q_actor_all[0]
+
+    def _checkpoint_metadata(self) -> dict[str, Any]:
+        return {
+            **super()._checkpoint_metadata(),
+            "policy_freq": self.policy_freq,
+            "target_noise_std": self.target_noise_std,
+            "target_noise_clip": self.target_noise_clip,
+        }

--- a/rl_garden/algorithms/transformer_ppo.py
+++ b/rl_garden/algorithms/transformer_ppo.py
@@ -1,0 +1,75 @@
+"""PPO with a GTrXL (Gated Transformer-XL) latent stage between the encoder
+and actor/critic heads -- Transformer sibling of ``RecurrentPPO``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rl_garden.algorithms.sequence_ppo import SequencePPO
+from rl_garden.networks.gtrxl import GTrXLLatentEncoder
+
+
+class TransformerPPO(SequencePPO):
+    """PPO whose policy carries a GTrXL segment-recurrent memory across rollout
+    steps and trains it via BPTT over sequence-preserving minibatches.
+
+    See ``rl_garden.networks.gtrxl.GTrXLLatentEncoder`` for the memory/masking
+    design and why burn-in is unimplemented (on-policy, no replay staleness).
+    Encoder-agnostic rollout/BPTT logic lives in ``SequencePPO``; this class
+    only adds GTrXL-specific construction (``RecurrentPPO`` is the RNN-based
+    sibling)."""
+
+    _compatible_checkpoint_algorithms = ("TransformerPPO",)
+
+    def __init__(
+        self,
+        env: Any,
+        *,
+        embed_dim: int = 256,
+        head_dim: int = 64,
+        num_heads: int = 4,
+        num_transformer_layers: int = 3,
+        mlp_num: int = 2,
+        memory_len: int = 64,
+        dropout_rate: float = 0.0,
+        gru_bias: float = 2.0,
+        **ppo_kwargs: Any,
+    ) -> None:
+        # Must be set before super().__init__(), which ends by calling
+        # self._setup_model() -- our _build_sequence_encoder() override below
+        # reads these attributes.
+        self.embed_dim = embed_dim
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.num_transformer_layers = num_transformer_layers
+        self.mlp_num = mlp_num
+        self.memory_len = memory_len
+        self.dropout_rate = dropout_rate
+        self.gru_bias = gru_bias
+        super().__init__(env, **ppo_kwargs)
+
+    def _build_sequence_encoder(self, features_extractor) -> GTrXLLatentEncoder:
+        return GTrXLLatentEncoder(
+            input_dim=features_extractor.features_dim,
+            embed_dim=self.embed_dim,
+            head_dim=self.head_dim,
+            num_heads=self.num_heads,
+            num_layers=self.num_transformer_layers,
+            mlp_num=self.mlp_num,
+            memory_len=self.memory_len,
+            dropout_rate=self.dropout_rate,
+            gru_bias=self.gru_bias,
+        )
+
+    def _checkpoint_metadata(self) -> dict[str, Any]:
+        return {
+            **super()._checkpoint_metadata(),
+            "embed_dim": self.embed_dim,
+            "head_dim": self.head_dim,
+            "num_heads": self.num_heads,
+            "num_transformer_layers": self.num_transformer_layers,
+            "mlp_num": self.mlp_num,
+            "memory_len": self.memory_len,
+            "dropout_rate": self.dropout_rate,
+            "gru_bias": self.gru_bias,
+        }

--- a/rl_garden/algorithms/transformer_sac.py
+++ b/rl_garden/algorithms/transformer_sac.py
@@ -1,0 +1,126 @@
+"""SAC with a GTrXL (Gated Transformer-XL) latent stage and a dense,
+burn-in-from-zero replay buffer -- Transformer sibling of ``RecurrentSAC``."""
+from __future__ import annotations
+
+from typing import Any
+
+from rl_garden.algorithms.sequence_sac import SequenceSAC
+from rl_garden.buffers.transformer_replay_buffer import TransformerReplayBuffer
+from rl_garden.networks.gtrxl import GTrXLLatentEncoder, GTrXLState
+
+
+class TransformerSAC(SequenceSAC):
+    """SAC whose policy carries a GTrXL segment-recurrent memory across rollout
+    steps and trains it via zero-init-burn-in-refreshed BPTT over densely
+    (not checkpoint-aligned) sampled, priority-sampled replay windows.
+
+    See ``rl_garden.networks.gtrxl.GTrXLLatentEncoder.forward_sequence_with_burn_in``
+    for why no stored per-transition hidden state is needed (unlike
+    ``RecurrentSAC``'s R2D2 scheme) and for the approximate-reconstruction
+    fidelity tradeoff burn_in_len/memory_len/num_transformer_layers control.
+    Encoder-agnostic off-policy-sequence logic lives in ``SequenceSAC``; this
+    class only adds GTrXL-specific construction (``RecurrentSAC`` is the
+    RNN-based sibling)."""
+
+    _compatible_checkpoint_algorithms = ("TransformerSAC",)
+
+    def __init__(
+        self,
+        env: Any,
+        *,
+        embed_dim: int = 256,
+        head_dim: int = 64,
+        num_heads: int = 4,
+        num_transformer_layers: int = 3,
+        mlp_num: int = 2,
+        memory_len: int = 16,
+        dropout_rate: float = 0.0,
+        gru_bias: float = 2.0,
+        **sequence_sac_kwargs: Any,
+    ) -> None:
+        # Must be set before super().__init__(), which ends by calling
+        # self._setup_model() -- our _build_sequence_encoder/_build_replay_buffer
+        # overrides below read these attributes.
+        self.embed_dim = embed_dim
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.num_transformer_layers = num_transformer_layers
+        self.mlp_num = mlp_num
+        self.memory_len = memory_len
+        self.dropout_rate = dropout_rate
+        self.gru_bias = gru_bias
+        super().__init__(env, **sequence_sac_kwargs)
+
+    def _build_sequence_encoder(self, features_extractor) -> GTrXLLatentEncoder:
+        if self.burn_in_len < self.memory_len:
+            raise ValueError(
+                f"TransformerSAC requires burn_in_len ({self.burn_in_len}) >= "
+                f"memory_len ({self.memory_len}) -- below this floor the memory "
+                "window isn't even fully populated once. This is a floor, not a "
+                "guarantee of exact reconstruction: full fidelity for all "
+                "num_transformer_layers layers needs burn_in_len >= "
+                "num_transformer_layers * memory_len (deeper layers see a "
+                "progressively-more-truncated effective context otherwise, "
+                "matching Transformer-XL's depth x segment-length compounding -- "
+                "see GTrXLLatentEncoder.forward_sequence_with_burn_in). Treat this "
+                "the same way R2D2 treats partial burn-in: an accepted, tunable "
+                "approximation."
+            )
+        return GTrXLLatentEncoder(
+            input_dim=features_extractor.features_dim,
+            embed_dim=self.embed_dim,
+            head_dim=self.head_dim,
+            num_heads=self.num_heads,
+            num_layers=self.num_transformer_layers,
+            mlp_num=self.mlp_num,
+            memory_len=self.memory_len,
+            dropout_rate=self.dropout_rate,
+            gru_bias=self.gru_bias,
+        )
+
+    def _build_replay_buffer(self) -> TransformerReplayBuffer:
+        return TransformerReplayBuffer(
+            observation_space=self.env.single_observation_space,
+            action_space=self.env.single_action_space,
+            num_envs=self.num_envs,
+            buffer_size=self.buffer_size,
+            burn_in_len=self.burn_in_len,
+            learning_len=self.learning_len,
+            forward_len=self.forward_len,
+            gamma=self.gamma,
+            prio_exponent=self.prio_exponent,
+            importance_sampling_exponent=self.importance_sampling_exponent,
+            storage_device=self.buffer_device,
+            sample_device=self.device,
+        )
+
+    def _initial_state_from_sample(self, data) -> GTrXLState:
+        # GTrXL's memory is a bounded sliding window of raw activations, not a
+        # compressed RNN-style state -- unlike RecurrentSAC, no stored
+        # per-transition hidden state is needed at all; burn-in always starts
+        # from zero (see _build_sequence_encoder's burn_in_len/memory_len floor).
+        batch_size = data.episode_starts.shape[1]
+        return self.policy.recurrent_encoder.get_initial_state(batch_size, self.device)
+
+    def _replay_buffer_add_kwargs(
+        self, action_context, obs, next_obs, real_next_obs, infos, need_final_obs
+    ) -> dict[str, Any]:
+        # GTrXL never stores a per-transition hidden checkpoint (see
+        # _initial_state_from_sample) -- override SequenceSAC's RNN-oriented
+        # default ({"hidden": ...}) since TransformerReplayBuffer.add() has no
+        # `hidden` parameter.
+        del action_context, obs, next_obs, real_next_obs, infos, need_final_obs
+        return {}
+
+    def _checkpoint_metadata(self) -> dict[str, Any]:
+        return {
+            **super()._checkpoint_metadata(),
+            "embed_dim": self.embed_dim,
+            "head_dim": self.head_dim,
+            "num_heads": self.num_heads,
+            "num_transformer_layers": self.num_transformer_layers,
+            "mlp_num": self.mlp_num,
+            "memory_len": self.memory_len,
+            "dropout_rate": self.dropout_rate,
+            "gru_bias": self.gru_bias,
+        }

--- a/rl_garden/buffers/__init__.py
+++ b/rl_garden/buffers/__init__.py
@@ -31,6 +31,11 @@ from rl_garden.buffers.rollout_buffer import (
     RolloutBuffer,
     RolloutBufferSample,
 )
+from rl_garden.buffers.recurrent_rollout_buffer import (
+    RecurrentDictRolloutBuffer,
+    RecurrentRolloutBuffer,
+    RecurrentRolloutBufferSample,
+)
 from rl_garden.buffers.nstep_tensor_buffer import NStepTensorReplayBuffer
 from rl_garden.buffers.tensor_buffer import TensorReplayBuffer
 
@@ -43,6 +48,9 @@ __all__ = [
     "MCReplayBufferSample",
     "MCTensorReplayBuffer",
     "NStepTensorReplayBuffer",
+    "RecurrentDictRolloutBuffer",
+    "RecurrentRolloutBuffer",
+    "RecurrentRolloutBufferSample",
     "ResidualDictReplayBuffer",
     "ResidualTensorReplayBuffer",
     "RolloutBuffer",

--- a/rl_garden/buffers/__init__.py
+++ b/rl_garden/buffers/__init__.py
@@ -36,6 +36,10 @@ from rl_garden.buffers.recurrent_rollout_buffer import (
     RecurrentRolloutBuffer,
     RecurrentRolloutBufferSample,
 )
+from rl_garden.buffers.recurrent_replay_buffer import (
+    RecurrentReplayBuffer,
+    RecurrentReplayBufferSample,
+)
 from rl_garden.buffers.nstep_tensor_buffer import NStepTensorReplayBuffer
 from rl_garden.buffers.tensor_buffer import TensorReplayBuffer
 
@@ -49,6 +53,8 @@ __all__ = [
     "MCTensorReplayBuffer",
     "NStepTensorReplayBuffer",
     "RecurrentDictRolloutBuffer",
+    "RecurrentReplayBuffer",
+    "RecurrentReplayBufferSample",
     "RecurrentRolloutBuffer",
     "RecurrentRolloutBufferSample",
     "ResidualDictReplayBuffer",

--- a/rl_garden/buffers/__init__.py
+++ b/rl_garden/buffers/__init__.py
@@ -40,6 +40,10 @@ from rl_garden.buffers.recurrent_replay_buffer import (
     RecurrentReplayBuffer,
     RecurrentReplayBufferSample,
 )
+from rl_garden.buffers.transformer_replay_buffer import (
+    TransformerReplayBuffer,
+    TransformerReplayBufferSample,
+)
 from rl_garden.buffers.nstep_tensor_buffer import NStepTensorReplayBuffer
 from rl_garden.buffers.tensor_buffer import TensorReplayBuffer
 
@@ -62,6 +66,8 @@ __all__ = [
     "RolloutBuffer",
     "RolloutBufferSample",
     "TensorReplayBuffer",
+    "TransformerReplayBuffer",
+    "TransformerReplayBufferSample",
     "count_residual_h5_transitions",
     "infer_box_specs_from_h5",
     "infer_specs_from_h5",

--- a/rl_garden/buffers/_final_obs_table.py
+++ b/rl_garden/buffers/_final_obs_table.py
@@ -1,0 +1,78 @@
+"""Compact final/terminal-observation side table, shared by sequence-aware
+replay buffers (``RecurrentReplayBuffer``, ``TransformerReplayBuffer``).
+
+Gymnasium autoreset means the ring buffer's naturally-following ``obs`` after an
+episode-end position is already the NEXT episode's reset obs, not the true final
+one -- this side table stores the true final obs compactly (a small side array,
+not one slot per buffer position) so ``RecurrentSamplingMixin._patch_final_obs``
+can patch it back in wherever a boundary falls inside a sampled window. Mirrors
+``LazyNextNStepDictReplayBuffer``'s exact mechanism (``nstep_buffer.py``),
+generalized to Box observations too.
+
+The host buffer must expose: ``observation_space``, ``storage_device``,
+``buffer_size``, ``_is_dict_obs``.
+"""
+from __future__ import annotations
+
+import torch
+
+from rl_garden.buffers.dict_buffer import DictArray
+
+
+def _copy_tree(src, dst, count: int) -> None:
+    if isinstance(src, DictArray):
+        for key, value in src.data.items():
+            _copy_tree(value, dst.data[key], count)
+    else:
+        dst[:count].copy_(src[:count])
+
+
+class FinalObsTableMixin:
+    def _init_final_obs_table(self, shape: tuple[int, ...]) -> None:
+        self._final_slot_ids = torch.full(
+            shape, -1, dtype=torch.long, device=self.storage_device
+        )
+        self._free_final_slots: list[int] = []
+        self._next_final_slot = 0
+        final_obs_capacity = max(1024, self.buffer_size // 64)
+        if self._is_dict_obs:
+            self._final_obs = DictArray(
+                (final_obs_capacity,), self.observation_space, device=self.storage_device
+            )
+        else:
+            self._final_obs = torch.zeros(
+                (final_obs_capacity,) + tuple(self.observation_space.shape),
+                device=self.storage_device,
+            )
+
+    def _grow_final_obs(self) -> None:
+        current = self._final_obs.shape[0]
+        new_capacity = current * 2
+        if self._is_dict_obs:
+            grown = DictArray(
+                (new_capacity,), self.observation_space, device=self.storage_device
+            )
+            _copy_tree(self._final_obs, grown, current)
+        else:
+            grown = torch.zeros(
+                (new_capacity,) + tuple(self.observation_space.shape),
+                device=self.storage_device,
+            )
+            grown[:current] = self._final_obs
+        self._final_obs = grown
+
+    def _allocate_final_slot(self) -> int:
+        if self._free_final_slots:
+            return self._free_final_slots.pop()
+        if self._next_final_slot >= self._final_obs.shape[0]:
+            self._grow_final_obs()
+        slot = self._next_final_slot
+        self._next_final_slot += 1
+        return slot
+
+    def _write_final_obs_slot(self, storage, slot: int, value, env: int) -> None:
+        if isinstance(storage, DictArray):
+            for key in storage.data:
+                self._write_final_obs_slot(storage.data[key], slot, value[key], env)
+        else:
+            storage[slot] = value[env].to(self.storage_device)

--- a/rl_garden/buffers/_recurrent_sampling.py
+++ b/rl_garden/buffers/_recurrent_sampling.py
@@ -1,0 +1,167 @@
+"""Sampling/validity mixin for ``RecurrentReplayBuffer``.
+
+Extends the vectorized contiguity-checking idiom already used by
+``_nstep_sampling.py`` (rejection sampling via torch tensor ops, no Python
+per-sample loops) to a much longer combined burn-in+learning+forward window,
+proposed by priority (a ``SumTree``) rather than drawn IID.
+
+The host buffer must expose: ``per_env_buffer_size``, ``num_envs``,
+``storage_device``, ``gamma``, ``burn_in_len``/``learning_len``/``forward_len``,
+``checkpoint_capacity``, ``_ep_id``, ``_step_id``, ``_ep_relative_step``,
+``episode_ends``, ``dones``, ``rewards``, ``_ckpt_slot_to_pos``,
+``_final_slot_ids``, ``_final_obs``, ``_priority_tree``.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+class RecurrentSamplingMixin:
+    def _valid_window_batch(
+        self, t0: torch.Tensor, env_inds: torch.Tensor
+    ) -> torch.Tensor:
+        """``t0`` candidates must reference already-collected, ring-buffer-
+        contiguous data for the full ``burn_in_len+learning_len+forward_len``
+        span. Episode boundaries WITHIN the window are fine (handled by
+        ``episode_starts`` masking and n-step reward zeroing) -- this only
+        guards against reading stale/uninitialized data past a wraparound."""
+        target_ep = self._ep_id[t0, env_inds]
+        base_step = self._step_id[t0, env_inds]
+        valid = (target_ep >= 0) & (base_step >= 0)
+        active = valid.clone()
+        window_len = self.burn_in_len + self.learning_len + self.forward_len
+
+        for i in range(1, window_len):
+            prev_idx = (t0 + i - 1) % self.per_env_buffer_size
+            active = active & ~self.episode_ends[prev_idx, env_inds]
+            idx = (t0 + i) % self.per_env_buffer_size
+            contiguous = (self._ep_id[idx, env_inds] == target_ep) & (
+                self._step_id[idx, env_inds] == base_step + i
+            )
+            valid = valid & (~active | contiguous)
+            active = active & contiguous
+
+        return valid
+
+    def _sample_valid_window_starts(
+        self, batch_size: int, generator: Optional[torch.Generator] = None
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Priority-proposed, rejection-sampled ``(t0, env, leaf_index,
+        is_weight)`` quadruple, all checkpoint-aligned and ring-buffer-safe."""
+        accepted_t0: list[torch.Tensor] = []
+        accepted_env: list[torch.Tensor] = []
+        accepted_leaf: list[torch.Tensor] = []
+        accepted_isw: list[torch.Tensor] = []
+        remaining = batch_size
+        attempted = 0
+        max_attempts = max(1_000, batch_size * 100) * batch_size
+
+        while remaining > 0:
+            candidate_count = max(32, remaining * 2)
+            leaf_indices, is_weights = self._priority_tree.sample(
+                candidate_count, generator=generator
+            )
+            slot = leaf_indices % self.checkpoint_capacity
+            env = leaf_indices // self.checkpoint_capacity
+            t0 = self._ckpt_slot_to_pos[slot, env]
+            has_ckpt = t0 >= 0
+            safe_t0 = t0.clamp(min=0)
+            candidate_valid = has_ckpt & self._valid_window_batch(safe_t0, env)
+
+            if candidate_valid.any():
+                sel = candidate_valid.nonzero(as_tuple=False).flatten()
+                sel = sel[: remaining]
+                accepted_t0.append(t0[sel])
+                accepted_env.append(env[sel])
+                accepted_leaf.append(leaf_indices[sel])
+                accepted_isw.append(is_weights[sel])
+                remaining -= sel.numel()
+
+            attempted += candidate_count
+            if attempted >= max_attempts and remaining > 0:
+                raise RuntimeError(
+                    "Could not sample enough valid recurrent windows. The buffer "
+                    "may not yet contain enough checkpoint-aligned, temporally "
+                    "contiguous data for burn_in_len+learning_len+forward_len."
+                )
+
+        return (
+            torch.cat(accepted_t0),
+            torch.cat(accepted_env),
+            torch.cat(accepted_leaf),
+            torch.cat(accepted_isw),
+        )
+
+    def _gather_window(
+        self, t0: torch.Tensor, env_inds: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """One-shot advanced-indexing gather grid: ``(window_len, batch)``."""
+        window_len = self.burn_in_len + self.learning_len + self.forward_len
+        offsets = torch.arange(window_len, device=self.storage_device).unsqueeze(1)
+        idx_grid = (t0.unsqueeze(0) + offsets) % self.per_env_buffer_size
+        env_grid = env_inds.unsqueeze(0).expand(window_len, -1)
+        return idx_grid, env_grid
+
+    def _patch_final_obs(self, window_obs, idx_grid: torch.Tensor, env_grid: torch.Tensor):
+        """Gymnasium autoreset means the ring buffer's naturally-following ``obs``
+        after an episode-end position is already the NEXT episode's reset
+        observation, not the true final one -- patch it in from the compact
+        final-obs side table wherever a boundary falls inside the window (needed
+        for truncation bootstrapping; harmless but also applied at true
+        terminations for consistency, matching ``LazyNextNStepDictReplayBuffer``'s
+        existing precedent)."""
+        slot_at_pos = self._final_slot_ids[idx_grid, env_grid]
+        boundary = self.episode_ends[idx_grid, env_grid] & (slot_at_pos >= 0)
+        boundary = boundary[:-1]  # last window position has no "next" to patch
+        if not boundary.any():
+            return window_obs
+
+        time_idx, batch_idx = torch.nonzero(boundary, as_tuple=True)
+        slots = slot_at_pos[time_idx, batch_idx]
+        final_values = self._final_obs[slots]
+        target_time = time_idx + 1
+
+        def _patch(tree, final_tree):
+            if isinstance(tree, dict):
+                return {key: _patch(value, final_tree[key]) for key, value in tree.items()}
+            tree = tree.clone()
+            tree[target_time, batch_idx] = final_tree
+            return tree
+
+        return _patch(window_obs, final_values)
+
+    def _accumulate_nstep_window(
+        self, t0: torch.Tensor, env_inds: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Generalizes ``_accumulate_nstep`` (``_nstep_sampling.py``) to
+        ``learning_len`` overlapping n-step windows simultaneously -- every
+        tensor op gains a leading ``learning_len`` axis. Returns
+        ``(rewards, discounts)``, each ``(learning_len, batch)``."""
+        batch = t0.shape[0]
+        learning_offsets = torch.arange(
+            self.learning_len, device=self.storage_device
+        ).unsqueeze(1)
+        learning_starts = self.burn_in_len + t0.unsqueeze(0) + learning_offsets
+        env_grid = env_inds.unsqueeze(0).expand(self.learning_len, -1)
+
+        rewards = torch.zeros(self.learning_len, batch, device=self.storage_device)
+        discounts = torch.ones(self.learning_len, batch, device=self.storage_device)
+        active = torch.ones(
+            self.learning_len, batch, dtype=torch.bool, device=self.storage_device
+        )
+
+        for i in range(self.forward_len):
+            idx = (learning_starts + i) % self.per_env_buffer_size
+            step_rewards = self.rewards[idx, env_grid]
+            rewards = rewards + torch.where(
+                active, discounts * step_rewards, torch.zeros_like(rewards)
+            )
+            discounts = torch.where(active, discounts * self.gamma, discounts)
+            terminal = active & self.dones[idx, env_grid]
+            stopped = terminal | (active & self.episode_ends[idx, env_grid])
+            discounts = torch.where(terminal, torch.zeros_like(discounts), discounts)
+            active = active & ~stopped
+
+        return rewards, discounts

--- a/rl_garden/buffers/recurrent_replay_buffer.py
+++ b/rl_garden/buffers/recurrent_replay_buffer.py
@@ -1,0 +1,395 @@
+"""Off-policy replay buffer for recurrent (RNN, later Transformer) latent modules.
+
+Ports R2D2's core mechanism (Kapturowski et al. 2019: stored hidden state +
+burn-in + n-step + priority replay) into rl-garden's ring-buffer architecture,
+reimplemented in this codebase's vectorized (torch tensor ops, no Python
+per-sample loops) idiom rather than the reference clone's Python/numpy style --
+see ``rl_garden/networks/recurrent.py``'s module docstring for the off-policy
+staleness problem this solves.
+
+Checkpoint-aligned sampling grid: the hidden state is stored once per ``stride
+== burn_in_len`` steps (measured from each episode's own start, not the buffer's
+absolute position), and every sampled window's start ``t0`` is constrained to a
+checkpoint position. This means burn-in length is always exactly ``burn_in_len``
+(seeded from the checkpoint stored AT ``t0``, which is either a genuine
+collection-time state or -- for an episode's very first checkpoint -- the
+all-zero initial state) with no per-sample variable-length bookkeeping needed;
+``episode_starts`` correctly reflects any episode boundary anywhere in the
+window, including inside burn-in itself, via the existing ``mask_state``
+mechanism in ``RecurrentLatentEncoder``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import torch
+from gymnasium import spaces
+
+from rl_garden.buffers._recurrent_sampling import RecurrentSamplingMixin
+from rl_garden.buffers.base import BaseReplayBuffer
+from rl_garden.buffers.dict_buffer import DictArray, _tree_to_device
+from rl_garden.buffers.sum_tree import SumTree
+from rl_garden.common.obs_utils import index_obs
+from rl_garden.common.types import Obs
+
+# Local, intentionally-duplicated type alias mirroring
+# rl_garden.networks.recurrent.RecurrentState -- rl_garden/buffers/ has zero
+# dependency on rl_garden/networks/ today (see recurrent_rollout_buffer.py's
+# identical precedent for this exact duplication).
+RecurrentState = Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]
+
+
+@dataclass
+class RecurrentReplayBufferSample:
+    obs: Obs                                   # (window_len, B, *obs_shape)
+    # Always None -- this buffer has no separate next_obs concept (the window
+    # itself covers "next" positions internally); present only so
+    # SACCore.train()'s unconditional features_extractor.prepare_batch(obs,
+    # next_obs) call has something to pass without a special case there.
+    next_obs: Optional[Obs]
+    actions: torch.Tensor                       # (learning_len, B, act_dim)
+    rewards: torch.Tensor                       # (learning_len, B) -- pre-accumulated n-step
+    discounts: torch.Tensor                     # (learning_len, B)
+    episode_starts: torch.Tensor                # (window_len, B)
+    initial_hidden_h: torch.Tensor              # (B, num_layers, H) -- batch-dim-first
+    initial_hidden_c: Optional[torch.Tensor]    # (B, num_layers, H), None for GRU
+    priority_indices: torch.Tensor              # (B,) LongTensor, flat leaf indices
+    is_weights: torch.Tensor                    # (B,)
+
+
+def _copy_tree(src, dst, count: int) -> None:
+    if isinstance(src, DictArray):
+        for key, value in src.data.items():
+            _copy_tree(value, dst.data[key], count)
+    else:
+        dst[:count].copy_(src[:count])
+
+
+class RecurrentReplayBuffer(RecurrentSamplingMixin, BaseReplayBuffer):
+    """One class for both Box and Dict observations (unlike the Tensor/Dict
+    n-step buffer pair) -- the sum-tree/checkpoint/burn-in machinery here is
+    already the novel bulk of this file; duplicating it across a second class
+    would double the review surface for no behavioral benefit."""
+
+    def __init__(
+        self,
+        observation_space: spaces.Box | spaces.Dict,
+        action_space: spaces.Box,
+        num_envs: int,
+        buffer_size: int,
+        *,
+        burn_in_len: int = 40,
+        learning_len: int = 40,
+        forward_len: int = 5,
+        rnn_type: str = "lstm",
+        rnn_hidden_size: int = 256,
+        rnn_num_layers: int = 1,
+        gamma: float = 0.99,
+        prio_exponent: float = 0.9,
+        importance_sampling_exponent: float = 0.6,
+        priority_eps: float = 1e-3,
+        storage_device: torch.device | str = "cuda",
+        sample_device: torch.device | str = "cuda",
+    ) -> None:
+        if burn_in_len < 1:
+            raise ValueError(f"burn_in_len must be >= 1, got {burn_in_len}")
+        if learning_len < 1:
+            raise ValueError(f"learning_len must be >= 1, got {learning_len}")
+        if forward_len < 1:
+            raise ValueError(f"forward_len must be >= 1, got {forward_len}")
+        if rnn_type not in ("lstm", "gru"):
+            raise ValueError(f"rnn_type must be 'lstm' or 'gru', got {rnn_type!r}")
+
+        self.observation_space = observation_space
+        self.action_space = action_space
+        self.num_envs = num_envs
+        self.buffer_size = buffer_size
+        self.per_env_buffer_size = buffer_size // num_envs
+
+        self.burn_in_len = burn_in_len
+        self.learning_len = learning_len
+        self.forward_len = forward_len
+        self.stride = burn_in_len
+        if self.per_env_buffer_size % self.stride != 0:
+            raise ValueError(
+                f"per_env_buffer_size ({self.per_env_buffer_size}) must be divisible "
+                f"by burn_in_len/checkpoint stride ({self.stride})."
+            )
+        self.rnn_type = rnn_type
+        self.rnn_hidden_size = rnn_hidden_size
+        self.rnn_num_layers = rnn_num_layers
+        self._has_cell_state = rnn_type == "lstm"
+        self.gamma = gamma
+
+        self.storage_device = torch.device(storage_device)
+        self.sample_device = torch.device(sample_device)
+        self.pos = 0
+        self.full = False
+
+        shape = (self.per_env_buffer_size, num_envs)
+        self._is_dict_obs = isinstance(observation_space, spaces.Dict)
+        if self._is_dict_obs:
+            self.obs = DictArray(shape, observation_space, device=self.storage_device)
+        elif isinstance(observation_space, spaces.Box):
+            self.obs = torch.zeros(
+                shape + tuple(observation_space.shape), device=self.storage_device
+            )
+        else:
+            raise TypeError(
+                "RecurrentReplayBuffer supports Box or Dict observations, got "
+                f"{type(observation_space)}."
+            )
+        self.actions = torch.zeros(
+            shape + tuple(action_space.shape), device=self.storage_device
+        )
+        self.rewards = torch.zeros(shape, device=self.storage_device)
+        self.dones = torch.zeros(shape, dtype=torch.bool, device=self.storage_device)
+        self.episode_ends = torch.zeros(shape, dtype=torch.bool, device=self.storage_device)
+
+        # Episode-contiguity bookkeeping -- same fields/semantics as
+        # NStepDictReplayBuffer (nstep_buffer.py), reused not reinvented.
+        self._ep_id = torch.full(shape, -1, dtype=torch.long, device=self.storage_device)
+        self._current_ep_id = torch.zeros(
+            num_envs, dtype=torch.long, device=self.storage_device
+        )
+        self._step_id = torch.full(shape, -1, dtype=torch.long, device=self.storage_device)
+        self._current_step_id = torch.zeros(
+            num_envs, dtype=torch.long, device=self.storage_device
+        )
+        # New: steps since episode start (resets to 0 the step after an episode
+        # ends), used for checkpoint eligibility and episode_starts computation.
+        self._ep_relative_step = torch.full(
+            shape, -1, dtype=torch.long, device=self.storage_device
+        )
+        self._current_ep_relative_step = torch.zeros(
+            num_envs, dtype=torch.long, device=self.storage_device
+        )
+
+        # Compact checkpoint side-buffer (stride-x smaller than per-timestep
+        # storage) -- this is what actually saves memory, not skip-writing into
+        # an equally-sized tensor.
+        self.checkpoint_capacity = self.per_env_buffer_size // self.stride
+        self._current_ckpt_pos = torch.zeros(
+            num_envs, dtype=torch.long, device=self.storage_device
+        )
+        self._ckpt_slot_to_pos = torch.full(
+            (self.checkpoint_capacity, num_envs),
+            -1,
+            dtype=torch.long,
+            device=self.storage_device,
+        )
+        self.hidden_checkpoints_h = torch.zeros(
+            self.checkpoint_capacity,
+            num_envs,
+            rnn_num_layers,
+            rnn_hidden_size,
+            device=self.storage_device,
+        )
+        self.hidden_checkpoints_c = (
+            torch.zeros(
+                self.checkpoint_capacity,
+                num_envs,
+                rnn_num_layers,
+                rnn_hidden_size,
+                device=self.storage_device,
+            )
+            if self._has_cell_state
+            else None
+        )
+        self.hidden_checkpoint_ep_id = torch.full(
+            (self.checkpoint_capacity, num_envs),
+            -1,
+            dtype=torch.long,
+            device=self.storage_device,
+        )
+
+        # Compact final/terminal-observation side table -- gymnasium autoreset
+        # means the ring buffer's naturally-following obs after an episode-end
+        # position is already the NEXT episode's reset obs, not the true final
+        # one. Mirrors LazyNextNStepDictReplayBuffer's exact mechanism
+        # (nstep_buffer.py), generalized to Box observations too.
+        self._final_slot_ids = torch.full(
+            shape, -1, dtype=torch.long, device=self.storage_device
+        )
+        self._free_final_slots: list[int] = []
+        self._next_final_slot = 0
+        final_obs_capacity = max(1024, self.buffer_size // 64)
+        if self._is_dict_obs:
+            self._final_obs = DictArray(
+                (final_obs_capacity,), observation_space, device=self.storage_device
+            )
+        else:
+            self._final_obs = torch.zeros(
+                (final_obs_capacity,) + tuple(observation_space.shape),
+                device=self.storage_device,
+            )
+
+        capacity_total = self.checkpoint_capacity * num_envs
+        self._priority_tree = SumTree(
+            capacity=capacity_total,
+            alpha=prio_exponent,
+            beta=importance_sampling_exponent,
+            device=self.storage_device,
+            eps=priority_eps,
+        )
+
+    # ------------------------------------------------------------------
+    # Final-obs side table
+    # ------------------------------------------------------------------
+
+    def _grow_final_obs(self) -> None:
+        current = self._final_obs.shape[0]
+        new_capacity = current * 2
+        if self._is_dict_obs:
+            grown = DictArray(
+                (new_capacity,), self.observation_space, device=self.storage_device
+            )
+            _copy_tree(self._final_obs, grown, current)
+        else:
+            grown = torch.zeros(
+                (new_capacity,) + tuple(self.observation_space.shape),
+                device=self.storage_device,
+            )
+            grown[:current] = self._final_obs
+        self._final_obs = grown
+
+    def _allocate_final_slot(self) -> int:
+        if self._free_final_slots:
+            return self._free_final_slots.pop()
+        if self._next_final_slot >= self._final_obs.shape[0]:
+            self._grow_final_obs()
+        slot = self._next_final_slot
+        self._next_final_slot += 1
+        return slot
+
+    def _write_final_obs_slot(self, storage, slot: int, value, env: int) -> None:
+        if isinstance(storage, DictArray):
+            for key in storage.data:
+                self._write_final_obs_slot(storage.data[key], slot, value[key], env)
+        else:
+            storage[slot] = value[env].to(self.storage_device)
+
+    # ------------------------------------------------------------------
+    # Storage
+    # ------------------------------------------------------------------
+
+    def add(
+        self,
+        obs: Obs,
+        next_obs: Obs,
+        action: torch.Tensor,
+        reward: torch.Tensor,
+        done: torch.Tensor,
+        episode_end: torch.Tensor,
+        hidden: RecurrentState,
+    ) -> None:
+        done_bool = done.to(self.storage_device).bool()
+        episode_end_bool = episode_end.to(self.storage_device).bool()
+
+        if self._is_dict_obs:
+            assert isinstance(obs, dict)
+            self.obs[self.pos] = {k: v.to(self.storage_device) for k, v in obs.items()}
+        else:
+            assert isinstance(obs, torch.Tensor)
+            self.obs[self.pos] = obs.to(self.storage_device)
+        self.actions[self.pos] = action.to(self.storage_device)
+        self.rewards[self.pos] = reward.reshape(self.num_envs).to(self.storage_device)
+        self.dones[self.pos] = done_bool.reshape(self.num_envs)
+        self.episode_ends[self.pos] = episode_end_bool.reshape(self.num_envs)
+
+        # Free any final-obs slot the position we're about to overwrite owned.
+        old_slots = self._final_slot_ids[self.pos]
+        for slot in old_slots[old_slots >= 0].tolist():
+            self._free_final_slots.append(int(slot))
+        old_slots.fill_(-1)
+        for env in episode_end_bool.reshape(self.num_envs).nonzero(as_tuple=False).flatten().tolist():
+            slot = self._allocate_final_slot()
+            self._final_slot_ids[self.pos, env] = slot
+            self._write_final_obs_slot(self._final_obs, slot, next_obs, env)
+
+        self._ep_id[self.pos] = self._current_ep_id
+        self._step_id[self.pos] = self._current_step_id
+        self._ep_relative_step[self.pos] = self._current_ep_relative_step
+
+        is_checkpoint = self._current_ep_relative_step % self.stride == 0
+        if is_checkpoint.any():
+            envs = is_checkpoint.nonzero(as_tuple=False).flatten()
+            slots = self._current_ckpt_pos[envs] % self.checkpoint_capacity
+            if self._has_cell_state:
+                h, c = hidden
+            else:
+                h, c = hidden, None
+            self.hidden_checkpoints_h[slots, envs] = (
+                h[:, envs].transpose(0, 1).to(self.storage_device)
+            )
+            if self._has_cell_state:
+                self.hidden_checkpoints_c[slots, envs] = (
+                    c[:, envs].transpose(0, 1).to(self.storage_device)
+                )
+            self.hidden_checkpoint_ep_id[slots, envs] = self._current_ep_id[envs]
+            self._ckpt_slot_to_pos[slots, envs] = self.pos
+            leaf_indices = envs * self.checkpoint_capacity + slots
+            self._priority_tree.set_uninitialized(leaf_indices)
+            self._current_ckpt_pos[envs] += 1
+
+        self._current_ep_id = self._current_ep_id + episode_end_bool.reshape(self.num_envs).long()
+        self._current_step_id = self._current_step_id + 1
+        self._current_ep_relative_step = torch.where(
+            episode_end_bool.reshape(self.num_envs),
+            torch.zeros_like(self._current_ep_relative_step),
+            self._current_ep_relative_step + 1,
+        )
+
+        self._advance()
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+
+    def sample(
+        self, batch_size: int, generator: Optional[torch.Generator] = None
+    ) -> RecurrentReplayBufferSample:
+        t0, env_inds, leaf_indices, is_weights = self._sample_valid_window_starts(
+            batch_size, generator=generator
+        )
+        idx_grid, env_grid = self._gather_window(t0, env_inds)
+
+        window_obs = index_obs(self.obs, (idx_grid, env_grid))
+        window_obs = self._patch_final_obs(window_obs, idx_grid, env_grid)
+
+        learn_slice = slice(self.burn_in_len, self.burn_in_len + self.learning_len)
+        actions = self.actions[idx_grid[learn_slice], env_grid[learn_slice]]
+
+        ep_rel = self._ep_relative_step[idx_grid, env_grid]
+        episode_starts = (ep_rel == 0).float()
+
+        rewards, discounts = self._accumulate_nstep_window(t0, env_inds)
+
+        slots = leaf_indices % self.checkpoint_capacity
+        initial_hidden_h = self.hidden_checkpoints_h[slots, env_inds]
+        initial_hidden_c = (
+            self.hidden_checkpoints_c[slots, env_inds] if self._has_cell_state else None
+        )
+
+        return RecurrentReplayBufferSample(
+            obs=_tree_to_device(window_obs, self.sample_device),
+            next_obs=None,
+            actions=actions.to(self.sample_device),
+            rewards=rewards.to(self.sample_device),
+            discounts=discounts.to(self.sample_device),
+            episode_starts=episode_starts.to(self.sample_device),
+            initial_hidden_h=initial_hidden_h.to(self.sample_device),
+            initial_hidden_c=(
+                initial_hidden_c.to(self.sample_device)
+                if initial_hidden_c is not None
+                else None
+            ),
+            priority_indices=leaf_indices.to(self.sample_device),
+            is_weights=is_weights.to(self.sample_device),
+        )
+
+    def update_priorities(self, indices: torch.Tensor, td_errors: torch.Tensor) -> None:
+        self._priority_tree.update(
+            indices.to(self.storage_device), td_errors.to(self.storage_device)
+        )

--- a/rl_garden/buffers/recurrent_rollout_buffer.py
+++ b/rl_garden/buffers/recurrent_rollout_buffer.py
@@ -1,0 +1,96 @@
+"""Rollout buffer variant that yields sequence-preserving minibatches for BPTT."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Optional, Union
+
+import torch
+
+from rl_garden.buffers.rollout_buffer import RolloutBuffer
+from rl_garden.common.obs_utils import index_obs
+from rl_garden.common.types import Obs
+
+# Local, intentionally-duplicated type alias mirroring
+# rl_garden.networks.recurrent.RecurrentState: rl_garden/buffers/ has zero
+# dependency on rl_garden/networks/ today, and this file preserves that
+# layering rather than importing the networks-layer type for one alias.
+RecurrentState = Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]
+
+
+def _index_recurrent_state(state: RecurrentState, indices: torch.Tensor) -> RecurrentState:
+    if isinstance(state, tuple):
+        return tuple(h[:, indices] for h in state)
+    return state[:, indices]
+
+
+@dataclass
+class RecurrentRolloutBufferSample:
+    obs: Obs                       # (T, mb_envs, *obs_shape)
+    actions: torch.Tensor          # (T, mb_envs, act_dim)
+    old_values: torch.Tensor       # (T, mb_envs)
+    old_log_prob: torch.Tensor     # (T, mb_envs)
+    advantages: torch.Tensor       # (T, mb_envs)
+    returns: torch.Tensor          # (T, mb_envs)
+    episode_starts: torch.Tensor   # (T, mb_envs) -- 1.0 = reset hidden state before this timestep
+    initial_hidden: RecurrentState # sliced to mb_envs
+
+
+class RecurrentRolloutBuffer(RolloutBuffer):
+    def get_sequences(
+        self,
+        num_minibatches: int,
+        initial_hidden: RecurrentState,
+        *,
+        shuffle: bool = True,
+        generator: Optional[torch.Generator] = None,
+    ) -> Iterator[RecurrentRolloutBufferSample]:
+        """Env-axis-only minibatching: every minibatch yields the FULL
+        ``(T, mb_envs, ...)`` window, never subsetting the time axis. This is what
+        lets ``initial_hidden`` (the true hidden state at the start of collection)
+        be reused directly for BPTT with zero per-timestep hidden-state storage --
+        see ``rl_garden.networks.recurrent.RecurrentLatentEncoder``'s module
+        docstring for why this is on-policy-only.
+
+        Requires ``self.num_envs % num_minibatches == 0``.
+        """
+        if not self.full:
+            raise RuntimeError("RolloutBuffer must be full before sampling.")
+        if self.num_envs % num_minibatches != 0:
+            raise ValueError(
+                f"num_envs ({self.num_envs}) must be divisible by num_minibatches "
+                f"({num_minibatches}) for env-axis minibatching."
+            )
+
+        # episode_starts[t+1] = dones[t] (dones[t] means "episode ended as a
+        # result of stepping from obs[t]"). Row 0 is always 0 here -- the true
+        # boundary reset from the END of the previous rollout window is folded
+        # into `initial_hidden` by the caller (see PPO's rollout loop), since
+        # this buffer has no visibility into a done from a prior window.
+        episode_starts = torch.cat(
+            [torch.zeros(1, self.num_envs, device=self.device), self.dones[:-1]], dim=0
+        )
+
+        mb_envs = self.num_envs // num_minibatches
+        env_indices = (
+            torch.randperm(self.num_envs, device=self.device, generator=generator)
+            if shuffle
+            else torch.arange(self.num_envs, device=self.device)
+        )
+
+        for start in range(0, self.num_envs, mb_envs):
+            idx = env_indices[start : start + mb_envs]
+            yield RecurrentRolloutBufferSample(
+                obs=index_obs(self.obs, (slice(None), idx)),
+                actions=self.actions[:, idx],
+                old_values=self.values[:, idx],
+                old_log_prob=self.log_probs[:, idx],
+                advantages=self.advantages[:, idx],
+                returns=self.returns[:, idx],
+                episode_starts=episode_starts[:, idx],
+                initial_hidden=_index_recurrent_state(initial_hidden, idx),
+            )
+
+
+class RecurrentDictRolloutBuffer(RecurrentRolloutBuffer):
+    """Alias class for SB3-style naming when observations are Dict spaces."""

--- a/rl_garden/buffers/rollout_buffer.py
+++ b/rl_garden/buffers/rollout_buffer.py
@@ -9,6 +9,7 @@ import torch
 from gymnasium import spaces
 
 from rl_garden.buffers.dict_buffer import DictArray
+from rl_garden.common.obs_utils import flatten_leading_dims, index_obs
 from rl_garden.common.types import Obs
 
 
@@ -20,20 +21,6 @@ class RolloutBufferSample:
     old_log_prob: torch.Tensor
     advantages: torch.Tensor
     returns: torch.Tensor
-
-
-def _flatten_obs(obs):
-    if isinstance(obs, DictArray):
-        return {key: _flatten_obs(value) for key, value in obs.data.items()}
-    if isinstance(obs, dict):
-        return {key: _flatten_obs(value) for key, value in obs.items()}
-    return obs.reshape((-1,) + obs.shape[2:])
-
-
-def _index_obs(obs, indices: torch.Tensor):
-    if isinstance(obs, dict):
-        return {key: _index_obs(value, indices) for key, value in obs.items()}
-    return obs[indices]
 
 
 class RolloutBuffer:
@@ -205,7 +192,7 @@ class RolloutBuffer:
             raise RuntimeError("RolloutBuffer must be full before sampling.")
         if batch_size is None:
             batch_size = self.buffer_size
-        flat_obs = _flatten_obs(self.obs)
+        flat_obs = flatten_leading_dims(self.obs)
         flat_actions = self.actions.reshape((-1,) + self.actions.shape[2:])
         flat_values = self.values.reshape(-1)
         flat_log_probs = self.log_probs.reshape(-1)
@@ -216,7 +203,7 @@ class RolloutBuffer:
         for start in range(0, self.buffer_size, batch_size):
             mb_inds = indices[start : start + batch_size]
             yield RolloutBufferSample(
-                obs=_index_obs(flat_obs, mb_inds),
+                obs=index_obs(flat_obs, mb_inds),
                 actions=flat_actions[mb_inds],
                 old_values=flat_values[mb_inds],
                 old_log_prob=flat_log_probs[mb_inds],

--- a/rl_garden/buffers/sum_tree.py
+++ b/rl_garden/buffers/sum_tree.py
@@ -1,0 +1,129 @@
+"""Vectorized proportional priority sum-tree (Schaul et al. 2016), torch-native.
+
+Ported from the R2D2 reference clone's numpy ``PriorityTree``
+(``3rd_party/R2D2/priority_tree.py``), generalized to run entirely as torch tensor
+ops on the buffer's storage device -- no numpy handoffs in the replay hot path.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+class SumTree:
+    """Flat, complete-binary-tree-backed sum-tree over ``capacity`` leaves.
+
+    ``update``/``sample`` operate in one shot over the whole batch -- no Python
+    loop over individual leaves. A small ``eps`` is added before exponentiating in
+    ``update`` so a legitimately-zero TD-error sample never acquires priority 0
+    and gets permanently excluded from sampling (not present in the R2D2
+    reference, added here as a safety fix, not a fidelity deviation).
+    """
+
+    def __init__(
+        self,
+        capacity: int,
+        alpha: float,
+        beta: float,
+        device: torch.device,
+        eps: float = 1e-3,
+    ) -> None:
+        if capacity < 1:
+            raise ValueError(f"capacity must be >= 1, got {capacity}")
+        self.capacity = capacity
+        self.alpha = alpha
+        self.beta = beta
+        self.eps = eps
+        self.device = torch.device(device)
+
+        num_layers = 1
+        while capacity > 2 ** (num_layers - 1):
+            num_layers += 1
+        self.num_layers = num_layers
+        self._leaf_offset = 2 ** (num_layers - 1) - 1
+        self.tree = torch.zeros(
+            2**num_layers - 1, dtype=torch.float64, device=self.device
+        )
+
+    def _propagate(self, idxes: torch.Tensor) -> None:
+        """``idxes``: absolute tree indices of leaves just written. Walks to the
+        root, recomputing each parent as the sum of its two children. Duplicate
+        indices at a given level always compute the same value from already-fixed
+        children, so repeated writes under ``tensor[idxes] = values`` are safe
+        without a ``np.unique``-style dedup pass (unlike the numpy reference)."""
+        for _ in range(self.num_layers - 1):
+            idxes = (idxes - 1) // 2
+            self.tree[idxes] = self.tree[2 * idxes + 1] + self.tree[2 * idxes + 2]
+
+    def update(self, indices: torch.Tensor, td_errors: torch.Tensor) -> None:
+        """``indices``: leaf-relative (``0..capacity-1``) LongTensor. ``td_errors``:
+        same shape, raw (signed) TD errors -- priority is computed here as
+        ``(|td_error| + eps) ** alpha``."""
+        priorities = (
+            td_errors.detach().abs().to(torch.float64) + self.eps
+        ) ** self.alpha
+        idxes = indices.to(device=self.device, dtype=torch.long) + self._leaf_offset
+        self.tree[idxes] = priorities
+        self._propagate(idxes)
+
+    def set_uninitialized(
+        self, indices: torch.Tensor, priority: Optional[float] = None
+    ) -> None:
+        """Seed freshly-created leaves at ``indices`` with the current max leaf
+        priority (or 1.0 if the tree is entirely empty), so new experience is
+        guaranteed a chance to be sampled before its first TD-error is known.
+        Pass an explicit ``priority`` to override this default."""
+        if priority is None:
+            max_p = self.tree[self._leaf_offset : self._leaf_offset + self.capacity].max()
+            fill = float(max_p.item()) if max_p > 0 else 1.0
+        else:
+            fill = float(priority)
+        idxes = indices.to(device=self.device, dtype=torch.long) + self._leaf_offset
+        self.tree[idxes] = fill
+        self._propagate(idxes)
+
+    def sample(
+        self, num_samples: int, generator: Optional[torch.Generator] = None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns ``(leaf_indices, is_weights)``, both length ``num_samples``."""
+        p_sum = self.tree[0]
+        if p_sum <= 0:
+            raise RuntimeError(
+                "SumTree.sample called with zero total priority -- no transitions "
+                "have been added/updated yet."
+            )
+        interval = p_sum / num_samples
+        offsets = (
+            torch.arange(num_samples, dtype=torch.float64, device=self.device)
+            * interval
+        )
+        jitter = (
+            torch.rand(
+                num_samples, generator=generator, device=self.device, dtype=torch.float64
+            )
+            * interval
+        )
+        prefix_sums = offsets + jitter
+
+        idxes = torch.zeros(num_samples, dtype=torch.long, device=self.device)
+        for _ in range(self.num_layers - 1):
+            left_child = idxes * 2 + 1
+            left_value = self.tree[left_child]
+            go_left = prefix_sums < left_value
+            idxes = torch.where(go_left, left_child, idxes * 2 + 2)
+            went_right = idxes % 2 == 0
+            prefix_sums = torch.where(
+                went_right, prefix_sums - self.tree[idxes - 1], prefix_sums
+            )
+
+        priorities = self.tree[idxes]
+        min_p = priorities.min().clamp_min(self.eps)
+        is_weights = (priorities / min_p).pow(-self.beta).to(torch.float32)
+
+        leaf_indices = idxes - self._leaf_offset
+        return leaf_indices, is_weights
+
+    @property
+    def total(self) -> torch.Tensor:
+        return self.tree[0]

--- a/rl_garden/buffers/transformer_replay_buffer.py
+++ b/rl_garden/buffers/transformer_replay_buffer.py
@@ -1,27 +1,27 @@
-"""Off-policy replay buffer for recurrent (RNN, later Transformer) latent modules.
+"""Off-policy replay buffer for GTrXL (Transformer) latent modules.
 
-Ports R2D2's core mechanism (Kapturowski et al. 2019: stored hidden state +
-burn-in + n-step + priority replay) into rl-garden's ring-buffer architecture,
-reimplemented in this codebase's vectorized (torch tensor ops, no Python
-per-sample loops) idiom rather than the reference clone's Python/numpy style --
-see ``rl_garden/networks/recurrent.py``'s module docstring for the off-policy
-staleness problem this solves.
-
-Checkpoint-aligned sampling grid: the hidden state is stored once per ``stride
-== burn_in_len`` steps (measured from each episode's own start, not the buffer's
-absolute position), and every sampled window's start ``t0`` is constrained to a
-checkpoint position. This means burn-in length is always exactly ``burn_in_len``
-(seeded from the checkpoint stored AT ``t0``, which is either a genuine
-collection-time state or -- for an episode's very first checkpoint -- the
-all-zero initial state) with no per-sample variable-length bookkeeping needed;
-``episode_starts`` correctly reflects any episode boundary anywhere in the
-window, including inside burn-in itself, via the existing ``mask_state``
-mechanism in ``RecurrentLatentEncoder``.
+Sibling of ``RecurrentReplayBuffer`` for a fundamentally simpler case: GTrXL's
+memory is a bounded sliding window of raw activations, not a compressed
+RNN-style state, so ``TransformerSAC`` never needs a stored per-transition
+hidden-state checkpoint -- burn-in always starts from a fresh zero state (see
+``rl_garden.networks.gtrxl.GTrXLLatentEncoder.forward_sequence_with_burn_in``
+and ``TransformerSAC._initial_state_from_sample``). That removes the entire
+reason ``RecurrentReplayBuffer`` constrains sampled window starts to a sparse
+``stride == burn_in_len`` checkpoint grid (that grid exists only to make
+storing a hidden-state snapshot at every position affordable). Here ``stride``
+is simply ``1``: every buffer position is a valid, independently-sampleable
+window start once it has ``burn_in_len + learning_len + forward_len`` steps of
+contiguous history ahead of it. This buffer therefore reuses
+``RecurrentSamplingMixin`` (sampling/contiguity/n-step accumulation) and
+``SumTree`` (priority tree) completely unmodified -- both are already generic
+over what "checkpoint" means -- and ``FinalObsTableMixin`` for the compact
+final-obs side table, but carries none of ``RecurrentReplayBuffer``'s
+hidden-state storage or shape parameters.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 from gymnasium import spaces
@@ -34,37 +34,21 @@ from rl_garden.buffers.sum_tree import SumTree
 from rl_garden.common.obs_utils import index_obs
 from rl_garden.common.types import Obs
 
-# Local, intentionally-duplicated type alias mirroring
-# rl_garden.networks.recurrent.RecurrentState -- rl_garden/buffers/ has zero
-# dependency on rl_garden/networks/ today (see recurrent_rollout_buffer.py's
-# identical precedent for this exact duplication).
-RecurrentState = Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]
-
 
 @dataclass
-class RecurrentReplayBufferSample:
+class TransformerReplayBufferSample:
     obs: Obs                                   # (window_len, B, *obs_shape)
-    # Always None -- this buffer has no separate next_obs concept (the window
-    # itself covers "next" positions internally); present only so
-    # SACCore.train()'s unconditional features_extractor.prepare_batch(obs,
-    # next_obs) call has something to pass without a special case there.
+    # Always None -- see RecurrentReplayBufferSample's identical field for why.
     next_obs: Optional[Obs]
     actions: torch.Tensor                       # (learning_len, B, act_dim)
     rewards: torch.Tensor                       # (learning_len, B) -- pre-accumulated n-step
     discounts: torch.Tensor                     # (learning_len, B)
     episode_starts: torch.Tensor                # (window_len, B)
-    initial_hidden_h: torch.Tensor              # (B, num_layers, H) -- batch-dim-first
-    initial_hidden_c: Optional[torch.Tensor]    # (B, num_layers, H), None for GRU
     priority_indices: torch.Tensor              # (B,) LongTensor, flat leaf indices
     is_weights: torch.Tensor                    # (B,)
 
 
-class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseReplayBuffer):
-    """One class for both Box and Dict observations (unlike the Tensor/Dict
-    n-step buffer pair) -- the sum-tree/checkpoint/burn-in machinery here is
-    already the novel bulk of this file; duplicating it across a second class
-    would double the review surface for no behavioral benefit."""
-
+class TransformerReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseReplayBuffer):
     def __init__(
         self,
         observation_space: spaces.Box | spaces.Dict,
@@ -75,9 +59,6 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
         burn_in_len: int = 40,
         learning_len: int = 40,
         forward_len: int = 5,
-        rnn_type: str = "lstm",
-        rnn_hidden_size: int = 256,
-        rnn_num_layers: int = 1,
         gamma: float = 0.99,
         prio_exponent: float = 0.9,
         importance_sampling_exponent: float = 0.6,
@@ -91,8 +72,6 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
             raise ValueError(f"learning_len must be >= 1, got {learning_len}")
         if forward_len < 1:
             raise ValueError(f"forward_len must be >= 1, got {forward_len}")
-        if rnn_type not in ("lstm", "gru"):
-            raise ValueError(f"rnn_type must be 'lstm' or 'gru', got {rnn_type!r}")
 
         self.observation_space = observation_space
         self.action_space = action_space
@@ -103,16 +82,10 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
         self.burn_in_len = burn_in_len
         self.learning_len = learning_len
         self.forward_len = forward_len
-        self.stride = burn_in_len
-        if self.per_env_buffer_size % self.stride != 0:
-            raise ValueError(
-                f"per_env_buffer_size ({self.per_env_buffer_size}) must be divisible "
-                f"by burn_in_len/checkpoint stride ({self.stride})."
-            )
-        self.rnn_type = rnn_type
-        self.rnn_hidden_size = rnn_hidden_size
-        self.rnn_num_layers = rnn_num_layers
-        self._has_cell_state = rnn_type == "lstm"
+        # Every position is a valid window start (no stored hidden state to
+        # align to) -- unlike RecurrentReplayBuffer, stride is not
+        # burn_in_len-periodic. See module docstring.
+        self.stride = 1
         self.gamma = gamma
 
         self.storage_device = torch.device(storage_device)
@@ -130,7 +103,7 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
             )
         else:
             raise TypeError(
-                "RecurrentReplayBuffer supports Box or Dict observations, got "
+                "TransformerReplayBuffer supports Box or Dict observations, got "
                 f"{type(observation_space)}."
             )
         self.actions = torch.zeros(
@@ -141,7 +114,7 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
         self.episode_ends = torch.zeros(shape, dtype=torch.bool, device=self.storage_device)
 
         # Episode-contiguity bookkeeping -- same fields/semantics as
-        # NStepDictReplayBuffer (nstep_buffer.py), reused not reinvented.
+        # RecurrentReplayBuffer/NStepDictReplayBuffer, reused not reinvented.
         self._ep_id = torch.full(shape, -1, dtype=torch.long, device=self.storage_device)
         self._current_ep_id = torch.zeros(
             num_envs, dtype=torch.long, device=self.storage_device
@@ -150,8 +123,6 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
         self._current_step_id = torch.zeros(
             num_envs, dtype=torch.long, device=self.storage_device
         )
-        # New: steps since episode start (resets to 0 the step after an episode
-        # ends), used for checkpoint eligibility and episode_starts computation.
         self._ep_relative_step = torch.full(
             shape, -1, dtype=torch.long, device=self.storage_device
         )
@@ -159,38 +130,14 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
             num_envs, dtype=torch.long, device=self.storage_device
         )
 
-        # Compact checkpoint side-buffer (stride-x smaller than per-timestep
-        # storage) -- this is what actually saves memory, not skip-writing into
-        # an equally-sized tensor.
-        self.checkpoint_capacity = self.per_env_buffer_size // self.stride
+        # RecurrentSamplingMixin needs a slot->position table and a capacity,
+        # but with stride=1 there is no compression: every position is its own
+        # slot (checkpoint_capacity == per_env_buffer_size).
+        self.checkpoint_capacity = self.per_env_buffer_size
         self._current_ckpt_pos = torch.zeros(
             num_envs, dtype=torch.long, device=self.storage_device
         )
         self._ckpt_slot_to_pos = torch.full(
-            (self.checkpoint_capacity, num_envs),
-            -1,
-            dtype=torch.long,
-            device=self.storage_device,
-        )
-        self.hidden_checkpoints_h = torch.zeros(
-            self.checkpoint_capacity,
-            num_envs,
-            rnn_num_layers,
-            rnn_hidden_size,
-            device=self.storage_device,
-        )
-        self.hidden_checkpoints_c = (
-            torch.zeros(
-                self.checkpoint_capacity,
-                num_envs,
-                rnn_num_layers,
-                rnn_hidden_size,
-                device=self.storage_device,
-            )
-            if self._has_cell_state
-            else None
-        )
-        self.hidden_checkpoint_ep_id = torch.full(
             (self.checkpoint_capacity, num_envs),
             -1,
             dtype=torch.long,
@@ -220,7 +167,6 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
         reward: torch.Tensor,
         done: torch.Tensor,
         episode_end: torch.Tensor,
-        hidden: RecurrentState,
     ) -> None:
         done_bool = done.to(self.storage_device).bool()
         episode_end_bool = episode_end.to(self.storage_device).bool()
@@ -250,26 +196,14 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
         self._step_id[self.pos] = self._current_step_id
         self._ep_relative_step[self.pos] = self._current_ep_relative_step
 
-        is_checkpoint = self._current_ep_relative_step % self.stride == 0
-        if is_checkpoint.any():
-            envs = is_checkpoint.nonzero(as_tuple=False).flatten()
-            slots = self._current_ckpt_pos[envs] % self.checkpoint_capacity
-            if self._has_cell_state:
-                h, c = hidden
-            else:
-                h, c = hidden, None
-            self.hidden_checkpoints_h[slots, envs] = (
-                h[:, envs].transpose(0, 1).to(self.storage_device)
-            )
-            if self._has_cell_state:
-                self.hidden_checkpoints_c[slots, envs] = (
-                    c[:, envs].transpose(0, 1).to(self.storage_device)
-                )
-            self.hidden_checkpoint_ep_id[slots, envs] = self._current_ep_id[envs]
-            self._ckpt_slot_to_pos[slots, envs] = self.pos
-            leaf_indices = envs * self.checkpoint_capacity + slots
-            self._priority_tree.set_uninitialized(leaf_indices)
-            self._current_ckpt_pos[envs] += 1
+        # stride == 1: every env's every step is a "checkpoint" (a candidate
+        # window start).
+        envs = torch.arange(self.num_envs, device=self.storage_device)
+        slots = self._current_ckpt_pos[envs] % self.checkpoint_capacity
+        self._ckpt_slot_to_pos[slots, envs] = self.pos
+        leaf_indices = envs * self.checkpoint_capacity + slots
+        self._priority_tree.set_uninitialized(leaf_indices)
+        self._current_ckpt_pos[envs] += 1
 
         self._current_ep_id = self._current_ep_id + episode_end_bool.reshape(self.num_envs).long()
         self._current_step_id = self._current_step_id + 1
@@ -287,7 +221,7 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
 
     def sample(
         self, batch_size: int, generator: Optional[torch.Generator] = None
-    ) -> RecurrentReplayBufferSample:
+    ) -> TransformerReplayBufferSample:
         t0, env_inds, leaf_indices, is_weights = self._sample_valid_window_starts(
             batch_size, generator=generator
         )
@@ -304,25 +238,13 @@ class RecurrentReplayBuffer(RecurrentSamplingMixin, FinalObsTableMixin, BaseRepl
 
         rewards, discounts = self._accumulate_nstep_window(t0, env_inds)
 
-        slots = leaf_indices % self.checkpoint_capacity
-        initial_hidden_h = self.hidden_checkpoints_h[slots, env_inds]
-        initial_hidden_c = (
-            self.hidden_checkpoints_c[slots, env_inds] if self._has_cell_state else None
-        )
-
-        return RecurrentReplayBufferSample(
+        return TransformerReplayBufferSample(
             obs=_tree_to_device(window_obs, self.sample_device),
             next_obs=None,
             actions=actions.to(self.sample_device),
             rewards=rewards.to(self.sample_device),
             discounts=discounts.to(self.sample_device),
             episode_starts=episode_starts.to(self.sample_device),
-            initial_hidden_h=initial_hidden_h.to(self.sample_device),
-            initial_hidden_c=(
-                initial_hidden_c.to(self.sample_device)
-                if initial_hidden_c is not None
-                else None
-            ),
             priority_indices=leaf_indices.to(self.sample_device),
             is_weights=is_weights.to(self.sample_device),
         )

--- a/rl_garden/common/obs_utils.py
+++ b/rl_garden/common/obs_utils.py
@@ -1,0 +1,27 @@
+"""Shared helpers for flattening/indexing ``Obs`` values with leading (T, N) axes."""
+from __future__ import annotations
+
+import torch
+
+from rl_garden.common.types import Obs
+
+
+def flatten_leading_dims(obs: Obs) -> Obs:
+    """Collapse the leading ``(T, N, ...)`` axes of ``obs`` into a single batch axis."""
+    # Deferred import: rl_garden.buffers.dict_buffer's package (rl_garden.buffers)
+    # imports rollout_buffer, which imports this module -- importing DictArray at
+    # module level here would be circular.
+    from rl_garden.buffers.dict_buffer import DictArray
+
+    if isinstance(obs, DictArray):
+        return {key: flatten_leading_dims(value) for key, value in obs.data.items()}
+    if isinstance(obs, dict):
+        return {key: flatten_leading_dims(value) for key, value in obs.items()}
+    return obs.reshape((-1,) + obs.shape[2:])
+
+
+def index_obs(obs: Obs, indices: torch.Tensor) -> Obs:
+    """Index a (possibly nested-dict) ``obs`` value along its leading batch axis."""
+    if isinstance(obs, dict):
+        return {key: index_obs(value, indices) for key, value in obs.items()}
+    return obs[indices]

--- a/rl_garden/networks/__init__.py
+++ b/rl_garden/networks/__init__.py
@@ -21,6 +21,7 @@ from rl_garden.networks.flash_sac_layers import (
     UnitRMSNorm,
 )
 from rl_garden.networks.mlp import KernelInit, MLPResNet, create_mlp
+from rl_garden.networks.recurrent import RecurrentLatentEncoder, RecurrentState, RNNType
 from rl_garden.networks.spatial_critic import SpatialEmbQEnsemble, SpatialEmbQHead
 from rl_garden.networks.value import ValueNetwork
 
@@ -40,6 +41,9 @@ __all__ = [
     "KernelInit",
     "MLPResNet",
     "NormalTanhPolicy",
+    "RecurrentLatentEncoder",
+    "RecurrentState",
+    "RNNType",
     "SpatialEmbQEnsemble",
     "SpatialEmbQHead",
     "SquashedGaussianActor",

--- a/rl_garden/networks/__init__.py
+++ b/rl_garden/networks/__init__.py
@@ -20,8 +20,10 @@ from rl_garden.networks.flash_sac_layers import (
     UnitLinear,
     UnitRMSNorm,
 )
+from rl_garden.networks.gtrxl import GTrXLLatentEncoder, GTrXLState
 from rl_garden.networks.mlp import KernelInit, MLPResNet, create_mlp
 from rl_garden.networks.recurrent import RecurrentLatentEncoder, RecurrentState, RNNType
+from rl_garden.networks.sequence_encoder import SequenceLatentEncoder, SequenceState
 from rl_garden.networks.spatial_critic import SpatialEmbQEnsemble, SpatialEmbQHead
 from rl_garden.networks.value import ValueNetwork
 
@@ -38,12 +40,16 @@ __all__ = [
     "EnsembleQCritic",
     "FlashSACBlock",
     "FlashSACEmbedder",
+    "GTrXLLatentEncoder",
+    "GTrXLState",
     "KernelInit",
     "MLPResNet",
     "NormalTanhPolicy",
     "RecurrentLatentEncoder",
     "RecurrentState",
     "RNNType",
+    "SequenceLatentEncoder",
+    "SequenceState",
     "SpatialEmbQEnsemble",
     "SpatialEmbQHead",
     "SquashedGaussianActor",

--- a/rl_garden/networks/gtrxl.py
+++ b/rl_garden/networks/gtrxl.py
@@ -53,6 +53,26 @@ accepted-but-suboptimal perf characteristic:
     rollout parity. A batched-window `forward_sequence()` would be a
     *different model* from the one that produced the rollout data, not a
     drop-in optimization of this one.
+
+`forward_sequence_with_burn_in()` (used by off-policy replay, e.g. TransformerSAC)
+zero-initializes `state` and burns in for `burn_in_len` steps before the tail
+unroll -- unlike `RecurrentLatentEncoder`'s R2D2 scheme, no stored per-transition
+checkpoint state is needed, because this memory is a bounded sliding window of
+raw activations rather than a compressed summary of unbounded history. This is
+an approximation whose fidelity depends on depth, not an exact reconstruction:
+  - Layer 0's memory holds raw embeddings only, so it is exactly correct once
+    `burn_in_len >= memory_len` (the FIFO window has fully cycled).
+  - Layer *i*'s memory holds layer *i-1*'s past outputs, which were themselves
+    computed from layer *i-1*'s own (possibly not-yet-warmed-up) memory earlier
+    in the burn-in window -- the same depth x segment-length compounding as
+    Transformer-XL (Dai et al. 2019). Layer *i*'s memory is only fully correct
+    once `burn_in_len >= (i+1) * memory_len`; for the last layer that is
+    `burn_in_len >= num_layers * memory_len`.
+  - `burn_in_len` shorter than that (down to the `>= memory_len` floor enforced
+    by `TransformerSAC._build_sequence_encoder`) is a deliberate, tunable
+    approximation -- deeper layers see a truncated effective context, same
+    spirit as R2D2's own finding that partial burn-in recovers most of the
+    benefit of full burn-in.
 """
 from __future__ import annotations
 
@@ -358,9 +378,23 @@ class GTrXLLatentEncoder(nn.Module):
         episode_starts: torch.Tensor,
         burn_in_len: int,
     ) -> tuple[torch.Tensor, GTrXLState]:
-        raise NotImplementedError(
-            "GTrXLLatentEncoder does not support burn-in replay this round -- "
-            "on-policy TransformerPPO never calls this (no replay staleness to "
-            "correct for, same reason RecurrentPPO never implemented burn-in). "
-            "Only relevant if/when a TransformerSAC is built."
+        """Off-policy BPTT call: re-derive ``state`` under CURRENT parameters over a
+        ``burn_in_len``-step prefix (no gradient), then unroll the remaining ``tail``
+        steps normally with gradients enabled. See the module docstring for why this
+        is an approximation whose fidelity depends on depth, not an exact
+        reconstruction, and for why ``state`` is always a fresh zero-initialized
+        state here (never a stored checkpoint, unlike ``RecurrentLatentEncoder``).
+
+        ``latent``/``episode_starts``: ``(burn_in_len + tail_len, B, ...)``. Returns
+        ``(tail_output, tail_final_state)`` where ``tail_output`` has shape
+        ``(tail_len, B, embed_dim)``. Gradient isolation falls out of
+        ``torch.no_grad()`` alone -- no extra ``.detach()`` needed at the seam.
+        """
+        with torch.no_grad():
+            _, state = self.forward_sequence(
+                latent[:burn_in_len], state, episode_starts[:burn_in_len]
+            )
+        tail_output, tail_final_state = self.forward_sequence(
+            latent[burn_in_len:], state, episode_starts[burn_in_len:]
         )
+        return tail_output, tail_final_state

--- a/rl_garden/networks/gtrxl.py
+++ b/rl_garden/networks/gtrxl.py
@@ -1,0 +1,366 @@
+"""GTrXL (Gated Transformer-XL) latent encoder -- Transformer counterpart to
+`RecurrentLatentEncoder`, both satisfying `SequenceLatentEncoder`.
+
+Core attention/gating math is ported from DI-engine's
+`ding/torch_utils/network/gtrxl.py` (Apache-2.0, see `3rd_party/DI-engine`):
+relative positional encoding (Transformer-XL `_rel_shift`) + GRU gating (the
+"Gated" in GTrXL, replacing residual-adds with a GRU-style gate for training
+stability, per Parisotto et al. 2020, https://arxiv.org/abs/1910.06764).
+
+Two things are NOT ported from DI-engine, by design:
+  1. DI-engine's `Memory`/`GTrXL` keep `self.memory` as internal mutable state
+     and have no notion of per-env episode boundaries -- their attention
+     `mask` is shape `(cur_seq, full_seq, 1)`, identical across the whole
+     batch. Real vectorized rollouts need per-env masking (env A's memory may
+     be mid-episode while env B just reset), so this module's mask is shaped
+     `(cur_seq, full_seq, B)` instead, and every call is explicit
+     state-in/state-out (matching `RecurrentLatentEncoder`'s existing
+     stateless-per-call contract) rather than a `self.memory` object.
+  2. Nothing here calls `.detach()`. Gradient isolation across segments comes
+     for free from how `initial_hidden`/`initial_memory` is produced (a
+     `torch.no_grad()` rollout snapshot -- see `RecurrentPPO`/`SequencePPO`),
+     exactly like `RecurrentLatentEncoder`. Detaching per-step here would
+     confine BPTT to a single step and defeat the point of the memory.
+
+State = `(memory, memory_valid)`:
+  - `memory`: `(num_layers+1, B, memory_len, embed_dim)` -- slot 0 is the
+    input embedding, slot i is the input to attention layer i. Batch is dim 1
+    (not DI-engine's dim 2) so `RecurrentRolloutBuffer._index_recurrent_state`
+    (`h[:, indices]` per tuple element) and `mask_state`/`index_state` work
+    unmodified.
+  - `memory_valid`: `(1, B, memory_len)` -- per-env validity of each memory
+    slot (False for slots before the current episode started). The leading
+    dummy dim exists only so dim 1 is batch, matching `memory`.
+
+`forward_sequence()` loops `step()` T times, same structural shape as
+`RecurrentLatentEncoder.forward_sequence()`, but here the loop is NOT just a
+slow stand-in for a batched call -- it is required for correctness, not an
+accepted-but-suboptimal perf characteristic:
+
+  - `step()`'s FIFO gives every position a *sliding* window of exactly the
+    last `memory_len` activations.
+  - A batched segment forward over the whole window at once (what DI-engine's
+    native `GTrXL.forward()` does, with a single `(cur_seq, full_seq, B)`
+    causal+validity mask) gives position *t* within the segment a *growing*
+    window of `memory_len + t` positions -- it still attends to pre-segment
+    memory that the sliding version has already evicted by the time it
+    reaches position *t*. These are different computations with different
+    outputs, not two ways of computing the same thing.
+  - Rollout necessarily calls `step()` one token at a time (env steps arrive
+    one at a time), so rollout always sees the sliding-window behavior.
+    `forward_sequence()` must match that exactly for the PPO ratio to be 1 at
+    the first training epoch -- looping `step()` is what guarantees train/
+    rollout parity. A batched-window `forward_sequence()` would be a
+    *different model* from the one that produced the rollout data, not a
+    drop-in optimization of this one.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+GTrXLState = tuple[torch.Tensor, torch.Tensor]
+
+
+class PositionalEmbedding(nn.Module):
+    """Sinusoidal embedding of *relative* distance (ported from DI-engine, itself
+    adapted from https://github.com/kimiyoung/transformer-xl). Depends only on
+    relative position, never absolute episode step -- unlike an absolute/learned
+    encoding, this needs no a-priori max-episode-length."""
+
+    def __init__(self, embed_dim: int) -> None:
+        super().__init__()
+        inv_freq = 1 / (10000 ** (torch.arange(0.0, embed_dim, 2.0) / embed_dim))
+        self.register_buffer("inv_freq", inv_freq)
+
+    def forward(self, pos_seq: torch.Tensor) -> torch.Tensor:
+        sinusoid_inp = torch.outer(pos_seq, self.inv_freq)
+        pos_embedding = torch.cat([sinusoid_inp.sin(), sinusoid_inp.cos()], dim=-1)
+        return pos_embedding.unsqueeze(1)
+
+
+class GRUGatingUnit(nn.Module):
+    """GRU-style gate combining a residual stream `x` with new signal `y`, in
+    place of a plain residual add -- the mechanism that makes GTrXL "Gated"."""
+
+    def __init__(self, input_dim: int, bias: float = 2.0) -> None:
+        super().__init__()
+        self.Wr = nn.Linear(input_dim, input_dim, bias=False)
+        self.Ur = nn.Linear(input_dim, input_dim, bias=False)
+        self.Wz = nn.Linear(input_dim, input_dim, bias=False)
+        self.Uz = nn.Linear(input_dim, input_dim, bias=False)
+        self.Wg = nn.Linear(input_dim, input_dim, bias=False)
+        self.Ug = nn.Linear(input_dim, input_dim, bias=False)
+        self.bias = nn.Parameter(torch.full([input_dim], bias))
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        r = torch.sigmoid(self.Wr(y) + self.Ur(x))
+        z = torch.sigmoid(self.Wz(y) + self.Uz(x) - self.bias)
+        h = torch.tanh(self.Wg(y) + self.Ug(r * x))
+        return (1 - z) * x + z * h
+
+
+class RelativeAttention(nn.Module):
+    """Transformer-XL relative-position multi-head attention. Shapes are
+    seq-major throughout (`(seq, B, dim)`), matching rl-garden's `(T, N, ...)`
+    convention."""
+
+    def __init__(self, input_dim: int, head_dim: int, num_heads: int, dropout: nn.Module) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dropout = dropout
+        self.attention_kv = nn.Linear(input_dim, head_dim * num_heads * 2)
+        self.attention_q = nn.Linear(input_dim, head_dim * num_heads)
+        self.project = nn.Linear(head_dim * num_heads, input_dim)
+        self.project_pos = nn.Linear(input_dim, head_dim * num_heads)
+        self.scale = 1 / (head_dim**0.5)
+
+    @staticmethod
+    def _rel_shift(x: torch.Tensor) -> torch.Tensor:
+        # x: (bs, head_num, cur_seq, full_seq) -- see DI-engine's `_rel_shift`
+        # docstring (rl_garden/../3rd_party/DI-engine/.../gtrxl.py) for the
+        # step-by-step derivation of this pad/reshape/slice trick.
+        x_padded = F.pad(x, [1, 0])
+        x_padded = x_padded.view(x.size(0), x.size(1), x.size(3) + 1, x.size(2))
+        return x_padded[:, :, 1:].view_as(x)
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        pos_embedding: torch.Tensor,
+        full_input: torch.Tensor,
+        u: torch.Tensor,
+        v: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        # inputs: (cur_seq, B, input_dim) raw (pre-LN) query source.
+        # full_input: (full_seq, B, input_dim) LN'd cat(memory, inputs).
+        # pos_embedding: (full_seq, 1, input_dim).
+        # mask: (cur_seq, full_seq, B) bool, True = masked out.
+        bs, cur_seq, full_seq = inputs.shape[1], inputs.shape[0], full_input.shape[0]
+
+        kv = self.attention_kv(full_input)
+        key, value = torch.chunk(kv, 2, dim=-1)
+        query = self.attention_q(inputs)
+        r = self.project_pos(pos_embedding)
+
+        key = key.view(full_seq, bs, self.num_heads, self.head_dim)
+        query = query.view(cur_seq, bs, self.num_heads, self.head_dim)
+        value = value.view(full_seq, bs, self.num_heads, self.head_dim)
+        r = r.view(full_seq, self.num_heads, self.head_dim)
+
+        content_attn = (query + u).permute(1, 2, 0, 3) @ key.permute(1, 2, 3, 0)
+        position_attn = (query + v).permute(1, 2, 0, 3) @ r.permute(1, 2, 0)
+        position_attn = self._rel_shift(position_attn)
+
+        attn = (content_attn + position_attn) * self.scale
+        if mask is not None and mask.any():
+            attn = attn.masked_fill(mask.permute(2, 0, 1).unsqueeze(1), -float("inf"))
+        attn = F.softmax(attn, dim=-1)
+        attn = self.dropout(attn)
+
+        out = attn @ value.permute(1, 2, 0, 3)
+        out = out.permute(2, 0, 1, 3).contiguous().view(cur_seq, bs, self.num_heads * self.head_dim)
+        return self.dropout(self.project(out))
+
+
+class GatedTransformerXLLayer(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        head_dim: int,
+        hidden_dim: int,
+        num_heads: int,
+        mlp_num: int,
+        dropout: nn.Module,
+        activation: nn.Module,
+        gru_bias: float = 2.0,
+    ) -> None:
+        super().__init__()
+        self.dropout = dropout
+        self.activation = activation
+        self.gate1 = GRUGatingUnit(input_dim, gru_bias)
+        self.gate2 = GRUGatingUnit(input_dim, gru_bias)
+        self.attention = RelativeAttention(input_dim, head_dim, num_heads, dropout)
+        dims = [input_dim] + [hidden_dim] * (mlp_num - 1) + [input_dim]
+        layers: list[nn.Module] = []
+        for i in range(mlp_num):
+            layers.append(nn.Linear(dims[i], dims[i + 1]))
+            layers.append(activation)
+            layers.append(dropout)
+        self.mlp = nn.Sequential(*layers)
+        self.layernorm1 = nn.LayerNorm(input_dim)
+        self.layernorm2 = nn.LayerNorm(input_dim)
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        pos_embedding: torch.Tensor,
+        u: torch.Tensor,
+        v: torch.Tensor,
+        memory: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        # inputs: (cur_seq, B, input_dim); memory: (memory_len, B, input_dim).
+        full_input = torch.cat([memory, inputs], dim=0)
+        x1 = self.layernorm1(full_input)
+        a1 = self.dropout(self.attention(inputs, pos_embedding, x1, u, v, mask=mask))
+        a1 = self.activation(a1)
+        o1 = self.gate1(inputs, a1)
+        x2 = self.layernorm2(o1)
+        m2 = self.dropout(self.mlp(x2))
+        return self.gate2(o1, m2)
+
+
+class GTrXLLatentEncoder(nn.Module):
+    """Explicit-state GTrXL encoder satisfying `SequenceLatentEncoder`. See
+    module docstring for the two deliberate departures from DI-engine's
+    reference (per-env masking, no internal `.detach()`)."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        *,
+        embed_dim: int = 256,
+        head_dim: int = 64,
+        num_heads: int = 4,
+        num_layers: int = 3,
+        mlp_num: int = 2,
+        memory_len: int = 64,
+        dropout_rate: float = 0.0,
+        gru_bias: float = 2.0,
+    ) -> None:
+        super().__init__()
+        if embed_dim % 2 != 0:
+            raise ValueError(f"embed_dim must be even (sinusoidal encoding), got {embed_dim}")
+        if num_layers < 1:
+            raise ValueError(f"num_layers must be >= 1, got {num_layers}")
+        if memory_len < 1:
+            raise ValueError(f"memory_len must be >= 1, got {memory_len}")
+
+        self.embed_dim = embed_dim
+        self.num_layers = num_layers
+        self.memory_len = memory_len
+
+        activation = nn.ReLU()
+        dropout = nn.Dropout(dropout_rate) if dropout_rate > 0 else nn.Identity()
+        self.embedding = nn.Sequential(nn.Linear(input_dim, embed_dim), activation)
+        self.dropout = dropout
+        self.layers = nn.ModuleList(
+            [
+                GatedTransformerXLLayer(
+                    embed_dim, head_dim, embed_dim, num_heads, mlp_num, dropout, activation, gru_bias
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.u = nn.Parameter(torch.zeros(num_heads, head_dim))
+        self.v = nn.Parameter(torch.zeros(num_heads, head_dim))
+
+        pos_embedding_module = PositionalEmbedding(embed_dim)
+        full_seq = memory_len + 1
+        pos_seq = torch.arange(full_seq - 1, -1, -1.0)
+        # (full_seq, 1, embed_dim); fixed given memory_len/embed_dim, so cached
+        # once as a buffer (moves with .to(device), never recomputed per step).
+        self.register_buffer("_pos_embedding", pos_embedding_module(pos_seq))
+
+    @property
+    def features_dim(self) -> int:
+        return self.embed_dim
+
+    def get_initial_state(self, batch_size: int, device: torch.device) -> GTrXLState:
+        memory = torch.zeros(self.num_layers + 1, batch_size, self.memory_len, self.embed_dim, device=device)
+        memory_valid = torch.zeros(1, batch_size, self.memory_len, device=device)
+        return memory, memory_valid
+
+    @staticmethod
+    def mask_state(state: GTrXLState, keep_mask: torch.Tensor) -> GTrXLState:
+        memory, memory_valid = state
+        keep_mask = keep_mask.to(dtype=memory.dtype, device=memory.device)
+        memory = memory * keep_mask.reshape(1, -1, 1, 1)
+        memory_valid = memory_valid * keep_mask.reshape(1, -1, 1)
+        return memory, memory_valid
+
+    @staticmethod
+    def index_state(state: GTrXLState, indices: torch.Tensor) -> GTrXLState:
+        memory, memory_valid = state
+        return memory[:, indices], memory_valid[:, indices]
+
+    def step(
+        self,
+        latent: torch.Tensor,
+        state: GTrXLState,
+        episode_starts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, GTrXLState]:
+        """Single rollout/BPTT step. ``latent``: (B, input_dim); ``episode_starts``: (B,)."""
+        if episode_starts is not None:
+            state = self.mask_state(state, 1.0 - episode_starts.float())
+        memory, memory_valid = state
+        batch_size = memory.shape[1]
+
+        # Internal computation uses DI-engine's seq-major-per-layer layout
+        # (memory_len, B, embed_dim); external state keeps batch at dim 1 for
+        # buffer/mask_state/index_state compatibility -- transpose at the
+        # boundary only.
+        memory_seq_major = memory.transpose(1, 2)  # (num_layers+1, memory_len, B, embed_dim)
+        valid_seq_major = memory_valid[0].transpose(0, 1)  # (memory_len, B)
+
+        # Matches DI-engine's GTrXL.forward(): dropout is applied to the
+        # embedded input and to the positional embedding (freshly each call,
+        # not baked into the cached buffer), in addition to the final output
+        # dropout below.
+        x = self.dropout(self.embedding(latent)).unsqueeze(0)  # (1, B, embed_dim)
+        pos_embedding = self.dropout(self._pos_embedding)
+        valid_full = torch.cat([valid_seq_major, torch.ones(1, batch_size, device=latent.device)], dim=0)
+        # mask: (cur_seq=1, full_seq, B), True = masked out. No causal term
+        # needed for cur_seq=1 (a single new query has nothing "in the
+        # future" within memory+itself) -- only per-env memory validity.
+        mask = (valid_full < 0.5).unsqueeze(0)  # (1, full_seq, B)
+
+        hidden_states = [x]
+        out = x
+        for i, layer in enumerate(self.layers):
+            out = layer(out, pos_embedding, self.u, self.v, memory=memory_seq_major[i], mask=mask)
+            hidden_states.append(out)
+        out = self.dropout(out)
+
+        new_memory_slot = torch.stack(hidden_states, dim=0)  # (num_layers+1, 1, B, embed_dim)
+        new_memory_seq_major = torch.cat([memory_seq_major, new_memory_slot], dim=1)[:, 1:]
+        new_valid_seq_major = torch.cat([valid_seq_major, torch.ones(1, batch_size, device=latent.device)], dim=0)[1:]
+
+        new_memory = new_memory_seq_major.transpose(1, 2)  # back to (num_layers+1, B, memory_len, embed_dim)
+        new_memory_valid = new_valid_seq_major.transpose(0, 1).unsqueeze(0)  # (1, B, memory_len)
+        return out.squeeze(0), (new_memory, new_memory_valid)
+
+    def forward_sequence(
+        self,
+        latent: torch.Tensor,
+        state: GTrXLState,
+        episode_starts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, GTrXLState]:
+        """BPTT update call. ``latent``: (T, B, input_dim); ``episode_starts``: (T, B)."""
+        num_steps = latent.shape[0]
+        outputs = []
+        for t in range(num_steps):
+            step_starts = episode_starts[t] if episode_starts is not None else None
+            output, state = self.step(latent[t], state, step_starts)
+            outputs.append(output)
+        return torch.stack(outputs, dim=0), state
+
+    def forward_sequence_with_burn_in(
+        self,
+        latent: torch.Tensor,
+        state: GTrXLState,
+        episode_starts: torch.Tensor,
+        burn_in_len: int,
+    ) -> tuple[torch.Tensor, GTrXLState]:
+        raise NotImplementedError(
+            "GTrXLLatentEncoder does not support burn-in replay this round -- "
+            "on-policy TransformerPPO never calls this (no replay staleness to "
+            "correct for, same reason RecurrentPPO never implemented burn-in). "
+            "Only relevant if/when a TransformerSAC is built."
+        )

--- a/rl_garden/networks/recurrent.py
+++ b/rl_garden/networks/recurrent.py
@@ -184,6 +184,35 @@ class RecurrentLatentEncoder(nn.Module):
             outputs.append(output)
         return torch.stack(outputs, dim=0), state
 
+    def forward_sequence_with_burn_in(
+        self,
+        latent: torch.Tensor,
+        state: RecurrentState,
+        episode_starts: torch.Tensor,
+        burn_in_len: int,
+    ) -> tuple[torch.Tensor, RecurrentState]:
+        """Off-policy BPTT call: re-derive ``state`` under CURRENT parameters over a
+        ``burn_in_len``-step prefix (no gradient), then unroll the remaining ``tail``
+        steps normally with gradients enabled.
+
+        ``latent``/``episode_starts``: ``(burn_in_len + tail_len, B, ...)``. Returns
+        ``(tail_output, tail_final_state)`` where ``tail_output`` has shape
+        ``(tail_len, B, hidden_size)``. Gradient isolation falls out of
+        ``torch.no_grad()`` alone -- no extra ``.detach()`` needed at the seam.
+
+        Callers do not need per-sample-variable burn-in lengths: replay buffers that
+        seed ``state`` from a stored checkpoint should align sampled windows so
+        ``burn_in_len`` is a fixed constant (see the buffer's own docs for why).
+        """
+        with torch.no_grad():
+            _, state = self.forward_sequence(
+                latent[:burn_in_len], state, episode_starts[:burn_in_len]
+            )
+        tail_output, tail_final_state = self.forward_sequence(
+            latent[burn_in_len:], state, episode_starts[burn_in_len:]
+        )
+        return tail_output, tail_final_state
+
     def forward(
         self,
         latent: torch.Tensor,

--- a/rl_garden/networks/recurrent.py
+++ b/rl_garden/networks/recurrent.py
@@ -92,6 +92,10 @@ class RecurrentLatentEncoder(nn.Module):
     required so the module composes cleanly with checkpointing and stays a pure
     function of ``(latent, state)``, matching how the rest of this codebase's
     actor/critic heads are already stateless per-call.
+
+    Satisfies ``rl_garden.networks.sequence_encoder.SequenceLatentEncoder``
+    (structurally -- ``Protocol`` needs no explicit subclassing), the same
+    contract ``GTrXLLatentEncoder`` implements.
     """
 
     def __init__(

--- a/rl_garden/networks/recurrent.py
+++ b/rl_garden/networks/recurrent.py
@@ -1,0 +1,205 @@
+"""Generic recurrent (LSTM/GRU) latent-processing module.
+
+Sits between a BaseFeaturesExtractor and policy/value heads. Consumes a flat
+(B, D) or (T, B, D) latent tensor -- never raw observations -- so it is
+generic over the *type* of upstream encoder (FlattenExtractor, PlainConv,
+ResNetEncoder, ...) without any encoder-specific casing.
+"""
+from __future__ import annotations
+
+from typing import Literal, Optional, Union
+
+import torch
+import torch.nn as nn
+
+RNNType = Literal["lstm", "gru"]
+RecurrentState = Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]
+# GRU: Tensor of shape (num_layers, B, hidden_size).
+# LSTM: tuple (h, c), each (num_layers, B, hidden_size).
+
+
+# ---------------------------------------------------------------------------
+# NOTE(future-work): why SAC / off-policy is NOT wired to this module (yet)
+# ---------------------------------------------------------------------------
+# This module is deliberately usable both for a single rollout step and for a
+# full (T, B, D) BPTT window (see `step()` / `forward_sequence()` below), and
+# nothing about its forward-pass API is PPO-specific. The reason only PPO
+# consumes it this round is entirely on the *buffer/sampling* side, not here:
+#
+# PPO is on-policy: `train()` runs immediately after `RolloutBuffer.add()`
+# finishes collecting a window, under (approximately) the same policy
+# parameters that produced the data. That lets `RolloutBuffer.get_sequences()`
+# always reconstruct BPTT windows starting from the TRUE hidden state that was
+# live at collection time (captured once per rollout, masked at episode
+# boundaries -- see PPO._setup_model()/train()) with zero staleness. No
+# stored per-timestep hidden state, no burn-in, no padding.
+#
+# SAC (and any off-policy algorithm) breaks that assumption: replay sampling
+# draws a WINDOW that starts at an arbitrary point in the buffer, not the true
+# start of collection, and by the time it's replayed the policy/critic
+# parameters have moved since that data was collected. A hidden state
+# recomputed from a zero-init at the sampled window's start does NOT match
+# what the CURRENT network would have produced walking in from the actual
+# episode start -- it's simply the wrong conditioning state, and the
+# mismatch compounds with off-policy staleness.
+#
+# R2D2 (Kapturowski et al., "Recurrent Experience Replay in Distributed
+# Reinforcement Learning", ICLR 2019) is the reference fix, and it combines
+# TWO mechanisms -- their own ablation shows either one alone underperforms:
+#   1. Store the RNN hidden state produced at collection time alongside each
+#      stored transition/sequence-start, so replay has a real starting point
+#      instead of a zero-init.
+#   2. Burn-in: before the actual loss/BPTT window, re-unroll the RNN under
+#      CURRENT parameters over a preceding window of transitions (no gradient
+#      through the burn-in portion) so the hidden state entering the loss
+#      window is freshly computed by today's weights rather than stale from
+#      collection time. Stored-state seeds the burn-in; it is not used
+#      directly as the loss-window's initial state.
+#
+# Concretely, wiring this module into SAC (or DDPG, or any replay-based
+# algorithm here) requires THREE things this round does not build:
+#   (a) Replay buffer storage for a hidden state per transition or per
+#       sequence-start. `rl_garden/buffers/tensor_buffer.py`,
+#       `dict_buffer.py`, and `nstep_buffer.py` currently store only flat
+#       per-transition fields (obs/next_obs/actions/rewards/dones) with no
+#       slot for auxiliary per-timestep state.
+#   (b) A sequence-aware sampler. `TensorReplayBuffer.sample()` (see
+#       `tensor_buffer.py::sample()`) draws fully IID
+#       `(batch_inds, env_inds)` pairs via `torch.randint(...)` for both
+#       axes -- no contiguity guarantee between consecutive samples at all.
+#       An R2D2-style sampler needs to draw a contiguous
+#       (burn_in_len + loss_len, ...) block per sample, anchored so the
+#       stored hidden state at the block's start is valid.
+#   (c) A burn-in-aware unroll mode on THIS module: something like
+#       `forward_sequence(latent, state, episode_starts, burn_in_len=...)`
+#       that runs the first `burn_in_len` steps under `torch.no_grad()` (or
+#       with gradients detached) purely to refresh `state`, then continues
+#       the remaining steps normally with gradients enabled for the loss.
+#       Today's `forward_sequence()` has no burn-in concept and assumes its
+#       caller's `state` argument is already the correct, un-stale starting
+#       point -- true for PPO's own-collection-then-immediate-update
+#       pattern, not for replay.
+#
+# None of the above exists yet anywhere in the repo. Do not assume
+# `forward_sequence()` is replay-safe just because the shapes line up.
+# ---------------------------------------------------------------------------
+
+
+class RecurrentLatentEncoder(nn.Module):
+    """Wraps ``nn.LSTM``/``nn.GRU`` behind an explicit-state, encoder-agnostic API.
+
+    Hidden state is always an explicit input/output, never stored on ``self`` --
+    required so the module composes cleanly with checkpointing and stays a pure
+    function of ``(latent, state)``, matching how the rest of this codebase's
+    actor/critic heads are already stateless per-call.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_size: int,
+        *,
+        rnn_type: RNNType = "lstm",
+        num_layers: int = 1,
+    ) -> None:
+        super().__init__()
+        if rnn_type not in ("lstm", "gru"):
+            raise ValueError(f"rnn_type must be 'lstm' or 'gru', got {rnn_type!r}")
+        if num_layers < 1:
+            raise ValueError(f"num_layers must be >= 1, got {num_layers}")
+
+        self.input_dim = input_dim
+        self.hidden_size = hidden_size
+        self.rnn_type: RNNType = rnn_type
+        self.num_layers = num_layers
+
+        rnn_cls = nn.LSTM if rnn_type == "lstm" else nn.GRU
+        self.rnn = rnn_cls(input_size=input_dim, hidden_size=hidden_size, num_layers=num_layers)
+
+    @property
+    def features_dim(self) -> int:
+        return self.hidden_size
+
+    def get_initial_state(self, batch_size: int, device: torch.device) -> RecurrentState:
+        h = torch.zeros(self.num_layers, batch_size, self.hidden_size, device=device)
+        if self.rnn_type == "lstm":
+            c = torch.zeros(self.num_layers, batch_size, self.hidden_size, device=device)
+            return (h, c)
+        return h
+
+    @staticmethod
+    def mask_state(state: RecurrentState, keep_mask: torch.Tensor) -> RecurrentState:
+        """``keep_mask``: (B,) of 1.0=keep / 0.0=reset. Broadcasts over (num_layers,B,H)."""
+
+        def _mask(h: torch.Tensor) -> torch.Tensor:
+            k = keep_mask.reshape(1, -1, *([1] * (h.dim() - 2))).to(dtype=h.dtype, device=h.device)
+            return h * k
+
+        if isinstance(state, tuple):
+            return tuple(_mask(h) for h in state)
+        return _mask(state)
+
+    @staticmethod
+    def index_state(state: RecurrentState, indices: torch.Tensor) -> RecurrentState:
+        """Index along the batch dim (dim=1). ``indices`` may be int or bool tensor."""
+
+        def _index(h: torch.Tensor) -> torch.Tensor:
+            return h[:, indices]
+
+        if isinstance(state, tuple):
+            return tuple(_index(h) for h in state)
+        return _index(state)
+
+    def step(
+        self,
+        latent: torch.Tensor,
+        state: RecurrentState,
+        episode_starts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, RecurrentState]:
+        """Single rollout step. ``latent``: (B, input_dim); ``episode_starts``: (B,)."""
+        if episode_starts is not None:
+            state = self.mask_state(state, 1.0 - episode_starts.float())
+        output, new_state = self.rnn(latent.unsqueeze(0), state)
+        return output.squeeze(0), new_state
+
+    def forward_sequence(
+        self,
+        latent: torch.Tensor,
+        state: RecurrentState,
+        episode_starts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, RecurrentState]:
+        """BPTT update call. ``latent``: (T, B, input_dim); ``episode_starts``: (T, B).
+
+        Loops ``step()`` T times so that a mid-sequence episode boundary is handled
+        via per-step masking rather than requiring the caller to hard-split the
+        sequence. ``episode_starts[0]`` is honored as given -- callers that have
+        already folded the window-boundary reset into ``state`` (see PPO's rollout
+        loop) should pass ``episode_starts[0] == 0``.
+        """
+        num_steps = latent.shape[0]
+        outputs = []
+        for t in range(num_steps):
+            step_starts = episode_starts[t] if episode_starts is not None else None
+            output, state = self.step(latent[t], state, step_starts)
+            outputs.append(output)
+        return torch.stack(outputs, dim=0), state
+
+    def forward(
+        self,
+        latent: torch.Tensor,
+        state: RecurrentState,
+        episode_starts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, RecurrentState]:
+        """Convenience ndim-dispatch wrapper: ``latent.dim()==2`` -> ``step()``,
+        ``latent.dim()==3`` -> ``forward_sequence()``. Production call sites
+        (PPOPolicy, PPO rollout/train loops) call ``step()``/``forward_sequence()``
+        explicitly and do NOT rely on this dispatch, since a length-1 window
+        ``(1,B,D)`` and a single step ``(B,D)`` are both valid but require
+        differently-shaped ``episode_starts``. This exists only so the module
+        still behaves like a normal ``nn.Module`` for isolated tests.
+        """
+        if latent.dim() == 2:
+            return self.step(latent, state, episode_starts)
+        if latent.dim() == 3:
+            return self.forward_sequence(latent, state, episode_starts)
+        raise ValueError(f"latent must have shape (B,D) or (T,B,D), got {tuple(latent.shape)}")

--- a/rl_garden/networks/sequence_encoder.py
+++ b/rl_garden/networks/sequence_encoder.py
@@ -1,0 +1,57 @@
+"""Shared structural contract for stateful sequence-latent encoders.
+
+`RecurrentLatentEncoder` (LSTM/GRU) and `GTrXLLatentEncoder` (Transformer) both
+implement this shape, letting `RecurrentPPOPolicy`/`RecurrentRolloutBuffer` stay
+encoder-agnostic. `Protocol` is structural: neither encoder needs to subclass
+this to satisfy it, this is a documented contract, not a base class in the
+inheritance sense. A future SSM/Mamba encoder is expected to satisfy the same
+Protocol without requiring any changes here.
+
+State shape is deliberately NOT part of the contract -- RNN state is a compact
+`(num_layers, B, hidden_size)` vector, GTrXL state is a much larger
+`(memory, memory_valid)` pair holding a window of raw past activations. Only
+the requirement that batch is tensor-dim 1 (for every tensor in the state,
+tuple or not) is shared, since `RecurrentRolloutBuffer._index_recurrent_state`
+and `mask_state`/`index_state` both index/broadcast along dim 1.
+"""
+from __future__ import annotations
+
+from typing import Optional, Protocol, Union, runtime_checkable
+
+import torch
+
+SequenceState = Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]
+
+
+@runtime_checkable
+class SequenceLatentEncoder(Protocol):
+    @property
+    def features_dim(self) -> int: ...
+
+    def get_initial_state(self, batch_size: int, device: torch.device) -> SequenceState: ...
+
+    def mask_state(self, state: SequenceState, keep_mask: torch.Tensor) -> SequenceState: ...
+
+    def index_state(self, state: SequenceState, indices: torch.Tensor) -> SequenceState: ...
+
+    def step(
+        self,
+        latent: torch.Tensor,
+        state: SequenceState,
+        episode_starts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, SequenceState]: ...
+
+    def forward_sequence(
+        self,
+        latent: torch.Tensor,
+        state: SequenceState,
+        episode_starts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, SequenceState]: ...
+
+    def forward_sequence_with_burn_in(
+        self,
+        latent: torch.Tensor,
+        state: SequenceState,
+        episode_starts: torch.Tensor,
+        burn_in_len: int,
+    ) -> tuple[torch.Tensor, SequenceState]: ...

--- a/rl_garden/policies/__init__.py
+++ b/rl_garden/policies/__init__.py
@@ -3,6 +3,7 @@ from rl_garden.policies.bc_policy import BCPolicy
 from rl_garden.policies.flash_sac_policy import FlashSACPolicy
 from rl_garden.policies.iql_policy import IQLPolicy
 from rl_garden.policies.ppo_policy import PPOPolicy
+from rl_garden.policies.recurrent_ppo_policy import RecurrentPPOPolicy
 from rl_garden.policies.residual_policy import ResidualSACPolicy
 from rl_garden.policies.sac_policy import Actor, ContinuousCritic, SACPolicy
 from rl_garden.policies.wsrl_policy import WSRLPolicy
@@ -15,6 +16,7 @@ __all__ = [
     "FlashSACPolicy",
     "IQLPolicy",
     "PPOPolicy",
+    "RecurrentPPOPolicy",
     "ResidualSACPolicy",
     "SACPolicy",
     "WSRLPolicy",

--- a/rl_garden/policies/__init__.py
+++ b/rl_garden/policies/__init__.py
@@ -4,6 +4,7 @@ from rl_garden.policies.flash_sac_policy import FlashSACPolicy
 from rl_garden.policies.iql_policy import IQLPolicy
 from rl_garden.policies.ppo_policy import PPOPolicy
 from rl_garden.policies.recurrent_ppo_policy import RecurrentPPOPolicy
+from rl_garden.policies.recurrent_sac_policy import RecurrentSACPolicy
 from rl_garden.policies.residual_policy import ResidualSACPolicy
 from rl_garden.policies.sac_policy import Actor, ContinuousCritic, SACPolicy
 from rl_garden.policies.wsrl_policy import WSRLPolicy
@@ -17,6 +18,7 @@ __all__ = [
     "IQLPolicy",
     "PPOPolicy",
     "RecurrentPPOPolicy",
+    "RecurrentSACPolicy",
     "ResidualSACPolicy",
     "SACPolicy",
     "WSRLPolicy",

--- a/rl_garden/policies/ppo_policy.py
+++ b/rl_garden/policies/ppo_policy.py
@@ -40,6 +40,7 @@ class PPOPolicy(BasePolicy):
         features_extractor: BaseFeaturesExtractor,
         net_arch: Sequence[int] | dict[str, Sequence[int]] = (256, 256, 256),
         *,
+        features_dim: Optional[int] = None,
         log_std_init: float = -0.5,
         actor_use_layer_norm: bool = False,
         value_use_layer_norm: bool = False,
@@ -58,7 +59,7 @@ class PPOPolicy(BasePolicy):
         self.action_space = action_space
         self.features_extractor = features_extractor
         actor_arch, value_arch = get_ppo_arch(net_arch)
-        fd = features_extractor.features_dim
+        fd = features_dim if features_dim is not None else features_extractor.features_dim
         self.actor = DiagGaussianActor(
             fd,
             action_space,

--- a/rl_garden/policies/recurrent_ppo_policy.py
+++ b/rl_garden/policies/recurrent_ppo_policy.py
@@ -1,0 +1,144 @@
+"""Recurrent variant of PPOPolicy: an RNN latent stage between the encoder and heads."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+from gymnasium import spaces
+
+from rl_garden.common.obs_utils import flatten_leading_dims
+from rl_garden.common.types import Obs
+from rl_garden.encoders.base import BaseFeaturesExtractor
+from rl_garden.networks import BackboneType, KernelInit, RecurrentLatentEncoder, RecurrentState
+from rl_garden.policies.ppo_policy import PPOPolicy
+
+
+class RecurrentPPOPolicy(PPOPolicy):
+    """PPOPolicy with a RecurrentLatentEncoder between features_extractor and the heads."""
+
+    def __init__(
+        self,
+        observation_space: spaces.Space,
+        action_space: spaces.Box,
+        features_extractor: BaseFeaturesExtractor,
+        recurrent_encoder: RecurrentLatentEncoder,
+        net_arch: Sequence[int] | dict[str, Sequence[int]] = (256, 256, 256),
+        *,
+        log_std_init: float = -0.5,
+        actor_use_layer_norm: bool = False,
+        value_use_layer_norm: bool = False,
+        actor_use_group_norm: bool = False,
+        value_use_group_norm: bool = False,
+        num_groups: int = 32,
+        actor_dropout_rate: Optional[float] = None,
+        value_dropout_rate: Optional[float] = None,
+        kernel_init: Optional[KernelInit] = None,
+        backbone_type: BackboneType = "mlp",
+    ) -> None:
+        # recurrent_encoder.features_dim is read here (a plain property, safe
+        # before nn.Module registration); self.recurrent_encoder is assigned
+        # AFTER super().__init__() returns, since nn.Module.__setattr__ requires
+        # nn.Module.__init__() (called inside super().__init__()) to have
+        # already run before any submodule attribute can be set.
+        super().__init__(
+            observation_space,
+            action_space,
+            features_extractor,
+            net_arch,
+            features_dim=recurrent_encoder.features_dim,
+            log_std_init=log_std_init,
+            actor_use_layer_norm=actor_use_layer_norm,
+            value_use_layer_norm=value_use_layer_norm,
+            actor_use_group_norm=actor_use_group_norm,
+            value_use_group_norm=value_use_group_norm,
+            num_groups=num_groups,
+            actor_dropout_rate=actor_dropout_rate,
+            value_dropout_rate=value_dropout_rate,
+            kernel_init=kernel_init,
+            backbone_type=backbone_type,
+        )
+        self.recurrent_encoder = recurrent_encoder
+
+    def act_recurrent(
+        self,
+        obs: Obs,
+        hidden: RecurrentState,
+        episode_starts: torch.Tensor,
+        deterministic: bool = False,
+        *,
+        stop_gradient_actor: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, RecurrentState]:
+        """Single rollout step. Returns (actions, values, log_prob, entropy, new_hidden)."""
+        raw = self._extract_features(obs, stop_gradient=False)
+        latent, new_hidden = self.recurrent_encoder.step(raw, hidden, episode_starts)
+        actor_latent = latent.detach() if stop_gradient_actor else latent
+        actions, log_prob, entropy = self.actor.action_log_prob(
+            actor_latent, deterministic=deterministic
+        )
+        values = self.value_net(latent)
+        return actions, values, log_prob, entropy, new_hidden
+
+    def predict_recurrent(
+        self,
+        obs: Obs,
+        hidden: RecurrentState,
+        episode_starts: torch.Tensor,
+        deterministic: bool = False,
+    ) -> tuple[torch.Tensor, RecurrentState]:
+        raw = self._extract_features(obs, stop_gradient=False)
+        latent, new_hidden = self.recurrent_encoder.step(raw, hidden, episode_starts)
+        if deterministic:
+            action = self.actor.clamp_action(self.actor.deterministic_action(latent))
+        else:
+            action, _, _ = self.actor.action_log_prob(latent, deterministic=False)
+            action = self.actor.clamp_action(action)
+        return action, new_hidden
+
+    def predict_values_recurrent(
+        self, obs: Obs, hidden: RecurrentState, episode_starts: torch.Tensor
+    ) -> tuple[torch.Tensor, RecurrentState]:
+        raw = self._extract_features(obs, stop_gradient=False)
+        latent, new_hidden = self.recurrent_encoder.step(raw, hidden, episode_starts)
+        return self.value_net(latent), new_hidden
+
+    def evaluate_actions_sequence(
+        self,
+        obs: Obs,
+        actions: torch.Tensor,
+        initial_hidden: RecurrentState,
+        episode_starts: torch.Tensor,
+        *,
+        stop_gradient_actor: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """BPTT update path. obs/actions: (T, B, ...). Returns (values, log_prob,
+        entropy), each (T, B, 1).
+
+        The encoder sees no time axis (T*B flattened -> encode -> reshaped back to
+        (T, B, -1)); the RNN unrolls over the (T, B, -1) latent.
+        """
+        num_steps, num_envs = actions.shape[0], actions.shape[1]
+        flat_obs = flatten_leading_dims(obs)
+        raw = self._extract_features(flat_obs, stop_gradient=False)
+        raw = raw.reshape(num_steps, num_envs, -1)
+        latent, _ = self.recurrent_encoder.forward_sequence(raw, initial_hidden, episode_starts)
+
+        # Detach the RNN's OUTPUT before the actor head, rather than calling
+        # extract_features twice with different stop_gradient settings like the
+        # non-recurrent forward()/evaluate_actions() do. Value-loss gradient
+        # still flows unconditionally through latent -> RNN -> raw -> encoder;
+        # actor-loss gradient is cut right here and therefore never reaches the
+        # RNN or encoder either -- topologically identical to two separate
+        # calls, computed once. Two calls would double the O(T) RNN unroll cost
+        # for no behavioral difference, unlike the flat-MLP-encoder case where a
+        # second call is cheap.
+        actor_latent = latent.detach() if stop_gradient_actor else latent
+        flat_actor_latent = actor_latent.reshape(num_steps * num_envs, -1)
+        flat_actions = actions.reshape(num_steps * num_envs, -1)
+        log_prob, entropy = self.actor.evaluate_action_log_prob(flat_actor_latent, flat_actions)
+        values = self.value_net(latent.reshape(num_steps * num_envs, -1))
+        return (
+            values.reshape(num_steps, num_envs, -1),
+            log_prob.reshape(num_steps, num_envs, -1),
+            entropy.reshape(num_steps, num_envs, -1),
+        )

--- a/rl_garden/policies/recurrent_sac_policy.py
+++ b/rl_garden/policies/recurrent_sac_policy.py
@@ -1,0 +1,116 @@
+"""Recurrent variant of SACPolicy: an RNN latent stage between the encoder and
+the actor/critic heads."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+from gymnasium import spaces
+
+from rl_garden.common.obs_utils import flatten_leading_dims
+from rl_garden.common.types import Obs
+from rl_garden.encoders.base import BaseFeaturesExtractor
+from rl_garden.networks import BackboneType, CriticImpl, KernelInit, RecurrentLatentEncoder, RecurrentState
+from rl_garden.policies.sac_policy import SACPolicy, LOG_STD_MAX, LOG_STD_MIN
+
+
+class RecurrentSACPolicy(SACPolicy):
+    """SACPolicy with a RecurrentLatentEncoder between features_extractor and
+    the actor/critic heads. Always assumes a flat-latent features_extractor --
+    the caller (RecurrentSAC._build_policy) is responsible for rejecting
+    ``structured_feature_config() is not None`` before constructing this."""
+
+    def __init__(
+        self,
+        observation_space: spaces.Space,
+        action_space: spaces.Box,
+        features_extractor: BaseFeaturesExtractor,
+        recurrent_encoder: RecurrentLatentEncoder,
+        net_arch: Sequence[int] | dict[str, Sequence[int]] = (256, 256, 256),
+        *,
+        n_critics: int = 2,
+        critic_subsample_size: Optional[int] = None,
+        actor_use_layer_norm: bool = False,
+        critic_use_layer_norm: bool = False,
+        actor_use_group_norm: bool = False,
+        critic_use_group_norm: bool = False,
+        num_groups: int = 32,
+        actor_dropout_rate: Optional[float] = None,
+        critic_dropout_rate: Optional[float] = None,
+        kernel_init: Optional[KernelInit] = None,
+        backbone_type: BackboneType = "mlp",
+        critic_impl: CriticImpl = "vmap",
+        std_parameterization: str = "exp",
+        log_std_mode: str = "tanh",
+        log_std_min: float = LOG_STD_MIN,
+        log_std_max: float = LOG_STD_MAX,
+    ) -> None:
+        # recurrent_encoder.features_dim is read here (a plain property, safe
+        # before nn.Module registration); self.recurrent_encoder is assigned
+        # AFTER super().__init__() returns, since nn.Module.__setattr__ requires
+        # nn.Module.__init__() (called inside super().__init__()) to have
+        # already run first -- same constraint RecurrentPPOPolicy documents.
+        super().__init__(
+            observation_space,
+            action_space,
+            features_extractor,
+            net_arch,
+            n_critics=n_critics,
+            critic_subsample_size=critic_subsample_size,
+            actor_use_layer_norm=actor_use_layer_norm,
+            critic_use_layer_norm=critic_use_layer_norm,
+            actor_use_group_norm=actor_use_group_norm,
+            critic_use_group_norm=critic_use_group_norm,
+            num_groups=num_groups,
+            actor_dropout_rate=actor_dropout_rate,
+            critic_dropout_rate=critic_dropout_rate,
+            kernel_init=kernel_init,
+            backbone_type=backbone_type,
+            critic_impl=critic_impl,
+            std_parameterization=std_parameterization,
+            log_std_mode=log_std_mode,
+            log_std_min=log_std_min,
+            log_std_max=log_std_max,
+            features_dim=recurrent_encoder.features_dim,
+        )
+        self.recurrent_encoder = recurrent_encoder
+
+    def act_recurrent_step(
+        self,
+        obs: Obs,
+        hidden: RecurrentState,
+        episode_starts: torch.Tensor,
+        deterministic: bool = False,
+    ) -> tuple[torch.Tensor, RecurrentState]:
+        """Single rollout step: obs -> features -> RNN step -> action. Returns
+        (action, new_hidden)."""
+        raw = self._extract_features(obs, stop_gradient=False)
+        latent, new_hidden = self.recurrent_encoder.step(raw, hidden, episode_starts)
+        if deterministic:
+            action = self.actor.deterministic_action(latent)
+        else:
+            action, _ = self.actor.action_log_prob(latent)
+        return action, new_hidden
+
+    def windowed_features(
+        self,
+        obs_window: Obs,
+        initial_hidden: RecurrentState,
+        episode_starts_window: torch.Tensor,
+        burn_in_len: int,
+        *,
+        stop_gradient: bool = False,
+    ) -> torch.Tensor:
+        """Training-time windowed feature extraction: obs_window ->
+        features_extractor (flattened over time) -> RNN burn-in+tail unroll.
+        Returns the TAIL post-RNN features, shape (tail_len, B, hidden_size).
+        """
+        num_envs = episode_starts_window.shape[1]
+        flat_obs = flatten_leading_dims(obs_window)
+        raw = self._extract_features(flat_obs, stop_gradient=stop_gradient)
+        raw = raw.reshape(-1, num_envs, raw.shape[-1])
+        tail, _ = self.recurrent_encoder.forward_sequence_with_burn_in(
+            raw, initial_hidden, episode_starts_window, burn_in_len
+        )
+        return tail

--- a/rl_garden/policies/sac_policy.py
+++ b/rl_garden/policies/sac_policy.py
@@ -151,6 +151,7 @@ class SACPolicy(BasePolicy):
         critic_hidden_dims: Optional[Sequence[int]] = None,
         actor_feature_dim: Optional[int] = None,
         critic_spatial_emb_dim: int = 1024,
+        features_dim: Optional[int] = None,
     ) -> None:
         del use_cql_alpha_lagrange, cql_alpha_lagrange_init
         super().__init__()
@@ -174,7 +175,7 @@ class SACPolicy(BasePolicy):
         else:
             actor_arch, critic_arch = get_actor_critic_arch(net_arch)
 
-        fd = features_extractor.features_dim
+        fd = features_dim if features_dim is not None else features_extractor.features_dim
         sc = features_extractor.structured_feature_config()
 
         # --- Actor adapter (token compression) ---

--- a/rl_garden/training/online/_args.py
+++ b/rl_garden/training/online/_args.py
@@ -100,6 +100,19 @@ class VisionPPOTrainingArgs(PPOTrainingArgs, VisionArgs):
 
 
 @dataclass
+class RecurrentPPOTrainingArgs(PPOTrainingArgs):
+    rnn_type: Literal["lstm", "gru"] = "lstm"
+    rnn_hidden_size: int = 256
+    rnn_num_layers: int = 1
+
+
+@dataclass
+class VisionRecurrentPPOTrainingArgs(RecurrentPPOTrainingArgs, VisionArgs):
+    camera_width: Optional[int] = 64
+    camera_height: Optional[int] = 64
+
+
+@dataclass
 class DrQv2TrainingArgs:
     env_id: str = "PickCube-v1"
     num_envs: int = 16

--- a/rl_garden/training/online/_args.py
+++ b/rl_garden/training/online/_args.py
@@ -132,6 +132,24 @@ class VisionRecurrentPPOTrainingArgs(RecurrentPPOTrainingArgs, VisionArgs):
 
 
 @dataclass
+class TransformerPPOTrainingArgs(PPOTrainingArgs):
+    embed_dim: int = 256
+    head_dim: int = 64
+    num_heads: int = 4
+    num_transformer_layers: int = 3
+    mlp_num: int = 2
+    memory_len: int = 64
+    dropout_rate: float = 0.0
+    gru_bias: float = 2.0
+
+
+@dataclass
+class VisionTransformerPPOTrainingArgs(TransformerPPOTrainingArgs, VisionArgs):
+    camera_width: Optional[int] = 64
+    camera_height: Optional[int] = 64
+
+
+@dataclass
 class DrQv2TrainingArgs:
     env_id: str = "PickCube-v1"
     num_envs: int = 16

--- a/rl_garden/training/online/_args.py
+++ b/rl_garden/training/online/_args.py
@@ -74,6 +74,30 @@ class VisionRecurrentSACTrainingArgs(RecurrentSACTrainingArgs, VisionArgs):
 
 
 @dataclass
+class TransformerSACTrainingArgs(SACTrainingArgs):
+    embed_dim: int = 256
+    head_dim: int = 64
+    num_heads: int = 4
+    num_transformer_layers: int = 3
+    mlp_num: int = 2
+    memory_len: int = 16
+    dropout_rate: float = 0.0
+    gru_bias: float = 2.0
+    burn_in_len: int = 40
+    learning_len: int = 40
+    forward_len: int = 5
+    prio_exponent: float = 0.9
+    importance_sampling_exponent: float = 0.6
+
+
+@dataclass
+class VisionTransformerSACTrainingArgs(TransformerSACTrainingArgs, VisionArgs):
+    buffer_size: int = 200_000
+    batch_size: int = 512
+    utd: float = 0.25
+
+
+@dataclass
 class PPOTrainingArgs(EnvRunArgs, CheckpointArgs):
     total_timesteps: int = 10_000_000
     num_steps: int = 50

--- a/rl_garden/training/online/_args.py
+++ b/rl_garden/training/online/_args.py
@@ -55,6 +55,25 @@ class VisionSACTrainingArgs(SACTrainingArgs, VisionArgs):
 
 
 @dataclass
+class RecurrentSACTrainingArgs(SACTrainingArgs):
+    rnn_type: Literal["lstm", "gru"] = "lstm"
+    rnn_hidden_size: int = 256
+    rnn_num_layers: int = 1
+    burn_in_len: int = 40
+    learning_len: int = 40
+    forward_len: int = 5
+    prio_exponent: float = 0.9
+    importance_sampling_exponent: float = 0.6
+
+
+@dataclass
+class VisionRecurrentSACTrainingArgs(RecurrentSACTrainingArgs, VisionArgs):
+    buffer_size: int = 200_000
+    batch_size: int = 512
+    utd: float = 0.25
+
+
+@dataclass
 class PPOTrainingArgs(EnvRunArgs, CheckpointArgs):
     total_timesteps: int = 10_000_000
     num_steps: int = 50

--- a/rl_garden/training/online/ppo.py
+++ b/rl_garden/training/online/ppo.py
@@ -30,25 +30,25 @@ def _ppo_env_request(args, run_name):
     )
 
 
-def build_ppo(args, env, eval_env, logger, checkpoint_dir):
-    from rl_garden.algorithms import PPO
+def _ppo_image_kwargs(args, env) -> dict:
     from rl_garden.common.cli_args import (
         image_encoder_factory_from_args,
         image_keys_from_env,
     )
 
-    is_visual = args.obs_mode != "state"
-    image_kwargs: dict = {}
-    if is_visual:
-        factory = image_encoder_factory_from_args(args)
-        image_keys = image_keys_from_env(env, args)
-        image_kwargs = dict(
-            image_keys=image_keys,
-            image_encoder_factory=factory,
-            image_fusion_mode=args.image_fusion_mode,
-        )
+    if args.obs_mode == "state":
+        return {}
+    return dict(
+        image_keys=image_keys_from_env(env, args),
+        image_encoder_factory=image_encoder_factory_from_args(args),
+        image_fusion_mode=args.image_fusion_mode,
+    )
 
-    agent = PPO(
+
+def _ppo_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs: dict) -> dict:
+    """Kwargs shared by ``PPO`` and ``RecurrentPPO`` construction -- everything
+    except the rnn-specific params that only ``RecurrentPPO`` accepts."""
+    return dict(
         env=env,
         eval_env=eval_env,
         num_steps=args.num_steps,
@@ -94,6 +94,13 @@ def build_ppo(args, env, eval_env, logger, checkpoint_dir):
         save_final_checkpoint=args.save_final_checkpoint,
         **image_kwargs,
     )
+
+
+def build_ppo(args, env, eval_env, logger, checkpoint_dir):
+    from rl_garden.algorithms import PPO
+
+    image_kwargs = _ppo_image_kwargs(args, env)
+    agent = PPO(**_ppo_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs))
     if args.load_checkpoint is not None:
         agent.load(args.load_checkpoint, load_replay_buffer=False)
     return agent

--- a/rl_garden/training/online/recurrent_ppo.py
+++ b/rl_garden/training/online/recurrent_ppo.py
@@ -1,0 +1,57 @@
+"""RecurrentPPO run function."""
+from __future__ import annotations
+
+from rl_garden.training.online.ppo import _ppo_common_kwargs, _ppo_env_request, _ppo_image_kwargs
+
+_recurrent_ppo_env_request = _ppo_env_request
+
+
+def build_recurrent_ppo(args, env, eval_env, logger, checkpoint_dir):
+    from rl_garden.algorithms import RecurrentPPO
+
+    image_kwargs = _ppo_image_kwargs(args, env)
+    agent = RecurrentPPO(
+        **_ppo_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs),
+        rnn_type=args.rnn_type,
+        rnn_hidden_size=args.rnn_hidden_size,
+        rnn_num_layers=args.rnn_num_layers,
+    )
+    if args.load_checkpoint is not None:
+        agent.load(args.load_checkpoint, load_replay_buffer=False)
+    return agent
+
+
+def run_recurrent_ppo(args: RecurrentPPOArgs) -> None:
+    from rl_garden.training.online._runner import run_online
+
+    is_visual = args.obs_mode != "state"
+    obs_tag = f"rgbd_{args.encoder}" if is_visual else "state"
+    run_online(
+        args,
+        obs_tag=obs_tag,
+        make_env_request=_recurrent_ppo_env_request,
+        build_agent=build_recurrent_ppo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Args + registration
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass  # noqa: E402
+
+from rl_garden.common.env_args import EnvBackendArgs  # noqa: E402
+from rl_garden.training.online._args import VisionRecurrentPPOTrainingArgs  # noqa: E402
+from rl_garden.training.online._registry import registry  # noqa: E402
+
+
+@dataclass
+class RecurrentPPOArgs(VisionRecurrentPPOTrainingArgs, EnvBackendArgs):
+    """RecurrentPPO — LSTM/GRU latent module between the encoder and actor/critic heads.
+
+    Combine with any encoder via ``--encoder``, e.g. ``recurrent_ppo --encoder resnet10``.
+    Env backend: ``--env_backend maniskill`` (default) or ``--env_backend robotwin``.
+    """
+
+
+registry.register("recurrent_ppo", RecurrentPPOArgs, run_recurrent_ppo)

--- a/rl_garden/training/online/recurrent_sac.py
+++ b/rl_garden/training/online/recurrent_sac.py
@@ -1,0 +1,78 @@
+"""RecurrentSAC run function."""
+from __future__ import annotations
+
+from rl_garden.training.online.sac import _sac_common_kwargs, _sac_env_request
+
+_recurrent_sac_env_request = _sac_env_request
+
+
+def build_recurrent_sac(args, env, eval_env, logger, checkpoint_dir):
+    from rl_garden.algorithms import RecurrentSAC
+    from rl_garden.common.cli_args import image_encoder_factory_from_args, image_keys_from_env
+
+    is_visual = args.obs_mode != "state"
+    image_kwargs: dict = {}
+    if is_visual:
+        image_kwargs = dict(
+            image_keys=image_keys_from_env(env, args),
+            image_encoder_factory=image_encoder_factory_from_args(args),
+            image_fusion_mode=args.image_fusion_mode,
+            enable_stacking=args.frame_stack > 1,
+            image_augmentation=args.image_augmentation,
+            random_shift_pad=args.image_random_shift_pad,
+            image_augmentation_seed=args.seed + 1_000_003,
+            # Deliberately omit vit_sac_kwargs_from_args(...) here -- ViT
+            # token_and_prop layouts are unsupported (RecurrentSAC._build_policy
+            # raises NotImplementedError for structured_feature_config()).
+        )
+
+    agent = RecurrentSAC(
+        **_sac_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs),
+        rnn_type=args.rnn_type,
+        rnn_hidden_size=args.rnn_hidden_size,
+        rnn_num_layers=args.rnn_num_layers,
+        burn_in_len=args.burn_in_len,
+        learning_len=args.learning_len,
+        forward_len=args.forward_len,
+        prio_exponent=args.prio_exponent,
+        importance_sampling_exponent=args.importance_sampling_exponent,
+    )
+    if args.load_checkpoint is not None:
+        agent.load(args.load_checkpoint, load_replay_buffer=False)
+    return agent
+
+
+def run_recurrent_sac(args: "RecurrentSACArgs") -> None:
+    from rl_garden.training.online._runner import run_online
+
+    is_visual = args.obs_mode != "state"
+    obs_tag = f"rgbd_{args.encoder}" if is_visual else "state"
+    run_online(
+        args,
+        obs_tag=obs_tag,
+        make_env_request=_recurrent_sac_env_request,
+        build_agent=build_recurrent_sac,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Args + registration
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass  # noqa: E402
+
+from rl_garden.common.env_args import EnvBackendArgs  # noqa: E402
+from rl_garden.training.online._args import VisionRecurrentSACTrainingArgs  # noqa: E402
+from rl_garden.training.online._registry import registry  # noqa: E402
+
+
+@dataclass
+class RecurrentSACArgs(VisionRecurrentSACTrainingArgs, EnvBackendArgs):
+    """RecurrentSAC — LSTM/GRU latent module + R2D2-style (stored hidden state
+    + burn-in + n-step + priority replay) recurrent buffer.
+
+    Env backend: ``--env_backend maniskill`` (default) or ``--env_backend robotwin``.
+    """
+
+
+registry.register("recurrent_sac", RecurrentSACArgs, run_recurrent_sac)

--- a/rl_garden/training/online/sac.py
+++ b/rl_garden/training/online/sac.py
@@ -31,36 +31,17 @@ def _sac_env_request(args, run_name):
     )
 
 
-def build_sac(args, env, eval_env, logger, checkpoint_dir):
-    from rl_garden.algorithms import SAC
-    from rl_garden.common.cli_args import (
-        image_encoder_factory_from_args,
-        image_keys_from_env,
-        vit_sac_kwargs_from_args,
-    )
+def _sac_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs) -> dict:
+    """Kwargs shared by every SAC-family algorithm built from ``SACTrainingArgs``
+    (plain SAC and RecurrentSAC alike) -- everything except the recurrent-only
+    ``rnn_*``/``burn_in_len``/etc. fields."""
     from rl_garden.training.online._args import sac_initial_training_phase_from_args
 
-    is_visual = args.obs_mode != "state"
     net_arch = {
         "pi": [args.hidden_dim] * args.actor_hidden_layers,
         "qf": [args.hidden_dim] * args.critic_hidden_layers,
     }
-    image_kwargs: dict = {}
-    if is_visual:
-        factory = image_encoder_factory_from_args(args)
-        image_keys = image_keys_from_env(env, args)
-        image_kwargs = dict(
-            image_keys=image_keys,
-            image_encoder_factory=factory,
-            image_fusion_mode=args.image_fusion_mode,
-            enable_stacking=args.frame_stack > 1,
-            image_augmentation=args.image_augmentation,
-            random_shift_pad=args.image_random_shift_pad,
-            image_augmentation_seed=args.seed + 1_000_003,
-            **vit_sac_kwargs_from_args(args, image_keys),
-        )
-
-    agent = SAC(
+    return dict(
         env=env,
         eval_env=eval_env,
         buffer_size=args.buffer_size,
@@ -103,6 +84,33 @@ def build_sac(args, env, eval_env, logger, checkpoint_dir):
         save_final_checkpoint=args.save_final_checkpoint,
         **image_kwargs,
     )
+
+
+def build_sac(args, env, eval_env, logger, checkpoint_dir):
+    from rl_garden.algorithms import SAC
+    from rl_garden.common.cli_args import (
+        image_encoder_factory_from_args,
+        image_keys_from_env,
+        vit_sac_kwargs_from_args,
+    )
+
+    is_visual = args.obs_mode != "state"
+    image_kwargs: dict = {}
+    if is_visual:
+        factory = image_encoder_factory_from_args(args)
+        image_keys = image_keys_from_env(env, args)
+        image_kwargs = dict(
+            image_keys=image_keys,
+            image_encoder_factory=factory,
+            image_fusion_mode=args.image_fusion_mode,
+            enable_stacking=args.frame_stack > 1,
+            image_augmentation=args.image_augmentation,
+            random_shift_pad=args.image_random_shift_pad,
+            image_augmentation_seed=args.seed + 1_000_003,
+            **vit_sac_kwargs_from_args(args, image_keys),
+        )
+
+    agent = SAC(**_sac_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs))
     if args.load_checkpoint is not None:
         agent.load(args.load_checkpoint, load_replay_buffer=args.load_replay_buffer)
     if args.load_actor_checkpoint is not None:

--- a/rl_garden/training/online/td3.py
+++ b/rl_garden/training/online/td3.py
@@ -1,0 +1,225 @@
+"""TD3 run function."""
+from __future__ import annotations
+
+import warnings
+from typing import Literal, Optional
+
+
+def _td3_env_request(args, run_name):
+    from rl_garden.envs.backend_registry import EnvRequest
+
+    backend_config = args.resolve_backend_config()
+    eval_record_dir = (
+        None
+        if args.eval_freq <= 0
+        else args.eval_output_dir
+        or f"{args.log_dir}/{run_name}/eval_videos"
+    )
+    return EnvRequest(
+        env_id=args.env_id,
+        num_envs=args.num_envs,
+        obs_mode=args.obs_mode,
+        control_mode=args.control_mode,
+        render_mode=args.render_mode,
+        seed=args.seed,
+        camera_width=args.camera_width,
+        camera_height=args.camera_height,
+        include_state=args.include_state,
+        per_camera_rgbd=args.per_camera_rgbd,
+        frame_stack=args.frame_stack,
+        num_eval_envs=args.num_eval_envs,
+        eval_record_dir=eval_record_dir,
+        capture_video=args.capture_video,
+        video_fps=args.video_fps,
+        num_eval_steps=args.num_eval_steps,
+        create_eval_env=args.eval_freq > 0,
+        backend_config=backend_config,
+    )
+
+
+def build_td3(args, env, eval_env, logger, checkpoint_dir):
+    from rl_garden.algorithms.td3 import TD3
+    from rl_garden.common.cli_args import image_encoder_factory_from_args
+    from rl_garden.encoders import discover_image_keys
+
+    if args.encoder != "drqv2_conv":
+        warnings.warn(
+            f"TD3's validated default encoder is 'drqv2_conv'; overriding "
+            f"with --encoder {args.encoder!r} deviates from the DrQ-v2 paper "
+            "architecture.",
+            stacklevel=2,
+        )
+    image_keys = discover_image_keys(env.single_observation_space)
+    agent = TD3(
+        env=env,
+        eval_env=eval_env,
+        buffer_size=args.buffer_size,
+        buffer_device=args.buffer_device,
+        mmap_dir=args.mmap_dir,
+        mmap_mode=args.mmap_mode,
+        replay_lazy_next_obs=args.replay_lazy_next_obs,
+        replay_pin_sampled_batch=args.replay_pin_sampled_batch,
+        learning_starts=args.learning_starts,
+        batch_size=args.batch_size,
+        gamma=args.gamma,
+        tau=args.tau,
+        training_freq=args.training_freq,
+        utd=args.utd,
+        policy_lr=args.policy_lr,
+        q_lr=args.q_lr,
+        feature_dim=args.feature_dim,
+        hidden_dim=args.hidden_dim,
+        nstep=args.nstep,
+        stddev_schedule=args.stddev_schedule,
+        stddev_clip=args.stddev_clip,
+        num_expl_steps=args.num_expl_steps,
+        policy_freq=args.policy_freq,
+        target_noise_std=args.target_noise_std,
+        target_noise_clip=args.target_noise_clip,
+        weight_decay=args.weight_decay,
+        use_adamw=args.use_adamw,
+        grad_clip_norm=args.grad_clip_norm,
+        image_keys=image_keys,
+        image_fusion_mode=args.image_fusion_mode,
+        image_augmentation=args.image_augmentation,
+        random_shift_pad=args.image_random_shift_pad,
+        enable_stacking=args.frame_stack > 1,
+        image_encoder_factory=image_encoder_factory_from_args(args),
+        image_augmentation_seed=args.seed + 1_000_003,
+        seed=args.seed,
+        logger=logger,
+        std_log=args.std_log,
+        log_freq=args.log_freq,
+        eval_freq=args.eval_freq,
+        num_eval_steps=args.num_eval_steps,
+        checkpoint_dir=checkpoint_dir,
+        checkpoint_freq=args.checkpoint_freq,
+        save_replay_buffer=args.save_replay_buffer,
+        save_final_checkpoint=args.save_final_checkpoint,
+    )
+    if args.load_checkpoint is not None:
+        agent.load(args.load_checkpoint, load_replay_buffer=args.load_replay_buffer)
+    return agent
+
+
+def run_td3(args: TD3Args) -> None:
+    from rl_garden.training.online._runner import run_online
+
+    if args.mmap_dir is not None and args.load_replay_buffer:
+        raise SystemExit(
+            "--load-replay-buffer is not supported with --mmap-dir; "
+            "use --mmap-mode open to resume the disk-backed buffer"
+        )
+    run_online(
+        args,
+        make_env_request=_td3_env_request,
+        build_agent=build_td3,
+        post_learn=lambda agent: agent.replay_buffer.flush(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Args + registration
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass  # noqa: E402
+
+from rl_garden.common.env_args import EnvBackendArgs  # noqa: E402
+from rl_garden.training.online._registry import registry  # noqa: E402
+
+
+@dataclass
+class TD3Args(EnvBackendArgs):
+    """TD3 with multi-env backend support.
+
+    ManiSkill-specific: ``--maniskill.sim-backend``, ``--maniskill.render-backend``,
+    ``--maniskill.reward-mode``.
+    """
+
+    # --- Env ---
+    env_id: str = "PickCube-v1"
+    num_envs: int = 16
+    num_eval_envs: int = 16
+    obs_mode: str = "rgbd"
+    include_state: bool = True
+    control_mode: str = "pd_ee_delta_pose"
+    camera_width: int = 128
+    camera_height: int = 128
+    render_mode: str = "rgb_array"
+    per_camera_rgbd: bool = False
+
+    # --- Training ---
+    total_timesteps: int = 1_000_000
+    buffer_size: int = 1_000_000
+    buffer_device: str = "cuda"
+    mmap_dir: Optional[str] = None
+    mmap_mode: Literal["create", "open"] = "create"
+    learning_starts: int = 4_000
+    batch_size: int = 256
+    seed: int = 1
+
+    # --- DDPG ---
+    gamma: float = 0.99
+    tau: float = 0.01
+    training_freq: int = 32
+    utd: float = 0.5
+    policy_lr: float = 1e-4
+    q_lr: float = 1e-4
+    feature_dim: int = 50
+    hidden_dim: int = 1024
+    nstep: int = 3
+    stddev_schedule: str = "linear(1.0,0.1,500000)"
+    stddev_clip: float = 0.3
+    num_expl_steps: int = 2000
+    grad_clip_norm: Optional[float] = None
+    weight_decay: float = 0.0
+    use_adamw: bool = False
+
+    # --- TD3 ---
+    policy_freq: int = 2
+    target_noise_std: float = 0.2
+    target_noise_clip: float = 0.5
+
+    # --- Vision ---
+    image_fusion_mode: str = "stack_channels"
+    image_augmentation: str = "random_shift"
+    image_random_shift_pad: int = 4
+    frame_stack: int = 1
+    encoder: Literal["drqv2_conv", "cnn3d"] = "drqv2_conv"
+    encoder_features_dim: int = 256
+    # Unused for drqv2_conv/cnn3d; required attributes for
+    # image_encoder_factory_from_args()'s resnet-only-flag validation.
+    pretrained_weights: Optional[str] = None
+    freeze_resnet_encoder: bool = False
+    freeze_resnet_backbone: bool = False
+
+    # --- Logging ---
+    log_type: str = "wandb"
+    log_dir: str = "runs"
+    exp_name: str = ""
+    wandb_project: str = "rl-garden"
+    wandb_entity: str = ""
+    wandb_group: str = ""
+    log_keywords: str = ""
+    std_log: bool = True
+    log_freq: int = 1_000
+
+    # --- Eval ---
+    eval_freq: int = 10_000
+    num_eval_steps: int = 50
+    capture_video: bool = True
+    eval_output_dir: Optional[str] = None
+    video_fps: int = 30
+
+    # --- Checkpoint ---
+    checkpoint_dir: Optional[str] = None
+    checkpoint_freq: int = 0
+    save_replay_buffer: bool = False
+    save_final_checkpoint: bool = True
+    load_checkpoint: Optional[str] = None
+    load_replay_buffer: bool = False
+    replay_lazy_next_obs: bool = False
+    replay_pin_sampled_batch: bool = False
+
+
+registry.register("td3", TD3Args, run_td3)

--- a/rl_garden/training/online/transformer_ppo.py
+++ b/rl_garden/training/online/transformer_ppo.py
@@ -1,0 +1,62 @@
+"""TransformerPPO run function."""
+from __future__ import annotations
+
+from rl_garden.training.online.ppo import _ppo_common_kwargs, _ppo_env_request, _ppo_image_kwargs
+
+_transformer_ppo_env_request = _ppo_env_request
+
+
+def build_transformer_ppo(args, env, eval_env, logger, checkpoint_dir):
+    from rl_garden.algorithms import TransformerPPO
+
+    image_kwargs = _ppo_image_kwargs(args, env)
+    agent = TransformerPPO(
+        **_ppo_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs),
+        embed_dim=args.embed_dim,
+        head_dim=args.head_dim,
+        num_heads=args.num_heads,
+        num_transformer_layers=args.num_transformer_layers,
+        mlp_num=args.mlp_num,
+        memory_len=args.memory_len,
+        dropout_rate=args.dropout_rate,
+        gru_bias=args.gru_bias,
+    )
+    if args.load_checkpoint is not None:
+        agent.load(args.load_checkpoint, load_replay_buffer=False)
+    return agent
+
+
+def run_transformer_ppo(args: TransformerPPOArgs) -> None:
+    from rl_garden.training.online._runner import run_online
+
+    is_visual = args.obs_mode != "state"
+    obs_tag = f"rgbd_{args.encoder}" if is_visual else "state"
+    run_online(
+        args,
+        obs_tag=obs_tag,
+        make_env_request=_transformer_ppo_env_request,
+        build_agent=build_transformer_ppo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Args + registration
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass  # noqa: E402
+
+from rl_garden.common.env_args import EnvBackendArgs  # noqa: E402
+from rl_garden.training.online._args import VisionTransformerPPOTrainingArgs  # noqa: E402
+from rl_garden.training.online._registry import registry  # noqa: E402
+
+
+@dataclass
+class TransformerPPOArgs(VisionTransformerPPOTrainingArgs, EnvBackendArgs):
+    """TransformerPPO — GTrXL latent module between the encoder and actor/critic heads.
+
+    Combine with any encoder via ``--encoder``, e.g. ``transformer_ppo --encoder resnet10``.
+    Env backend: ``--env_backend maniskill`` (default) or ``--env_backend robotwin``.
+    """
+
+
+registry.register("transformer_ppo", TransformerPPOArgs, run_transformer_ppo)

--- a/rl_garden/training/online/transformer_sac.py
+++ b/rl_garden/training/online/transformer_sac.py
@@ -1,0 +1,83 @@
+"""TransformerSAC run function."""
+from __future__ import annotations
+
+from rl_garden.training.online.sac import _sac_common_kwargs, _sac_env_request
+
+_transformer_sac_env_request = _sac_env_request
+
+
+def build_transformer_sac(args, env, eval_env, logger, checkpoint_dir):
+    from rl_garden.algorithms import TransformerSAC
+    from rl_garden.common.cli_args import image_encoder_factory_from_args, image_keys_from_env
+
+    is_visual = args.obs_mode != "state"
+    image_kwargs: dict = {}
+    if is_visual:
+        image_kwargs = dict(
+            image_keys=image_keys_from_env(env, args),
+            image_encoder_factory=image_encoder_factory_from_args(args),
+            image_fusion_mode=args.image_fusion_mode,
+            enable_stacking=args.frame_stack > 1,
+            image_augmentation=args.image_augmentation,
+            random_shift_pad=args.image_random_shift_pad,
+            image_augmentation_seed=args.seed + 1_000_003,
+            # Deliberately omit vit_sac_kwargs_from_args(...) here -- ViT
+            # token_and_prop layouts are unsupported (SequenceSAC._build_policy
+            # raises NotImplementedError for structured_feature_config()).
+        )
+
+    agent = TransformerSAC(
+        **_sac_common_kwargs(args, env, eval_env, logger, checkpoint_dir, image_kwargs),
+        embed_dim=args.embed_dim,
+        head_dim=args.head_dim,
+        num_heads=args.num_heads,
+        num_transformer_layers=args.num_transformer_layers,
+        mlp_num=args.mlp_num,
+        memory_len=args.memory_len,
+        dropout_rate=args.dropout_rate,
+        gru_bias=args.gru_bias,
+        burn_in_len=args.burn_in_len,
+        learning_len=args.learning_len,
+        forward_len=args.forward_len,
+        prio_exponent=args.prio_exponent,
+        importance_sampling_exponent=args.importance_sampling_exponent,
+    )
+    if args.load_checkpoint is not None:
+        agent.load(args.load_checkpoint, load_replay_buffer=False)
+    return agent
+
+
+def run_transformer_sac(args: "TransformerSACArgs") -> None:
+    from rl_garden.training.online._runner import run_online
+
+    is_visual = args.obs_mode != "state"
+    obs_tag = f"rgbd_{args.encoder}" if is_visual else "state"
+    run_online(
+        args,
+        obs_tag=obs_tag,
+        make_env_request=_transformer_sac_env_request,
+        build_agent=build_transformer_sac,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Args + registration
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass  # noqa: E402
+
+from rl_garden.common.env_args import EnvBackendArgs  # noqa: E402
+from rl_garden.training.online._args import VisionTransformerSACTrainingArgs  # noqa: E402
+from rl_garden.training.online._registry import registry  # noqa: E402
+
+
+@dataclass
+class TransformerSACArgs(VisionTransformerSACTrainingArgs, EnvBackendArgs):
+    """TransformerSAC — GTrXL latent module + dense (not checkpoint-aligned),
+    burn-in-from-zero priority replay buffer.
+
+    Env backend: ``--env_backend maniskill`` (default) or ``--env_backend robotwin``.
+    """
+
+
+registry.register("transformer_sac", TransformerSACArgs, run_transformer_sac)

--- a/tests/test_gtrxl.py
+++ b/tests/test_gtrxl.py
@@ -57,14 +57,16 @@ def test_index_state_selects_envs():
     assert memory_valid.shape == (1, 2, 4)
 
 
-def test_burn_in_not_implemented():
+def test_forward_sequence_with_burn_in_output_shape():
     enc = _make_encoder()
     state = enc.get_initial_state(2, torch.device("cpu"))
-    try:
-        enc.forward_sequence_with_burn_in(torch.randn(3, 2, 8), state, torch.zeros(3, 2), burn_in_len=1)
-        assert False, "expected NotImplementedError"
-    except NotImplementedError:
-        pass
+    tail_out, tail_state = enc.forward_sequence_with_burn_in(
+        torch.randn(3, 2, 8), state, torch.zeros(3, 2), burn_in_len=1
+    )
+    assert tail_out.shape == (2, 2, 16)  # (tail_len=3-1, B, embed_dim)
+    memory, memory_valid = tail_state
+    assert memory.shape == (3, 2, 4, 16)
+    assert memory_valid.shape == (1, 2, 4)
 
 
 def test_gradient_isolated_at_segment_boundary_but_flows_within_window():
@@ -161,3 +163,85 @@ def test_rejects_odd_embed_dim():
         assert False, "expected ValueError"
     except ValueError:
         pass
+
+
+def test_burn_in_reconstruction_error_decreases_with_burn_in_len_and_vanishes_at_num_layers_times_memory_len():
+    """GTrXL memory is a bounded sliding window (unlike RNN's compressed
+    state), so zero-init + burn-in exactly reconstructs layer 0's memory once
+    burn_in_len >= memory_len, but deeper layers compound (Transformer-XL's
+    depth x segment-length property, Dai et al. 2019): layer i needs
+    burn_in_len >= (i+1)*memory_len to be exact. This test is discriminating --
+    asserting EXACT equality at burn_in_len == memory_len would fail for the
+    2-layer encoder used here, which is exactly the incorrect claim this test
+    replaces (an earlier draft assumed burn_in_len >= memory_len alone was
+    sufficient for exact reconstruction at any depth)."""
+    torch.manual_seed(7)
+    enc = _make_encoder()  # num_layers=2, memory_len=4
+    enc.eval()
+    B = 2
+    target = 12
+    T = target + 1
+    latents = torch.randn(T, B, 8)
+    episode_starts = torch.zeros(T, B)
+
+    with torch.no_grad():
+        true_state = enc.get_initial_state(B, torch.device("cpu"))
+        true_out = None
+        for t in range(T):
+            true_out, true_state = enc.step(latents[t], true_state, episode_starts[t])
+        true_output_at_target = true_out
+
+    def reconstruction_error(burn_in_len: int) -> float:
+        t0 = target - burn_in_len
+        window_latents = latents[t0 : target + 1]
+        window_starts = episode_starts[t0 : target + 1]
+        state0 = enc.get_initial_state(B, torch.device("cpu"))
+        with torch.no_grad():
+            tail_out, _ = enc.forward_sequence_with_burn_in(
+                window_latents, state0, window_starts, burn_in_len
+            )
+        return (tail_out[0] - true_output_at_target).abs().max().item()
+
+    error_1x = reconstruction_error(4)  # burn_in_len == memory_len: only layer 0 exact
+    error_1_5x = reconstruction_error(6)
+    error_2x = reconstruction_error(8)  # burn_in_len == num_layers * memory_len: both layers exact
+
+    assert error_1x > 1e-4, (
+        "expected a real reconstruction gap at burn_in_len == memory_len for a "
+        "2-layer encoder -- if this is ~0, the depth-compounding property this "
+        "test checks for isn't being exercised"
+    )
+    assert error_1_5x < error_1x
+    assert error_2x < error_1_5x
+    assert error_2x < 1e-5, "expected near-exact reconstruction at burn_in_len == num_layers * memory_len"
+
+
+def test_burn_in_crossing_episode_boundary_ignores_pre_boundary_latents():
+    """A burn-in window that crosses an episode boundary must produce a
+    post-boundary tail output independent of what happened before the
+    boundary -- new logic neither reference implementation provides, exercised
+    specifically through forward_sequence_with_burn_in (the replay-training
+    code path), complementing test_episode_reset_blocks_information_flow
+    (which only covers forward_sequence)."""
+    torch.manual_seed(11)
+    enc = _make_encoder()
+    enc.eval()
+    B = 1
+    burn_in_len = 6
+    tail_len = 1
+    T = burn_in_len + tail_len
+    boundary = 3  # episode reset partway through the burn-in window
+
+    latents_a = torch.randn(T, B, 8)
+    latents_b = latents_a.clone()
+    latents_b[:boundary] = torch.randn(boundary, B, 8)  # differ only BEFORE the reset
+
+    episode_starts = torch.zeros(T, B)
+    episode_starts[boundary, 0] = 1.0
+
+    state0 = enc.get_initial_state(B, torch.device("cpu"))
+    with torch.no_grad():
+        out_a, _ = enc.forward_sequence_with_burn_in(latents_a, state0, episode_starts, burn_in_len)
+        out_b, _ = enc.forward_sequence_with_burn_in(latents_b, state0, episode_starts, burn_in_len)
+
+    assert torch.allclose(out_a, out_b, atol=1e-6)

--- a/tests/test_gtrxl.py
+++ b/tests/test_gtrxl.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import torch
+
+from rl_garden.networks.gtrxl import GTrXLLatentEncoder
+
+
+def _make_encoder(**overrides) -> GTrXLLatentEncoder:
+    kwargs = dict(input_dim=8, embed_dim=16, head_dim=8, num_heads=2, num_layers=2, memory_len=4)
+    kwargs.update(overrides)
+    return GTrXLLatentEncoder(**kwargs)
+
+
+def test_get_initial_state_shapes():
+    enc = _make_encoder()
+    memory, memory_valid = enc.get_initial_state(batch_size=3, device=torch.device("cpu"))
+    assert memory.shape == (3, 3, 4, 16)  # (num_layers+1, B, memory_len, embed_dim)
+    assert memory_valid.shape == (1, 3, 4)
+    assert torch.all(memory_valid == 0)
+
+
+def test_step_output_and_state_shapes():
+    enc = _make_encoder()
+    state = enc.get_initial_state(3, torch.device("cpu"))
+    out, (memory, memory_valid) = enc.step(torch.randn(3, 8), state, torch.zeros(3))
+    assert out.shape == (3, 16)
+    assert memory.shape == (3, 3, 4, 16)
+    assert memory_valid.shape == (1, 3, 4)
+    # FIFO: the just-added slot (last one) is valid for every env.
+    assert torch.all(memory_valid[0, :, -1] == 1)
+
+
+def test_forward_sequence_output_shape():
+    enc = _make_encoder()
+    state = enc.get_initial_state(3, torch.device("cpu"))
+    out, _ = enc.forward_sequence(torch.randn(5, 3, 8), state, torch.zeros(5, 3))
+    assert out.shape == (5, 3, 16)
+
+
+def test_mask_state_zeroes_selected_envs_only():
+    enc = _make_encoder()
+    state = enc.get_initial_state(3, torch.device("cpu"))
+    _, state = enc.step(torch.randn(3, 8), state, torch.zeros(3))
+    keep = torch.tensor([1.0, 0.0, 1.0])
+    memory, memory_valid = enc.mask_state(state, keep)
+    assert torch.all(memory[:, 1] == 0)
+    assert torch.all(memory_valid[:, 1] == 0)
+    assert torch.any(memory[:, 0] != 0) or torch.any(memory_valid[:, 0] != 0)
+
+
+def test_index_state_selects_envs():
+    enc = _make_encoder()
+    state = enc.get_initial_state(4, torch.device("cpu"))
+    _, state = enc.step(torch.randn(4, 8), state, torch.zeros(4))
+    memory, memory_valid = enc.index_state(state, torch.tensor([0, 2]))
+    assert memory.shape == (3, 2, 4, 16)
+    assert memory_valid.shape == (1, 2, 4)
+
+
+def test_burn_in_not_implemented():
+    enc = _make_encoder()
+    state = enc.get_initial_state(2, torch.device("cpu"))
+    try:
+        enc.forward_sequence_with_burn_in(torch.randn(3, 2, 8), state, torch.zeros(3, 2), burn_in_len=1)
+        assert False, "expected NotImplementedError"
+    except NotImplementedError:
+        pass
+
+
+def test_gradient_isolated_at_segment_boundary_but_flows_within_window():
+    """Core correctness property (advisor-flagged fix): the seed state at a
+    window's start carries no gradient (it comes from a no_grad rollout, exactly
+    like RecurrentPPO's initial_hidden), but gradient DOES flow across timesteps
+    within the training window -- step()/forward_sequence() must never detach
+    internally, or BPTT would be confined to a single step."""
+    torch.manual_seed(0)
+    enc = _make_encoder()
+    B = 2
+    with torch.no_grad():
+        state = enc.get_initial_state(B, torch.device("cpu"))
+        warmup = torch.randn(3, B, 8)
+        _, state = enc.forward_sequence(warmup, state, torch.zeros(3, B))
+    seed_memory, _ = state
+    assert not seed_memory.requires_grad
+
+    latent = torch.randn(4, B, 8, requires_grad=True)
+    out, _ = enc.forward_sequence(latent, state, torch.zeros(4, B))
+    out.sum().backward()
+    assert latent.grad is not None
+    assert all((latent.grad[t].abs().sum() > 0).item() for t in range(4))
+
+
+def test_gradient_flows_across_steps_through_memory():
+    """Discriminates the fix from the original bug in a way the previous test
+    does not: ``out[t]`` always gets gradient from ``latent[t]`` via its own
+    step's direct forward, regardless of whether memory is detached -- that
+    alone doesn't prove cross-step BPTT works. The real test is whether a
+    LATER step's output has gradient w.r.t. an EARLIER step's input, which can
+    only happen through the memory path."""
+    torch.manual_seed(3)
+    enc = _make_encoder()  # memory_len=4
+    B = 2
+    state = enc.get_initial_state(B, torch.device("cpu"))
+
+    T = 4
+    latent = torch.randn(T, B, 8, requires_grad=True)
+    out, _ = enc.forward_sequence(latent, state, torch.zeros(T, B))
+    grad = torch.autograd.grad(out[-1].sum(), latent)[0]
+    assert grad[0].abs().sum() > 0, "no gradient from the last step back to the first -- memory is detached"
+
+
+def test_episode_reset_blocks_information_flow():
+    """New logic neither reference implementation has: post-reset output must
+    be completely independent of pre-reset latent history."""
+    torch.manual_seed(1)
+    enc = _make_encoder()
+    enc.eval()
+    state = enc.get_initial_state(1, torch.device("cpu"))
+    T = 6
+    latent_a = torch.randn(T, 1, 8)
+    latent_b = latent_a.clone()
+    latent_b[:3] = torch.randn(3, 1, 8)
+    episode_starts = torch.zeros(T, 1)
+    episode_starts[3, 0] = 1.0
+
+    with torch.no_grad():
+        out_a, _ = enc.forward_sequence(latent_a, state, episode_starts)
+        out_b, _ = enc.forward_sequence(latent_b, state, episode_starts)
+
+    assert torch.allclose(out_a[3:], out_b[3:], atol=1e-6)
+    assert not torch.allclose(out_a[:3], out_b[:3], atol=1e-6)
+
+
+def test_encoder_is_a_pure_function_of_explicit_state():
+    """Relative (not absolute) positional encoding means step() must be a pure
+    function of (latent, state, episode_starts) -- identical (memory,
+    memory_valid) content must give identical output regardless of how many
+    prior step() calls produced it (no hidden internal time counter)."""
+    torch.manual_seed(2)
+    enc = _make_encoder()
+    enc.eval()
+    memory_content = torch.randn(3, 1, 4, 16)
+    valid = torch.ones(1, 1, 4)
+
+    state_direct = (memory_content.clone(), valid.clone())
+    state_via_many_calls = enc.get_initial_state(1, torch.device("cpu"))
+    for _ in range(37):
+        _, state_via_many_calls = enc.step(torch.randn(1, 8), state_via_many_calls, torch.zeros(1))
+    state_via_many_calls = (memory_content.clone(), valid.clone())
+
+    final_latent = torch.randn(1, 8)
+    with torch.no_grad():
+        out_direct, _ = enc.step(final_latent, state_direct, torch.zeros(1))
+        out_via_many, _ = enc.step(final_latent, state_via_many_calls, torch.zeros(1))
+    assert torch.allclose(out_direct, out_via_many, atol=1e-6)
+
+
+def test_rejects_odd_embed_dim():
+    try:
+        _make_encoder(embed_dim=15)
+        assert False, "expected ValueError"
+    except ValueError:
+        pass

--- a/tests/test_recurrent_latent_encoder.py
+++ b/tests/test_recurrent_latent_encoder.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from rl_garden.networks.recurrent import RecurrentLatentEncoder
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_get_initial_state_shapes(rnn_type):
+    enc = RecurrentLatentEncoder(input_dim=4, hidden_size=8, rnn_type=rnn_type, num_layers=2)
+    state = enc.get_initial_state(batch_size=3, device=torch.device("cpu"))
+    if rnn_type == "lstm":
+        h, c = state
+        assert h.shape == (2, 3, 8)
+        assert c.shape == (2, 3, 8)
+    else:
+        assert state.shape == (2, 3, 8)
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_step_output_shape(rnn_type):
+    enc = RecurrentLatentEncoder(input_dim=4, hidden_size=6, rnn_type=rnn_type)
+    state = enc.get_initial_state(3, torch.device("cpu"))
+    out, new_state = enc.step(torch.randn(3, 4), state)
+    assert out.shape == (3, 6)
+    if rnn_type == "lstm":
+        assert new_state[0].shape == (1, 3, 6)
+        assert new_state[1].shape == (1, 3, 6)
+    else:
+        assert new_state.shape == (1, 3, 6)
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_forward_sequence_output_shape(rnn_type):
+    enc = RecurrentLatentEncoder(input_dim=4, hidden_size=6, rnn_type=rnn_type)
+    state = enc.get_initial_state(3, torch.device("cpu"))
+    out, _ = enc.forward_sequence(torch.randn(5, 3, 4), state)
+    assert out.shape == (5, 3, 6)
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_step_by_step_matches_forward_sequence_with_reset(rnn_type):
+    """Core correctness property: forward_sequence() must be equivalent to
+    manually looping step() with the same per-timestep episode_starts, including
+    across a real mid-sequence reset for one env in the batch."""
+    torch.manual_seed(0)
+    enc = RecurrentLatentEncoder(input_dim=4, hidden_size=5, rnn_type=rnn_type, num_layers=2)
+    state = enc.get_initial_state(2, torch.device("cpu"))
+
+    latent = torch.randn(5, 2, 4)
+    episode_starts = torch.zeros(5, 2)
+    episode_starts[2, 0] = 1.0  # env 0 resets mid-sequence; env 1 never resets
+
+    out_seq, final_state_seq = enc.forward_sequence(latent, state, episode_starts)
+
+    manual_state = state
+    manual_outs = []
+    for t in range(5):
+        out_t, manual_state = enc.step(latent[t], manual_state, episode_starts[t])
+        manual_outs.append(out_t)
+    manual_out = torch.stack(manual_outs, dim=0)
+
+    assert torch.allclose(out_seq, manual_out)
+    if rnn_type == "lstm":
+        assert torch.allclose(final_state_seq[0], manual_state[0])
+        assert torch.allclose(final_state_seq[1], manual_state[1])
+    else:
+        assert torch.allclose(final_state_seq, manual_state)
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_gradient_flows_to_all_timesteps(rnn_type):
+    enc = RecurrentLatentEncoder(input_dim=3, hidden_size=4, rnn_type=rnn_type)
+    state = enc.get_initial_state(2, torch.device("cpu"))
+    latent = torch.randn(6, 2, 3, requires_grad=True)
+
+    out, _ = enc.forward_sequence(latent, state)
+    out.sum().backward()
+
+    assert latent.grad is not None
+    for t in range(6):
+        assert bool((latent.grad[t].abs().sum() > 0).item()), f"timestep {t} has zero grad"
+
+
+def test_mask_state_zeros_reset_envs_only():
+    h = torch.arange(1, 1 + 1 * 3 * 2, dtype=torch.float32).reshape(1, 3, 2)
+    keep_mask = torch.tensor([1.0, 0.0, 1.0])
+    masked = RecurrentLatentEncoder.mask_state(h, keep_mask)
+    assert torch.all(masked[:, 0] == h[:, 0])
+    assert torch.all(masked[:, 1] == 0)
+    assert torch.all(masked[:, 2] == h[:, 2])
+
+
+def test_mask_state_lstm_tuple():
+    h = torch.ones(1, 2, 3)
+    c = torch.ones(1, 2, 3) * 2
+    keep_mask = torch.tensor([0.0, 1.0])
+    masked_h, masked_c = RecurrentLatentEncoder.mask_state((h, c), keep_mask)
+    assert torch.all(masked_h[:, 0] == 0)
+    assert torch.all(masked_c[:, 0] == 0)
+    assert torch.all(masked_h[:, 1] == 1)
+    assert torch.all(masked_c[:, 1] == 2)
+
+
+def test_index_state_selects_correct_batch_rows():
+    h = torch.arange(1, 1 + 1 * 4 * 2, dtype=torch.float32).reshape(1, 4, 2)
+    indices = torch.tensor([0, 2])
+    indexed = RecurrentLatentEncoder.index_state(h, indices)
+    assert indexed.shape == (1, 2, 2)
+    assert torch.equal(indexed[:, 0], h[:, 0])
+    assert torch.equal(indexed[:, 1], h[:, 2])
+
+
+def test_forward_dispatches_on_ndim():
+    enc = RecurrentLatentEncoder(input_dim=3, hidden_size=4)
+    state = enc.get_initial_state(2, torch.device("cpu"))
+    out_step, _ = enc.forward(torch.randn(2, 3), state)
+    assert out_step.shape == (2, 4)
+    out_seq, _ = enc.forward(torch.randn(5, 2, 3), state)
+    assert out_seq.shape == (5, 2, 4)
+    with pytest.raises(ValueError):
+        enc.forward(torch.randn(2, 3, 4, 5), state)

--- a/tests/test_recurrent_latent_encoder.py
+++ b/tests/test_recurrent_latent_encoder.py
@@ -112,6 +112,64 @@ def test_index_state_selects_correct_batch_rows():
     assert torch.equal(indexed[:, 1], h[:, 2])
 
 
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_forward_sequence_with_burn_in_tail_matches_manual_slice(rnn_type):
+    """Functional equivalence: with gradients enabled throughout, the tail output
+    of forward_sequence_with_burn_in must equal slicing a full forward_sequence()
+    call at [burn_in_len:], given the same initial state."""
+    torch.manual_seed(0)
+    enc = RecurrentLatentEncoder(input_dim=4, hidden_size=5, rnn_type=rnn_type, num_layers=2)
+    state = enc.get_initial_state(3, torch.device("cpu"))
+
+    burn_in_len = 2
+    latent = torch.randn(7, 3, 4)
+    episode_starts = torch.zeros(7, 3)
+    episode_starts[4, 1] = 1.0  # mid-sequence reset in the tail portion
+
+    full_out, full_state = enc.forward_sequence(latent, state, episode_starts)
+    tail_out, tail_state = enc.forward_sequence_with_burn_in(
+        latent, state, episode_starts, burn_in_len
+    )
+
+    assert torch.allclose(tail_out, full_out[burn_in_len:])
+    if rnn_type == "lstm":
+        assert torch.allclose(tail_state[0], full_state[0])
+        assert torch.allclose(tail_state[1], full_state[1])
+    else:
+        assert torch.allclose(tail_state, full_state)
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_forward_sequence_with_burn_in_isolates_gradient(rnn_type):
+    """Burn-in must carry no gradient; the tail must remain fully differentiable."""
+    enc = RecurrentLatentEncoder(input_dim=3, hidden_size=4, rnn_type=rnn_type)
+    state = enc.get_initial_state(2, torch.device("cpu"))
+
+    burn_in_len = 3
+    latent = torch.randn(6, 2, 3, requires_grad=True)
+    episode_starts = torch.zeros(6, 2)
+
+    tail_out, tail_state = enc.forward_sequence_with_burn_in(
+        latent, state, episode_starts, burn_in_len
+    )
+
+    assert tail_out.requires_grad
+    if rnn_type == "lstm":
+        assert tail_state[0].requires_grad
+        assert tail_state[1].requires_grad
+    else:
+        assert tail_state.requires_grad
+
+    tail_out.sum().backward()
+    assert latent.grad is not None
+    # No gradient should reach the burn-in-only prefix positions.
+    for t in range(burn_in_len):
+        assert bool((latent.grad[t].abs().sum() == 0).item()), f"burn-in timestep {t} has nonzero grad"
+    # Every tail position must receive gradient.
+    for t in range(burn_in_len, 6):
+        assert bool((latent.grad[t].abs().sum() > 0).item()), f"tail timestep {t} has zero grad"
+
+
 def test_forward_dispatches_on_ndim():
     enc = RecurrentLatentEncoder(input_dim=3, hidden_size=4)
     state = enc.get_initial_state(2, torch.device("cpu"))

--- a/tests/test_recurrent_ppo.py
+++ b/tests/test_recurrent_ppo.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.algorithms import RecurrentPPO
+from rl_garden.buffers.recurrent_rollout_buffer import RecurrentRolloutBuffer
+
+
+class DummyVecEnv:
+    def __init__(
+        self, observation_space: spaces.Space, action_space: spaces.Box
+    ) -> None:
+        self.num_envs = 2
+        self.single_observation_space = observation_space
+        self.single_action_space = action_space
+        self.action_space = spaces.Box(
+            low=np.broadcast_to(
+                action_space.low, (self.num_envs,) + action_space.shape
+            ),
+            high=np.broadcast_to(
+                action_space.high, (self.num_envs,) + action_space.shape
+            ),
+            dtype=action_space.dtype,
+        )
+        self._step = 0
+
+    def reset(self, seed: int | None = None):
+        del seed
+        self._step = 0
+        return self._obs(), {}
+
+    def step(self, actions):
+        assert torch.all(actions <= 1.0)
+        assert torch.all(actions >= -1.0)
+        self._step += 1
+        obs = self._obs()
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        return obs, rewards, terminations, truncations, {}
+
+    def close(self) -> None:
+        return None
+
+    def _obs(self):
+        if isinstance(self.single_observation_space, spaces.Dict):
+            return {
+                "rgb": torch.randint(
+                    0, 256, (self.num_envs, 64, 64, 3), dtype=torch.uint8
+                ),
+                "state": torch.randn(self.num_envs, 4),
+            }
+        return torch.randn(self.num_envs, *self.single_observation_space.shape)
+
+
+def _state_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+
+
+def _dict_space() -> spaces.Dict:
+    return spaces.Dict(
+        {
+            "rgb": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "state": spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32),
+        }
+    )
+
+
+def _action_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+def _ppo_kwargs() -> dict[str, object]:
+    return {
+        "device": "cpu",
+        "num_steps": 2,
+        "num_minibatches": 1,
+        "update_epochs": 1,
+        "eval_freq": 0,
+        "log_freq": 0,
+        "target_kl": None,
+        "net_arch": [16],
+    }
+
+
+class RecurrentDoneVecEnv:
+    """Like DummyVecEnv, but env 0 terminates at a chosen global step and reports
+    ``final_observation``, so tests can exercise the recurrent bootstrap-value and
+    window-boundary hidden-state-reset paths that never fire with DummyVecEnv."""
+
+    def __init__(
+        self, observation_space: spaces.Space, action_space: spaces.Box, done_at_step: int
+    ) -> None:
+        self.num_envs = 2
+        self.single_observation_space = observation_space
+        self.single_action_space = action_space
+        self.action_space = spaces.Box(
+            low=np.broadcast_to(action_space.low, (self.num_envs,) + action_space.shape),
+            high=np.broadcast_to(action_space.high, (self.num_envs,) + action_space.shape),
+            dtype=action_space.dtype,
+        )
+        self._step = 0
+        self._done_at_step = done_at_step
+
+    def reset(self, seed: int | None = None):
+        del seed
+        self._step = 0
+        return self._obs(), {}
+
+    def step(self, actions):
+        self._step += 1
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        infos: dict = {}
+        if self._step == self._done_at_step:
+            terminations[0] = True
+            infos["final_observation"] = self._obs()  # true terminal obs for env 0
+        obs = self._obs()  # gymnasium autoreset convention: next obs is already reset
+        return obs, rewards, terminations, truncations, infos
+
+    def close(self) -> None:
+        return None
+
+    def _obs(self):
+        return torch.randn(self.num_envs, *self.single_observation_space.shape)
+
+
+def _capture_train_losses(agent):
+    captured: list[dict] = []
+    original_train = agent.train
+
+    def _wrapped():
+        result = original_train()
+        captured.append(result)
+        return result
+
+    agent.train = _wrapped
+    return captured
+
+
+def test_recurrent_rollout_buffer_preserves_time_order_and_env_axis():
+    buffer = RecurrentRolloutBuffer(
+        _state_space(), _action_space(), num_steps=4, num_envs=4, device="cpu"
+    )
+    for t in range(4):
+        obs = torch.stack(
+            [torch.full((4,), t * 100.0 + n) for n in range(4)], dim=0
+        )
+        buffer.add(
+            obs,
+            torch.zeros(4, 2),
+            torch.zeros(4),
+            torch.zeros(4),
+            torch.zeros(4, 1),
+            torch.zeros(4, 1),
+        )
+    buffer.compute_returns_and_advantage(torch.zeros(4), torch.zeros(4))
+
+    initial_hidden = torch.zeros(1, 4, 3)
+    seen_envs: set[int] = set()
+    for mb in buffer.get_sequences(num_minibatches=2, initial_hidden=initial_hidden, shuffle=False):
+        assert mb.obs.shape == (4, 2, 4)
+        assert mb.initial_hidden.shape == (1, 2, 3)
+        for col in range(mb.obs.shape[1]):
+            marker = mb.obs[0, col, 0].item()
+            env_id = int(round(marker)) % 100
+            seen_envs.add(env_id)
+            for t in range(4):
+                assert mb.obs[t, col, 0].item() == pytest.approx(t * 100.0 + env_id)
+    assert seen_envs == {0, 1, 2, 3}
+
+
+def test_recurrent_rollout_buffer_episode_starts_shift():
+    buffer = RecurrentRolloutBuffer(
+        _state_space(), _action_space(), num_steps=5, num_envs=2, device="cpu"
+    )
+    for t in range(5):
+        dones = torch.zeros(2)
+        if t == 2:
+            dones[0] = 1.0  # env 0's episode ends as a result of acting on obs[2]
+        buffer.add(
+            torch.zeros(2, 4),
+            torch.zeros(2, 2),
+            torch.zeros(2),
+            dones,
+            torch.zeros(2, 1),
+            torch.zeros(2, 1),
+        )
+    buffer.compute_returns_and_advantage(torch.zeros(2), torch.zeros(2))
+
+    initial_hidden = torch.zeros(1, 2, 3)
+    mb = next(buffer.get_sequences(num_minibatches=1, initial_hidden=initial_hidden, shuffle=False))
+    assert mb.episode_starts[:, 0].tolist() == [0.0, 0.0, 0.0, 1.0, 0.0]
+    assert mb.episode_starts[:, 1].tolist() == [0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def test_recurrent_rollout_buffer_get_sequences_requires_divisible_num_envs():
+    buffer = RecurrentRolloutBuffer(
+        _state_space(), _action_space(), num_steps=2, num_envs=3, device="cpu"
+    )
+    for _ in range(2):
+        buffer.add(
+            torch.zeros(3, 4),
+            torch.zeros(3, 2),
+            torch.zeros(3),
+            torch.zeros(3),
+            torch.zeros(3, 1),
+            torch.zeros(3, 1),
+        )
+    buffer.compute_returns_and_advantage(torch.zeros(3), torch.zeros(3))
+    with pytest.raises(ValueError):
+        next(buffer.get_sequences(num_minibatches=2, initial_hidden=torch.zeros(1, 3, 3)))
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_recurrent_ppo_learn_one_iteration_state(rnn_type):
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = RecurrentPPO(
+        env=env,
+        **_ppo_kwargs(),
+        rnn_type=rnn_type,
+        rnn_hidden_size=8,
+    )
+    captured = _capture_train_losses(agent)
+
+    agent.learn(total_timesteps=4)
+
+    assert agent._global_step == 4
+    assert agent._global_update == 1
+    assert agent.policy.recurrent_encoder is not None
+    assert len(captured) == 1
+    assert torch.isfinite(torch.tensor(captured[0]["loss"]))
+    assert torch.isfinite(torch.tensor(captured[0]["value_loss"]))
+
+
+def test_recurrent_ppo_handles_episode_termination_across_windows():
+    # num_steps=2, num_envs=2 (from _ppo_kwargs()) => batch_size=4, so
+    # total_timesteps=8 spans 2 rollout windows. env 0 terminates on the LAST
+    # step of the first window, exercising both the non-early-return branch of
+    # _compute_final_values (bootstrap value for a just-finished episode) and
+    # window_initial_hidden's reset-mask at the start of window 2.
+    env = RecurrentDoneVecEnv(_state_space(), _action_space(), done_at_step=2)
+    agent = RecurrentPPO(env=env, **_ppo_kwargs(), rnn_hidden_size=8)
+    captured = _capture_train_losses(agent)
+
+    agent.learn(total_timesteps=8)  # 2 rollout windows of num_steps=2
+
+    assert agent._global_step == 8
+    assert agent._global_update == 2
+    assert len(captured) == 2
+    for losses in captured:
+        assert torch.isfinite(torch.tensor(losses["loss"]))
+        assert torch.isfinite(torch.tensor(losses["value_loss"]))
+    assert torch.isfinite(agent.rollout_buffer.values).all()
+
+
+def test_recurrent_ppo_dict_obs_smoke():
+    env = DummyVecEnv(_dict_space(), _action_space())
+    agent = RecurrentPPO(
+        env=env,
+        **_ppo_kwargs(),
+        image_keys=("rgb",),
+        rnn_hidden_size=8,
+    )
+    captured = _capture_train_losses(agent)
+
+    agent.learn(total_timesteps=4)
+
+    assert agent._global_step == 4
+    assert torch.isfinite(torch.tensor(captured[0]["loss"]))
+
+
+def test_recurrent_ppo_checkpoint_roundtrip(tmp_path):
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = RecurrentPPO(env=env, **_ppo_kwargs(), rnn_hidden_size=8)
+    agent.learn(total_timesteps=4)
+    path = tmp_path / "recurrent_ppo.pt"
+    agent.save(path)
+
+    loaded = RecurrentPPO(
+        env=DummyVecEnv(_state_space(), _action_space()),
+        **_ppo_kwargs(),
+        rnn_hidden_size=8,
+    )
+    loaded.load(path)
+
+    assert loaded._global_step == agent._global_step
+    for key, value in agent.policy.state_dict().items():
+        assert torch.equal(value, loaded.policy.state_dict()[key]), key

--- a/tests/test_recurrent_replay_buffer.py
+++ b/tests/test_recurrent_replay_buffer.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.buffers.recurrent_replay_buffer import RecurrentReplayBuffer
+from rl_garden.common.obs_utils import index_obs
+
+
+def _obs_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+
+
+def _action_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+def _make_buffer(
+    num_envs=1,
+    per_env_buffer_size=8,
+    burn_in_len=2,
+    learning_len=2,
+    forward_len=1,
+    rnn_type="lstm",
+    hidden_size=3,
+    num_layers=1,
+    gamma=1.0,
+) -> RecurrentReplayBuffer:
+    return RecurrentReplayBuffer(
+        _obs_space(),
+        _action_space(),
+        num_envs,
+        per_env_buffer_size * num_envs,
+        burn_in_len=burn_in_len,
+        learning_len=learning_len,
+        forward_len=forward_len,
+        rnn_type=rnn_type,
+        rnn_hidden_size=hidden_size,
+        rnn_num_layers=num_layers,
+        gamma=gamma,
+        storage_device="cpu",
+        sample_device="cpu",
+    )
+
+
+def _hidden(value: float, num_layers: int, num_envs: int, hidden_size: int) -> torch.Tensor:
+    return torch.full((num_layers, num_envs, hidden_size), float(value))
+
+
+def _add_step(
+    buf: RecurrentReplayBuffer,
+    t: int,
+    *,
+    done=None,
+    episode_end=None,
+    reward=None,
+    num_layers=1,
+    hidden_size=3,
+):
+    num_envs = buf.num_envs
+    obs = torch.full((num_envs, 4), float(t))
+    action = torch.zeros(num_envs, 2)
+    reward = torch.zeros(num_envs) if reward is None else reward
+    done = torch.zeros(num_envs) if done is None else done
+    episode_end = torch.zeros(num_envs) if episode_end is None else episode_end
+    if buf._has_cell_state:
+        hidden = (
+            _hidden(t, num_layers, num_envs, hidden_size),
+            _hidden(t + 1000, num_layers, num_envs, hidden_size),
+        )
+    else:
+        hidden = _hidden(t, num_layers, num_envs, hidden_size)
+    buf.add(obs, obs, action, reward, done, episode_end, hidden)
+
+
+def test_checkpoint_writes_only_at_stride_multiples():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(8):
+        _add_step(buf, t)
+
+    assert buf._current_ckpt_pos[0].item() == 4
+    for slot, expected_pos in enumerate([0, 2, 4, 6]):
+        assert buf._ckpt_slot_to_pos[slot, 0].item() == expected_pos
+        assert torch.allclose(buf.hidden_checkpoints_h[slot, 0], torch.full((1, 3), float(expected_pos)))
+        assert torch.allclose(
+            buf.hidden_checkpoints_c[slot, 0], torch.full((1, 3), float(expected_pos + 1000))
+        )
+
+
+def test_checkpoint_relative_to_episode_start_not_buffer_position():
+    """An episode ending mid-grid must reset the checkpoint cadence, not just
+    the buffer's absolute position."""
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1)
+    # Episode 0: steps 0,1,2 (ends at step 2 -- episode_end=True at pos=2).
+    _add_step(buf, 0)
+    _add_step(buf, 1)
+    _add_step(buf, 2, episode_end=torch.ones(1))
+    # Episode 1 starts at pos=3 with ep_relative_step=0 -- a fresh checkpoint.
+    _add_step(buf, 3)
+    _add_step(buf, 4)
+
+    # Checkpoints expected at pos 0 (ep0, rel 0), pos 2 (ep0, rel 2), pos 3 (ep1, rel 0).
+    assert buf._current_ckpt_pos[0].item() == 3
+    assert buf._ckpt_slot_to_pos[0, 0].item() == 0
+    assert buf._ckpt_slot_to_pos[1, 0].item() == 2
+    assert buf._ckpt_slot_to_pos[2, 0].item() == 3
+    assert buf.hidden_checkpoint_ep_id[2, 0].item() == 1  # new episode id
+
+
+def test_valid_window_batch_distinguishes_ready_vs_not_yet_ready_checkpoints():
+    """After more than one full ring-buffer wrap, the checkpoints closest to the
+    write cursor don't yet have window_len more real steps collected after them
+    (invalid -- rejected, not silently read as stale garbage), while older
+    checkpoints do, wrapping seamlessly into the next lap's already-written data
+    (valid). Exact validity pattern below is derived by hand for
+    per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1
+    (window_len=5), checkpoint_capacity=4, after 20 sequential steps."""
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(20):
+        _add_step(buf, t)
+
+    env = torch.zeros(1, dtype=torch.long)
+    validity = {}
+    for slot in range(buf.checkpoint_capacity):
+        t0 = buf._ckpt_slot_to_pos[slot, 0].unsqueeze(0)
+        validity[slot] = bool(buf._valid_window_batch(t0, env).item())
+
+    assert validity[2] is True
+    assert validity[3] is True
+    assert validity[0] is False
+    assert validity[1] is False
+
+
+def test_episode_starts_reset_within_sampled_window():
+    """A short episode ending inside the sampled window must produce
+    episode_starts=1 exactly at the new episode's first step, anywhere in the
+    window -- not just at position 0."""
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=1, learning_len=2, forward_len=1)
+    # Episode 0: single step at pos 0, ends immediately (episode_end=True).
+    _add_step(buf, 0, episode_end=torch.ones(1))
+    # Episode 1 starts at pos 1 (checkpoint), runs long enough to fill the window.
+    for t in range(1, 8):
+        _add_step(buf, t)
+
+    torch.manual_seed(0)
+    sample = buf.sample(batch_size=64, generator=torch.Generator().manual_seed(0))
+    # window_len = burn_in(1)+learning(2)+forward(1) = 4. t0 must always be a
+    # checkpoint position; pos=1 is one such checkpoint (episode 1's start).
+    ep_rel = buf._ep_relative_step
+    for b in range(sample.episode_starts.shape[1]):
+        pass  # existence check only -- correctness is validated structurally below
+
+    # Directly probe the pos=1 checkpoint window.
+    t0 = torch.tensor([1])
+    env = torch.zeros(1, dtype=torch.long)
+    idx_grid, env_grid = buf._gather_window(t0, env)
+    starts = (buf._ep_relative_step[idx_grid, env_grid] == 0).float()
+    assert starts[0, 0].item() == 1.0  # pos=1 IS episode 1's first step
+    assert torch.all(starts[1:, 0] == 0.0)
+
+
+def test_nstep_window_matches_manual_accumulation():
+    gamma = 0.9
+    buf = _make_buffer(
+        num_envs=1, per_env_buffer_size=8, burn_in_len=1, learning_len=2, forward_len=2, gamma=gamma
+    )
+    rewards_seq = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    for t in range(8):
+        _add_step(buf, t, reward=torch.tensor([rewards_seq[t]]))
+
+    t0 = torch.tensor([0])
+    env = torch.zeros(1, dtype=torch.long)
+    rewards, discounts = buf._accumulate_nstep_window(t0, env)
+    # burn_in_len=1, learning_len=2, forward_len=2 -> learning starts at pos 1,2.
+    # learning position 0 (pos=1): forward window covers pos 1,2 -> r[1]+gamma*r[2]
+    expected_0 = rewards_seq[1] + gamma * rewards_seq[2]
+    expected_1 = rewards_seq[2] + gamma * rewards_seq[3]
+    assert torch.allclose(rewards[0, 0], torch.tensor(expected_0))
+    assert torch.allclose(rewards[1, 0], torch.tensor(expected_1))
+    assert torch.allclose(discounts[0, 0], torch.tensor(gamma**2))
+    assert torch.allclose(discounts[1, 0], torch.tensor(gamma**2))
+
+
+def test_nstep_window_zeroes_discount_at_termination():
+    gamma = 0.9
+    buf = _make_buffer(
+        num_envs=1, per_env_buffer_size=8, burn_in_len=1, learning_len=1, forward_len=3, gamma=gamma
+    )
+    rewards_seq = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    dones = [False] * 8
+    dones[2] = True  # episode terminates at pos=2 (learning position's +1 offset)
+    for t in range(8):
+        buf_done = torch.ones(1) if dones[t] else torch.zeros(1)
+        buf_ep_end = buf_done
+        _add_step(buf, t, reward=torch.tensor([rewards_seq[t]]), done=buf_done, episode_end=buf_ep_end)
+
+    t0 = torch.tensor([0])
+    env = torch.zeros(1, dtype=torch.long)
+    rewards, discounts = buf._accumulate_nstep_window(t0, env)
+    # learning position 0 -> forward window starts at pos=1: r[1] + gamma*r[2], then
+    # terminates at pos=2 so discount zeroes and accumulation stops there.
+    expected = rewards_seq[1] + gamma * rewards_seq[2]
+    assert torch.allclose(rewards[0, 0], torch.tensor(expected))
+    assert torch.allclose(discounts[0, 0], torch.tensor(0.0))
+
+
+def test_sample_never_reads_uninitialized_data():
+    buf = _make_buffer(num_envs=2, per_env_buffer_size=16, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(16):
+        _add_step(buf, t)
+
+    generator = torch.Generator().manual_seed(0)
+    for _ in range(20):
+        sample = buf.sample(batch_size=8, generator=generator)
+        assert torch.isfinite(sample.rewards).all()
+        assert torch.isfinite(sample.discounts).all()
+
+
+def test_priority_update_shifts_sampling_distribution():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=16, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(16):
+        _add_step(buf, t)
+
+    generator = torch.Generator().manual_seed(0)
+    baseline = buf.sample(batch_size=200, generator=generator)
+    baseline_counts = torch.bincount(baseline.priority_indices, minlength=buf.checkpoint_capacity)
+
+    # Boost one specific window's priority sky-high.
+    target_leaf = baseline.priority_indices[0].reshape(1)
+    buf.update_priorities(target_leaf, torch.tensor([1000.0]))
+
+    generator2 = torch.Generator().manual_seed(1)
+    boosted = buf.sample(batch_size=200, generator=generator2)
+    boosted_counts = torch.bincount(boosted.priority_indices, minlength=buf.checkpoint_capacity)
+
+    assert boosted_counts[target_leaf.item()] > baseline_counts[target_leaf.item()]
+
+
+def test_gru_buffer_has_no_cell_state():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1, rnn_type="gru")
+    assert buf.hidden_checkpoints_c is None
+    for t in range(8):
+        _add_step(buf, t)
+    sample = buf.sample(batch_size=4, generator=torch.Generator().manual_seed(0))
+    assert sample.initial_hidden_c is None
+    assert sample.initial_hidden_h.shape == (4, 1, 3)
+
+
+def test_sample_raises_before_any_checkpoint_ready():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1)
+    with pytest.raises(RuntimeError):
+        buf.sample(batch_size=4)
+
+
+def test_truncation_bootstrap_uses_patched_final_obs_not_reset_obs():
+    """episode_end=True with done=False (truncation, bootstrap should continue)
+    must patch in the true final observation, not the auto-reset one."""
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=1, learning_len=1, forward_len=1)
+    true_final_obs = torch.full((1, 4), 999.0)
+    for t in range(8):
+        if t == 1:
+            action = torch.zeros(1, 2)
+            reward = torch.zeros(1)
+            obs = torch.full((1, 4), float(t))
+            buf.add(
+                obs, true_final_obs, action, reward,
+                torch.zeros(1), torch.ones(1),  # done=False, episode_end=True
+                (_hidden(t, 1, 1, 3), _hidden(t + 1000, 1, 1, 3)),
+            )
+        else:
+            _add_step(buf, t)
+
+    # window_len = burn_in(1)+learning(1)+forward(1) = 3, indices 0,1,2 relative
+    # to t0=0 -- truncation at absolute pos=1 means window position 2 (pos=2)
+    # must be patched with the true final observation.
+    t0 = torch.tensor([0])
+    env = torch.zeros(1, dtype=torch.long)
+    idx_grid, env_grid = buf._gather_window(t0, env)
+    window_obs = index_obs(buf.obs, (idx_grid, env_grid))
+    patched = buf._patch_final_obs(window_obs, idx_grid, env_grid)
+    assert torch.allclose(patched[2, 0], true_final_obs[0])

--- a/tests/test_recurrent_sac.py
+++ b/tests/test_recurrent_sac.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.algorithms import RecurrentSAC
+from rl_garden.encoders.base import BaseFeaturesExtractor
+
+
+class DummyVecEnv:
+    def __init__(
+        self, observation_space: spaces.Space, action_space: spaces.Box, num_envs: int = 2
+    ) -> None:
+        self.num_envs = num_envs
+        self.single_observation_space = observation_space
+        self.single_action_space = action_space
+        self.action_space = spaces.Box(
+            low=np.broadcast_to(action_space.low, (self.num_envs,) + action_space.shape),
+            high=np.broadcast_to(action_space.high, (self.num_envs,) + action_space.shape),
+            dtype=action_space.dtype,
+        )
+
+    def reset(self, seed: int | None = None):
+        del seed
+        return self._obs(), {}
+
+    def step(self, actions):
+        assert torch.all(actions <= 1.0 + 1e-4)
+        assert torch.all(actions >= -1.0 - 1e-4)
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        return self._obs(), rewards, terminations, truncations, {}
+
+    def close(self) -> None:
+        return None
+
+    def _obs(self):
+        if isinstance(self.single_observation_space, spaces.Dict):
+            return {
+                "rgb": torch.randint(
+                    0, 256, (self.num_envs, 64, 64, 3), dtype=torch.uint8
+                ),
+                "state": torch.randn(self.num_envs, 4),
+            }
+        return torch.randn(self.num_envs, *self.single_observation_space.shape)
+
+
+class RecurrentDoneVecEnv(DummyVecEnv):
+    """Like DummyVecEnv, but env 0 terminates at a chosen global step and reports
+    ``final_observation``, exercising the truncation/termination-boundary and
+    checkpoint-reset paths that never fire with DummyVecEnv."""
+
+    def __init__(self, observation_space, action_space, done_at_step: int, num_envs: int = 2) -> None:
+        super().__init__(observation_space, action_space, num_envs=num_envs)
+        self._step = 0
+        self._done_at_step = done_at_step
+
+    def reset(self, seed: int | None = None):
+        del seed
+        self._step = 0
+        return self._obs(), {}
+
+    def step(self, actions):
+        del actions
+        self._step += 1
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        infos: dict = {}
+        if self._step == self._done_at_step:
+            terminations[0] = True
+            infos["final_observation"] = self._obs()
+        obs = self._obs()  # gymnasium autoreset convention: next obs is already reset
+        return obs, rewards, terminations, truncations, infos
+
+
+class StructuredFeaturesExtractor(BaseFeaturesExtractor):
+    """Minimal fake extractor declaring a token_and_prop layout, purely to
+    exercise RecurrentSAC's ViT opt-out at construction time."""
+
+    def __init__(self, observation_space) -> None:
+        super().__init__(observation_space, features_dim=16)
+
+    def structured_feature_config(self):
+        return {"layout": "token_and_prop", "num_patches": 4, "patch_dim": 4, "prop_dim": 0}
+
+    def extract(self, obs, stop_gradient: bool = False) -> torch.Tensor:
+        return torch.randn(obs.shape[0], 16)
+
+
+def _state_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+
+
+def _dict_space() -> spaces.Dict:
+    return spaces.Dict(
+        {
+            "rgb": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "state": spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32),
+        }
+    )
+
+
+def _action_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+def _recurrent_sac_kwargs() -> dict[str, object]:
+    return {
+        "device": "cpu",
+        "buffer_device": "cpu",
+        "buffer_size": 32,
+        "batch_size": 4,
+        "learning_starts": 10,
+        "training_freq": 4,
+        "eval_freq": 0,
+        "log_freq": 0,
+        "net_arch": [16],
+        "burn_in_len": 2,
+        "learning_len": 2,
+        "forward_len": 1,
+        "rnn_hidden_size": 8,
+    }
+
+
+@pytest.mark.parametrize("rnn_type", ["lstm", "gru"])
+def test_recurrent_sac_learn_one_iteration_state(rnn_type):
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = RecurrentSAC(env=env, rnn_type=rnn_type, **_recurrent_sac_kwargs())
+
+    agent.learn(total_timesteps=40)
+
+    assert agent._global_step == 40
+    assert agent.policy.recurrent_encoder is not None
+
+
+def test_recurrent_sac_handles_episode_termination_across_windows():
+    env = RecurrentDoneVecEnv(_state_space(), _action_space(), done_at_step=6)
+    agent = RecurrentSAC(env=env, **_recurrent_sac_kwargs())
+
+    agent.learn(total_timesteps=40)
+
+    assert agent._global_step == 40
+    # A real episode boundary occurred mid-training; the replay buffer must
+    # still only ever hand back finite rewards/discounts (no corrupted reads
+    # from the boundary-reset checkpoint bookkeeping).
+    sample = agent.replay_buffer.sample(4, generator=torch.Generator().manual_seed(0))
+    assert torch.isfinite(sample.rewards).all()
+    assert torch.isfinite(sample.discounts).all()
+
+
+def test_recurrent_sac_actor_loss_does_not_train_encoder_or_rnn_when_stop_gradient_actor():
+    """Regression test: actor-loss gradient must be cut BEFORE the RNN (not
+    just before the encoder) when _actor_stop_gradient() is True, matching
+    RecurrentPPOPolicy's identical "detach latent, not raw features" pattern.
+    Detaching only the pre-RNN raw features (an earlier, buggy version of this
+    code) does not block gradient to the RNN's own parameters."""
+    env = DummyVecEnv(_dict_space(), _action_space())
+    agent = RecurrentSAC(env=env, image_keys=("rgb",), **_recurrent_sac_kwargs())
+    assert agent._actor_stop_gradient() is True
+
+    obs, _ = agent.env.reset(seed=agent.seed)
+    agent._on_env_reset(obs)
+    for _ in range(20):
+        action, env_action, action_context = agent._rollout_action(obs, False)
+        next_obs, rewards, terminations, truncations, infos = agent.env.step(env_action)
+        stop_bootstrap = torch.zeros(2, dtype=torch.bool)
+        need_final_obs = torch.zeros(2, dtype=torch.bool)
+        replay_kwargs = agent._replay_buffer_add_kwargs(
+            action_context, obs, next_obs, next_obs, infos, need_final_obs
+        )
+        replay_kwargs.update(agent._replay_buffer_step_kwargs(terminations, truncations))
+        agent.replay_buffer.add(obs, next_obs, action, rewards, stop_bootstrap, **replay_kwargs)
+        agent._post_rollout_step(action_context, terminations, truncations, infos)
+        obs = next_obs
+
+    data = agent.replay_buffer.sample(4, generator=torch.Generator().manual_seed(0))
+    actor_loss, _ = agent._actor_loss_from_batch(data)
+
+    agent.policy.zero_grad()
+    actor_loss.backward()
+
+    for name, param in agent.policy.features_extractor.named_parameters():
+        assert param.grad is None or torch.all(param.grad == 0), f"encoder param {name} got actor grad"
+    for name, param in agent.policy.recurrent_encoder.named_parameters():
+        assert param.grad is None or torch.all(param.grad == 0), f"RNN param {name} got actor grad"
+
+
+def test_recurrent_sac_eval_resets_hidden_state_only_at_episode_boundary():
+    """Regression test: the eval loop must reset episode_start exactly on a
+    real termination/truncation, not on every step (which would erase hidden
+    state constantly) and not never (which would leak state across episodes)."""
+    env = DummyVecEnv(_state_space(), _action_space())
+    eval_env = RecurrentDoneVecEnv(_state_space(), _action_space(), done_at_step=3)
+    agent = RecurrentSAC(env=env, eval_env=eval_env, **_recurrent_sac_kwargs())
+
+    agent.policy.eval()
+    obs, _ = agent.eval_env.reset()
+    agent._eval_start_hook()
+    assert torch.all(agent._eval_episode_start == 1.0)
+
+    for step in range(1, 6):
+        env_action, critic_action = agent._eval_action_and_critic_action(obs)
+        # After _eval_action_and_critic_action, episode_start must NOT have
+        # been reset yet (only _eval_step_hook, called after env.step(), may
+        # reset it) -- it should still reflect whatever it was before this
+        # step ran.
+        obs, rewards, terminations, truncations, infos = agent.eval_env.step(env_action)
+        agent._eval_step_hook(obs, critic_action, rewards, terminations, truncations, infos)
+        if step == 3:
+            assert bool(terminations[0].item())
+            assert agent._eval_episode_start[0].item() == 1.0
+        else:
+            assert agent._eval_episode_start[0].item() == 0.0
+
+
+def test_recurrent_sac_priority_replay_updates_after_train_step():
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = RecurrentSAC(env=env, **_recurrent_sac_kwargs())
+
+    obs, _ = agent.env.reset(seed=agent.seed)
+    agent._on_env_reset(obs)
+    for _ in range(20):
+        action, env_action, action_context = agent._rollout_action(obs, False)
+        next_obs, rewards, terminations, truncations, infos = agent.env.step(env_action)
+        stop_bootstrap, need_final_obs = torch.zeros(2, dtype=torch.bool), torch.zeros(2, dtype=torch.bool)
+        replay_kwargs = agent._replay_buffer_add_kwargs(action_context, obs, next_obs, next_obs, infos, need_final_obs)
+        replay_kwargs.update(agent._replay_buffer_step_kwargs(terminations, truncations))
+        agent.replay_buffer.add(obs, next_obs, action, rewards, stop_bootstrap, **replay_kwargs)
+        agent._post_rollout_step(action_context, terminations, truncations, infos)
+        obs = next_obs
+
+    tree_before = agent.replay_buffer._priority_tree.tree.clone()
+    agent.train(1, compute_info=False)
+    tree_after = agent.replay_buffer._priority_tree.tree
+
+    assert not torch.equal(tree_before, tree_after)
+
+
+def test_recurrent_sac_dict_obs_smoke():
+    env = DummyVecEnv(_dict_space(), _action_space())
+    agent = RecurrentSAC(env=env, image_keys=("rgb",), **_recurrent_sac_kwargs())
+
+    agent.learn(total_timesteps=40)
+
+    assert agent._global_step == 40
+
+
+def test_recurrent_sac_rejects_token_and_prop_features():
+    env = DummyVecEnv(_state_space(), _action_space())
+    with pytest.raises(NotImplementedError):
+        RecurrentSAC(
+            env=env,
+            policy_kwargs={"features_extractor_class": StructuredFeaturesExtractor},
+            **_recurrent_sac_kwargs(),
+        )
+
+
+def test_recurrent_sac_rejects_nstep_kwarg():
+    env = DummyVecEnv(_state_space(), _action_space())
+    with pytest.raises(ValueError):
+        RecurrentSAC(env=env, nstep=3, **_recurrent_sac_kwargs())
+
+
+def test_recurrent_sac_rejects_integer_utd_greater_than_one():
+    env = DummyVecEnv(_state_space(), _action_space())
+    with pytest.raises(ValueError):
+        RecurrentSAC(env=env, utd=2, **_recurrent_sac_kwargs())
+
+
+def test_recurrent_sac_checkpoint_roundtrip(tmp_path):
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = RecurrentSAC(env=env, **_recurrent_sac_kwargs())
+    agent.learn(total_timesteps=40)
+    path = tmp_path / "recurrent_sac.pt"
+    agent.save(path)
+
+    loaded = RecurrentSAC(env=DummyVecEnv(_state_space(), _action_space()), **_recurrent_sac_kwargs())
+    loaded.load(path)
+
+    assert loaded._global_step == agent._global_step
+    for key, value in agent.policy.state_dict().items():
+        assert torch.equal(value, loaded.policy.state_dict()[key]), key

--- a/tests/test_sum_tree.py
+++ b/tests/test_sum_tree.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import torch
+
+from rl_garden.buffers.sum_tree import SumTree
+
+
+def test_update_propagates_to_root_sum():
+    tree = SumTree(capacity=8, alpha=1.0, beta=1.0, device=torch.device("cpu"))
+    indices = torch.arange(8)
+    td_errors = torch.tensor([1.0, 2.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    tree.update(indices, td_errors)
+
+    leaf_priorities = (td_errors.abs() + tree.eps) ** tree.alpha
+    assert torch.allclose(tree.total, leaf_priorities.sum().to(torch.float64), atol=1e-6)
+
+
+def test_update_is_idempotent_for_repeated_calls():
+    tree = SumTree(capacity=4, alpha=0.9, beta=0.6, device=torch.device("cpu"))
+    tree.update(torch.arange(4), torch.tensor([1.0, 1.0, 1.0, 1.0]))
+    first_total = float(tree.total.item())
+    tree.update(torch.tensor([2]), torch.tensor([1.0]))
+    assert float(tree.total.item()) == first_total
+
+
+def test_sample_matches_priority_distribution_statistically():
+    torch.manual_seed(0)
+    tree = SumTree(capacity=4, alpha=1.0, beta=0.0, device=torch.device("cpu"), eps=0.0)
+    # Priorities proportional to [1, 2, 3, 4] -- index 3 should be sampled ~4x as
+    # often as index 0.
+    tree.update(torch.arange(4), torch.tensor([1.0, 2.0, 3.0, 4.0]))
+
+    generator = torch.Generator().manual_seed(0)
+    leaf_indices, _ = tree.sample(20_000, generator=generator)
+    counts = torch.bincount(leaf_indices, minlength=4).float()
+    empirical = counts / counts.sum()
+    expected = torch.tensor([1.0, 2.0, 3.0, 4.0]) / 10.0
+
+    assert torch.allclose(empirical, expected, atol=0.02)
+
+
+def test_sample_is_weights_bounded_by_one_via_local_min():
+    """IS weight = (priority/batch_min_priority)^-beta; since priority >= the
+    batch-local min, weights are bounded ABOVE by 1 (not below)."""
+    torch.manual_seed(0)
+    tree = SumTree(capacity=4, alpha=1.0, beta=0.5, device=torch.device("cpu"))
+    tree.update(torch.arange(4), torch.tensor([1.0, 2.0, 3.0, 4.0]))
+
+    _, is_weights = tree.sample(1000, generator=torch.Generator().manual_seed(1))
+    assert torch.all(is_weights <= 1.0 + 1e-4)
+
+
+def test_set_uninitialized_uses_current_max_priority():
+    tree = SumTree(capacity=4, alpha=1.0, beta=1.0, device=torch.device("cpu"), eps=0.0)
+    tree.update(torch.tensor([0, 1]), torch.tensor([1.0, 5.0]))
+    max_before = tree.tree[tree._leaf_offset : tree._leaf_offset + 4].max().item()
+
+    tree.set_uninitialized(torch.tensor([2, 3]))
+
+    leaf_priorities = tree.tree[tree._leaf_offset : tree._leaf_offset + 4]
+    assert torch.allclose(leaf_priorities[2], torch.tensor(max_before, dtype=torch.float64))
+    assert torch.allclose(leaf_priorities[3], torch.tensor(max_before, dtype=torch.float64))
+
+
+def test_set_uninitialized_defaults_to_one_when_tree_empty():
+    tree = SumTree(capacity=4, alpha=1.0, beta=1.0, device=torch.device("cpu"))
+    tree.set_uninitialized(torch.tensor([0]))
+    assert float(tree.total.item()) == 1.0
+
+
+def test_capacity_non_power_of_two_builds_valid_tree():
+    tree = SumTree(capacity=5, alpha=1.0, beta=1.0, device=torch.device("cpu"), eps=0.0)
+    tree.update(torch.arange(5), torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0]))
+    assert torch.allclose(tree.total, torch.tensor(5.0, dtype=torch.float64))
+    leaf_indices, _ = tree.sample(100, generator=torch.Generator().manual_seed(0))
+    assert torch.all(leaf_indices < 5)
+    assert torch.all(leaf_indices >= 0)

--- a/tests/test_td3.py
+++ b/tests/test_td3.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.algorithms import TD3
+
+
+class DummyDictVecEnv:
+    def __init__(self) -> None:
+        self.num_envs = 1
+        self.single_observation_space = spaces.Dict(
+            {
+                "rgb": spaces.Box(low=0, high=255, shape=(32, 40, 3), dtype=np.uint8),
+                "state": spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32),
+            }
+        )
+        self.single_action_space = spaces.Box(
+            low=-1.0, high=1.0, shape=(2,), dtype=np.float32
+        )
+
+
+def _make_agent(**overrides) -> TD3:
+    kwargs = dict(
+        env=DummyDictVecEnv(),
+        device="cpu",
+        buffer_device="cpu",
+        buffer_size=16,
+        batch_size=2,
+        learning_starts=0,
+        training_freq=1,
+        eval_freq=0,
+        hidden_dim=16,
+        feature_dim=8,
+        image_keys=("rgb",),
+        proprio_latent_dim=4,
+        image_augmentation="none",
+    )
+    kwargs.update(overrides)
+    return TD3(**kwargs)
+
+
+def _add_transition(agent: TD3, reward: float) -> None:
+    obs = {
+        "rgb": torch.randint(0, 256, (1, 32, 40, 3), dtype=torch.uint8),
+        "state": torch.randn(1, 4),
+    }
+    next_obs = {
+        "rgb": torch.randint(0, 256, (1, 32, 40, 3), dtype=torch.uint8),
+        "state": torch.randn(1, 4),
+    }
+    agent.replay_buffer.add(
+        obs=obs,
+        next_obs=next_obs,
+        action=torch.randn(1, 2).clamp(-1, 1),
+        reward=torch.full((1,), reward),
+        done=torch.zeros(1, dtype=torch.bool),
+        episode_end=torch.zeros(1, dtype=torch.bool),
+    )
+
+
+def test_td3_one_update_smoke():
+    agent = _make_agent(nstep=3, gamma=0.9)
+    for step in range(5):
+        _add_transition(agent, float(step))
+
+    metrics = agent.train(1, compute_info=True)
+
+    assert set(metrics) >= {"critic_loss", "target_q", "predicted_q"}
+    assert all(np.isfinite(v) for v in metrics.values())
+
+
+def test_td3_target_action_noise_is_fixed_and_decoupled_from_schedule():
+    agent = _make_agent(
+        target_noise_std=0.2,
+        target_noise_clip=0.5,
+        stddev_schedule="linear(1.0,0.1,100)",
+        stddev_clip=0.3,
+    )
+
+    std0, clip0 = agent._target_action_noise()
+    agent._global_step = 1000
+    std1, clip1 = agent._target_action_noise()
+
+    assert std0 == std1 == 0.2
+    assert clip0 == clip1 == 0.5
+    # Contrast with the exploration schedule, which decays with _global_step
+    # (DDPG's default _target_action_noise reuses it; TD3's does not).
+    assert agent._current_stddev() < 1.0
+
+
+def test_td3_actor_q_value_uses_first_critic_only():
+    agent = _make_agent()
+    q_actor_all = torch.tensor([[[5.0], [6.0]], [[1.0], [2.0]]])  # (2, B=2, 1); q1 is NOT the min
+
+    reduced = agent._actor_q_value(q_actor_all)
+
+    assert torch.equal(reduced, q_actor_all[0])
+    assert not torch.equal(reduced, q_actor_all.min(dim=0).values)
+
+
+def test_td3_delays_actor_and_target_update():
+    agent = _make_agent(nstep=1, gamma=0.9, policy_freq=2, tau=0.9)
+    for step in range(5):
+        _add_transition(agent, float(step))
+
+    actor_before = [p.clone() for p in agent.policy.actor_parameters()]
+    target_before = [p.clone() for p in agent.policy.critic_target.parameters()]
+
+    # First gradient step: _global_update becomes 1, 1 % 2 != 0 -> actor/target skipped.
+    metrics = agent.train(1, compute_info=True)
+    assert "actor_loss" not in metrics
+    for before, after in zip(actor_before, agent.policy.actor_parameters()):
+        assert torch.equal(before, after)
+    for before, after in zip(target_before, agent.policy.critic_target.parameters()):
+        assert torch.equal(before, after)
+
+    # Second gradient step: _global_update becomes 2, 2 % 2 == 0 -> actor/target update.
+    metrics = agent.train(1, compute_info=True)
+    assert "actor_loss" in metrics
+    assert any(
+        not torch.equal(before, after)
+        for before, after in zip(actor_before, agent.policy.actor_parameters())
+    )
+    assert any(
+        not torch.equal(before, after)
+        for before, after in zip(target_before, agent.policy.critic_target.parameters())
+    )
+
+
+def test_td3_checkpoint_roundtrip(tmp_path):
+    agent = _make_agent(nstep=1, gamma=0.9)
+    for step in range(5):
+        _add_transition(agent, float(step))
+    agent.train(2)
+
+    path = tmp_path / "td3.pt"
+    agent.save(path)
+
+    loaded = _make_agent(nstep=1, gamma=0.9)
+    loaded.load(path, load_replay_buffer=False)
+
+    for key, value in agent.policy.state_dict().items():
+        assert torch.equal(value, loaded.policy.state_dict()[key]), key
+
+
+def test_td3_rejects_bad_construction_like_ddpg():
+    with pytest.raises(ValueError):
+        TD3(
+            env=DummyDictVecEnv(),
+            device="cpu",
+            buffer_device="cpu",
+            replay_lazy_next_obs=True,
+            save_replay_buffer=True,
+        )

--- a/tests/test_training_registry.py
+++ b/tests/test_training_registry.py
@@ -83,7 +83,9 @@ def test_phase_registries_discover_expected_algorithms():
     offline.discover()
     off2on.discover()
 
-    assert set(online.entries()) == {"sac", "ppo", "drqv2", "flash_sac", "residual_sac"}
+    assert set(online.entries()) == {
+        "sac", "ppo", "recurrent_ppo", "drqv2", "flash_sac", "residual_sac"
+    }
     assert set(offline.entries()) == {"bc", "iql", "cql", "calql", "wsrl"}
     assert set(off2on.entries()) == {"wsrl"}
 

--- a/tests/test_training_registry.py
+++ b/tests/test_training_registry.py
@@ -84,7 +84,7 @@ def test_phase_registries_discover_expected_algorithms():
     off2on.discover()
 
     assert set(online.entries()) == {
-        "sac", "ppo", "recurrent_ppo", "recurrent_sac", "drqv2", "flash_sac", "residual_sac"
+        "sac", "ppo", "recurrent_ppo", "recurrent_sac", "transformer_ppo", "drqv2", "flash_sac", "residual_sac"
     }
     assert set(offline.entries()) == {"bc", "iql", "cql", "calql", "wsrl"}
     assert set(off2on.entries()) == {"wsrl"}

--- a/tests/test_training_registry.py
+++ b/tests/test_training_registry.py
@@ -84,7 +84,8 @@ def test_phase_registries_discover_expected_algorithms():
     off2on.discover()
 
     assert set(online.entries()) == {
-        "sac", "ppo", "recurrent_ppo", "recurrent_sac", "transformer_ppo", "drqv2", "flash_sac", "residual_sac"
+        "sac", "ppo", "recurrent_ppo", "recurrent_sac", "transformer_ppo", "transformer_sac",
+        "drqv2", "flash_sac", "residual_sac"
     }
     assert set(offline.entries()) == {"bc", "iql", "cql", "calql", "wsrl"}
     assert set(off2on.entries()) == {"wsrl"}

--- a/tests/test_training_registry.py
+++ b/tests/test_training_registry.py
@@ -84,7 +84,7 @@ def test_phase_registries_discover_expected_algorithms():
     off2on.discover()
 
     assert set(online.entries()) == {
-        "sac", "ppo", "recurrent_ppo", "drqv2", "flash_sac", "residual_sac"
+        "sac", "ppo", "recurrent_ppo", "recurrent_sac", "drqv2", "flash_sac", "residual_sac"
     }
     assert set(offline.entries()) == {"bc", "iql", "cql", "calql", "wsrl"}
     assert set(off2on.entries()) == {"wsrl"}

--- a/tests/test_training_registry.py
+++ b/tests/test_training_registry.py
@@ -85,7 +85,7 @@ def test_phase_registries_discover_expected_algorithms():
 
     assert set(online.entries()) == {
         "sac", "ppo", "recurrent_ppo", "recurrent_sac", "transformer_ppo", "transformer_sac",
-        "drqv2", "flash_sac", "residual_sac"
+        "drqv2", "flash_sac", "residual_sac", "td3"
     }
     assert set(offline.entries()) == {"bc", "iql", "cql", "calql", "wsrl"}
     assert set(off2on.entries()) == {"wsrl"}

--- a/tests/test_transformer_ppo.py
+++ b/tests/test_transformer_ppo.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.algorithms import TransformerPPO
+from rl_garden.encoders.base import BaseFeaturesExtractor
+
+
+class StructuredFeaturesExtractor(BaseFeaturesExtractor):
+    """Minimal fake extractor declaring a token_and_prop layout, purely to
+    exercise TransformerPPO's ViT opt-out at construction time."""
+
+    def __init__(self, observation_space) -> None:
+        super().__init__(observation_space, features_dim=16)
+
+    def structured_feature_config(self):
+        return {"layout": "token_and_prop", "num_patches": 4, "patch_dim": 4, "prop_dim": 0}
+
+    def extract(self, obs, stop_gradient: bool = False) -> torch.Tensor:
+        return torch.randn(obs.shape[0], 16)
+
+
+class DummyVecEnv:
+    def __init__(self, observation_space: spaces.Space, action_space: spaces.Box) -> None:
+        self.num_envs = 2
+        self.single_observation_space = observation_space
+        self.single_action_space = action_space
+        self.action_space = spaces.Box(
+            low=np.broadcast_to(action_space.low, (self.num_envs,) + action_space.shape),
+            high=np.broadcast_to(action_space.high, (self.num_envs,) + action_space.shape),
+            dtype=action_space.dtype,
+        )
+        self._step = 0
+
+    def reset(self, seed: int | None = None):
+        del seed
+        self._step = 0
+        return self._obs(), {}
+
+    def step(self, actions):
+        assert torch.all(actions <= 1.0)
+        assert torch.all(actions >= -1.0)
+        self._step += 1
+        obs = self._obs()
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        return obs, rewards, terminations, truncations, {}
+
+    def close(self) -> None:
+        return None
+
+    def _obs(self):
+        if isinstance(self.single_observation_space, spaces.Dict):
+            return {
+                "rgb": torch.randint(0, 256, (self.num_envs, 64, 64, 3), dtype=torch.uint8),
+                "state": torch.randn(self.num_envs, 4),
+            }
+        return torch.randn(self.num_envs, *self.single_observation_space.shape)
+
+
+class TransformerDoneVecEnv:
+    """Like DummyVecEnv, but env 0 terminates at a chosen global step and reports
+    ``final_observation``, exercising the bootstrap-value and window-boundary
+    memory-reset paths that never fire with DummyVecEnv."""
+
+    def __init__(self, observation_space: spaces.Space, action_space: spaces.Box, done_at_step: int) -> None:
+        self.num_envs = 2
+        self.single_observation_space = observation_space
+        self.single_action_space = action_space
+        self.action_space = spaces.Box(
+            low=np.broadcast_to(action_space.low, (self.num_envs,) + action_space.shape),
+            high=np.broadcast_to(action_space.high, (self.num_envs,) + action_space.shape),
+            dtype=action_space.dtype,
+        )
+        self._step = 0
+        self._done_at_step = done_at_step
+
+    def reset(self, seed: int | None = None):
+        del seed
+        self._step = 0
+        return self._obs(), {}
+
+    def step(self, actions):
+        self._step += 1
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        infos: dict = {}
+        if self._step == self._done_at_step:
+            terminations[0] = True
+            infos["final_observation"] = self._obs()
+        obs = self._obs()  # gymnasium autoreset convention: next obs is already reset
+        return obs, rewards, terminations, truncations, infos
+
+    def close(self) -> None:
+        return None
+
+    def _obs(self):
+        return torch.randn(self.num_envs, *self.single_observation_space.shape)
+
+
+def _state_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+
+
+def _dict_space() -> spaces.Dict:
+    return spaces.Dict(
+        {
+            "rgb": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "state": spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32),
+        }
+    )
+
+
+def _action_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+def _ppo_kwargs() -> dict[str, object]:
+    return {
+        "device": "cpu",
+        "num_steps": 2,
+        "num_minibatches": 1,
+        "update_epochs": 1,
+        "eval_freq": 0,
+        "log_freq": 0,
+        "target_kl": None,
+        "net_arch": [16],
+    }
+
+
+def _transformer_kwargs() -> dict[str, object]:
+    # Deliberately tiny for fast tests -- shape correctness, not capacity.
+    return {
+        "embed_dim": 8,
+        "head_dim": 4,
+        "num_heads": 2,
+        "num_transformer_layers": 1,
+        "mlp_num": 1,
+        "memory_len": 2,
+    }
+
+
+def _capture_train_losses(agent):
+    captured: list[dict] = []
+    original_train = agent.train
+
+    def _wrapped():
+        result = original_train()
+        captured.append(result)
+        return result
+
+    agent.train = _wrapped
+    return captured
+
+
+def test_transformer_ppo_learn_one_iteration_state():
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = TransformerPPO(env=env, **_ppo_kwargs(), **_transformer_kwargs())
+    captured = _capture_train_losses(agent)
+
+    agent.learn(total_timesteps=4)
+
+    assert agent._global_step == 4
+    assert agent._global_update == 1
+    assert agent.policy.recurrent_encoder is not None
+    assert len(captured) == 1
+    assert torch.isfinite(torch.tensor(captured[0]["loss"]))
+    assert torch.isfinite(torch.tensor(captured[0]["value_loss"]))
+
+
+def test_transformer_ppo_handles_episode_termination_across_windows():
+    env = TransformerDoneVecEnv(_state_space(), _action_space(), done_at_step=2)
+    agent = TransformerPPO(env=env, **_ppo_kwargs(), **_transformer_kwargs())
+    captured = _capture_train_losses(agent)
+
+    agent.learn(total_timesteps=8)  # 2 rollout windows of num_steps=2
+
+    assert agent._global_step == 8
+    assert agent._global_update == 2
+    assert len(captured) == 2
+    for losses in captured:
+        assert torch.isfinite(torch.tensor(losses["loss"]))
+        assert torch.isfinite(torch.tensor(losses["value_loss"]))
+    assert torch.isfinite(agent.rollout_buffer.values).all()
+
+
+def test_transformer_ppo_dict_obs_smoke():
+    env = DummyVecEnv(_dict_space(), _action_space())
+    agent = TransformerPPO(env=env, **_ppo_kwargs(), image_keys=("rgb",), **_transformer_kwargs())
+    captured = _capture_train_losses(agent)
+
+    agent.learn(total_timesteps=4)
+
+    assert agent._global_step == 4
+    assert torch.isfinite(torch.tensor(captured[0]["loss"]))
+
+
+def test_transformer_ppo_checkpoint_roundtrip(tmp_path):
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = TransformerPPO(env=env, **_ppo_kwargs(), **_transformer_kwargs())
+    agent.learn(total_timesteps=4)
+    path = tmp_path / "transformer_ppo.pt"
+    agent.save(path)
+
+    loaded = TransformerPPO(
+        env=DummyVecEnv(_state_space(), _action_space()),
+        **_ppo_kwargs(),
+        **_transformer_kwargs(),
+    )
+    loaded.load(path)
+
+    assert loaded._global_step == agent._global_step
+    for key, value in agent.policy.state_dict().items():
+        assert torch.equal(value, loaded.policy.state_dict()[key]), key
+
+
+def test_transformer_ppo_rejects_num_envs_not_divisible_by_minibatches():
+    env = DummyVecEnv(_state_space(), _action_space())  # num_envs=2
+    kwargs = _ppo_kwargs()
+    kwargs["num_minibatches"] = 3
+    with pytest.raises(ValueError):
+        TransformerPPO(env=env, **kwargs, **_transformer_kwargs())
+
+
+def test_transformer_ppo_rejects_structured_vit_features():
+    env = DummyVecEnv(_state_space(), _action_space())
+    with pytest.raises(NotImplementedError):
+        TransformerPPO(
+            env=env,
+            policy_kwargs={"features_extractor_class": StructuredFeaturesExtractor},
+            **_ppo_kwargs(),
+            **_transformer_kwargs(),
+        )

--- a/tests/test_transformer_replay_buffer.py
+++ b/tests/test_transformer_replay_buffer.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.buffers.transformer_replay_buffer import TransformerReplayBuffer
+from rl_garden.common.obs_utils import index_obs
+
+
+def _obs_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+
+
+def _action_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+def _make_buffer(
+    num_envs=1,
+    per_env_buffer_size=8,
+    burn_in_len=2,
+    learning_len=2,
+    forward_len=1,
+    gamma=1.0,
+) -> TransformerReplayBuffer:
+    return TransformerReplayBuffer(
+        _obs_space(),
+        _action_space(),
+        num_envs,
+        per_env_buffer_size * num_envs,
+        burn_in_len=burn_in_len,
+        learning_len=learning_len,
+        forward_len=forward_len,
+        gamma=gamma,
+        storage_device="cpu",
+        sample_device="cpu",
+    )
+
+
+def _add_step(buf: TransformerReplayBuffer, t: int, *, done=None, episode_end=None, reward=None):
+    num_envs = buf.num_envs
+    obs = torch.full((num_envs, 4), float(t))
+    action = torch.zeros(num_envs, 2)
+    reward = torch.zeros(num_envs) if reward is None else reward
+    done = torch.zeros(num_envs) if done is None else done
+    episode_end = torch.zeros(num_envs) if episode_end is None else episode_end
+    buf.add(obs, obs, action, reward, done, episode_end)
+
+
+def test_add_has_no_hidden_parameter():
+    """TransformerReplayBuffer never stores a per-transition hidden checkpoint
+    -- add() must not accept a `hidden` kwarg at all (the key structural
+    difference from RecurrentReplayBuffer.add())."""
+    buf = _make_buffer()
+    with pytest.raises(TypeError):
+        buf.add(
+            torch.zeros(1, 4), torch.zeros(1, 4), torch.zeros(1, 2), torch.zeros(1),
+            torch.zeros(1), torch.zeros(1), hidden=torch.zeros(1, 3),
+        )
+
+
+def test_every_position_is_checkpoint_aligned_not_just_burn_in_len_multiples():
+    """Key behavioral difference from RecurrentReplayBuffer: stride=1 means
+    every position becomes its own checkpoint slot, so window starts are NOT
+    constrained to burn_in_len-periodic positions."""
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(8):
+        _add_step(buf, t)
+
+    assert buf._current_ckpt_pos[0].item() == 8
+    for pos in range(8):
+        assert buf._ckpt_slot_to_pos[pos, 0].item() == pos
+
+    # A position that is NOT a multiple of burn_in_len (e.g. pos=3) must still
+    # be a valid, ready window start once enough contiguous data follows it.
+    env = torch.zeros(1, dtype=torch.long)
+    t0 = torch.tensor([3])
+    assert bool(buf._valid_window_batch(t0, env).item())
+
+
+def test_sample_draws_from_non_aligned_positions():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=32, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(32):
+        _add_step(buf, t)
+
+    generator = torch.Generator().manual_seed(0)
+    sample = buf.sample(batch_size=200, generator=generator)
+    t0s = buf._ckpt_slot_to_pos[
+        sample.priority_indices % buf.checkpoint_capacity,
+        sample.priority_indices // buf.checkpoint_capacity,
+    ]
+    # burn_in_len=2 -- if sampling were still constrained to a stride-2 grid,
+    # every t0 would be even. With stride=1 we expect at least one odd t0.
+    assert (t0s % 2 != 0).any()
+
+
+def test_nstep_window_matches_manual_accumulation():
+    gamma = 0.9
+    buf = _make_buffer(
+        num_envs=1, per_env_buffer_size=8, burn_in_len=1, learning_len=2, forward_len=2, gamma=gamma
+    )
+    rewards_seq = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    for t in range(8):
+        _add_step(buf, t, reward=torch.tensor([rewards_seq[t]]))
+
+    t0 = torch.tensor([0])
+    env = torch.zeros(1, dtype=torch.long)
+    rewards, discounts = buf._accumulate_nstep_window(t0, env)
+    expected_0 = rewards_seq[1] + gamma * rewards_seq[2]
+    expected_1 = rewards_seq[2] + gamma * rewards_seq[3]
+    assert torch.allclose(rewards[0, 0], torch.tensor(expected_0))
+    assert torch.allclose(rewards[1, 0], torch.tensor(expected_1))
+    assert torch.allclose(discounts[0, 0], torch.tensor(gamma**2))
+    assert torch.allclose(discounts[1, 0], torch.tensor(gamma**2))
+
+
+def test_episode_starts_reset_within_sampled_window():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=1, learning_len=2, forward_len=1)
+    _add_step(buf, 0, episode_end=torch.ones(1))
+    for t in range(1, 8):
+        _add_step(buf, t)
+
+    t0 = torch.tensor([1])
+    env = torch.zeros(1, dtype=torch.long)
+    idx_grid, env_grid = buf._gather_window(t0, env)
+    starts = (buf._ep_relative_step[idx_grid, env_grid] == 0).float()
+    assert starts[0, 0].item() == 1.0
+    assert torch.all(starts[1:, 0] == 0.0)
+
+
+def test_sample_never_reads_uninitialized_data():
+    buf = _make_buffer(num_envs=2, per_env_buffer_size=16, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(16):
+        _add_step(buf, t)
+
+    generator = torch.Generator().manual_seed(0)
+    for _ in range(20):
+        sample = buf.sample(batch_size=8, generator=generator)
+        assert torch.isfinite(sample.rewards).all()
+        assert torch.isfinite(sample.discounts).all()
+
+
+def test_sample_has_no_hidden_state_fields():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(8):
+        _add_step(buf, t)
+    sample = buf.sample(batch_size=4, generator=torch.Generator().manual_seed(0))
+    assert not hasattr(sample, "initial_hidden_h")
+    assert not hasattr(sample, "initial_hidden_c")
+
+
+def test_priority_update_shifts_sampling_distribution():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=16, burn_in_len=2, learning_len=2, forward_len=1)
+    for t in range(16):
+        _add_step(buf, t)
+
+    generator = torch.Generator().manual_seed(0)
+    baseline = buf.sample(batch_size=200, generator=generator)
+    baseline_counts = torch.bincount(baseline.priority_indices, minlength=buf.checkpoint_capacity)
+
+    target_leaf = baseline.priority_indices[0].reshape(1)
+    buf.update_priorities(target_leaf, torch.tensor([1000.0]))
+
+    generator2 = torch.Generator().manual_seed(1)
+    boosted = buf.sample(batch_size=200, generator=generator2)
+    boosted_counts = torch.bincount(boosted.priority_indices, minlength=buf.checkpoint_capacity)
+
+    assert boosted_counts[target_leaf.item()] > baseline_counts[target_leaf.item()]
+
+
+def test_sample_raises_before_any_checkpoint_ready():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=2, learning_len=2, forward_len=1)
+    with pytest.raises(RuntimeError):
+        buf.sample(batch_size=4)
+
+
+def test_truncation_bootstrap_uses_patched_final_obs_not_reset_obs():
+    buf = _make_buffer(num_envs=1, per_env_buffer_size=8, burn_in_len=1, learning_len=1, forward_len=1)
+    true_final_obs = torch.full((1, 4), 999.0)
+    for t in range(8):
+        if t == 1:
+            action = torch.zeros(1, 2)
+            reward = torch.zeros(1)
+            obs = torch.full((1, 4), float(t))
+            buf.add(
+                obs, true_final_obs, action, reward,
+                torch.zeros(1), torch.ones(1),  # done=False, episode_end=True
+            )
+        else:
+            _add_step(buf, t)
+
+    t0 = torch.tensor([0])
+    env = torch.zeros(1, dtype=torch.long)
+    idx_grid, env_grid = buf._gather_window(t0, env)
+    window_obs = index_obs(buf.obs, (idx_grid, env_grid))
+    patched = buf._patch_final_obs(window_obs, idx_grid, env_grid)
+    assert torch.allclose(patched[2, 0], true_final_obs[0])

--- a/tests/test_transformer_sac.py
+++ b/tests/test_transformer_sac.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_garden.algorithms import TransformerSAC
+from rl_garden.encoders.base import BaseFeaturesExtractor
+
+
+class DummyVecEnv:
+    def __init__(
+        self, observation_space: spaces.Space, action_space: spaces.Box, num_envs: int = 2
+    ) -> None:
+        self.num_envs = num_envs
+        self.single_observation_space = observation_space
+        self.single_action_space = action_space
+        self.action_space = spaces.Box(
+            low=np.broadcast_to(action_space.low, (self.num_envs,) + action_space.shape),
+            high=np.broadcast_to(action_space.high, (self.num_envs,) + action_space.shape),
+            dtype=action_space.dtype,
+        )
+
+    def reset(self, seed: int | None = None):
+        del seed
+        return self._obs(), {}
+
+    def step(self, actions):
+        assert torch.all(actions <= 1.0 + 1e-4)
+        assert torch.all(actions >= -1.0 - 1e-4)
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        return self._obs(), rewards, terminations, truncations, {}
+
+    def close(self) -> None:
+        return None
+
+    def _obs(self):
+        if isinstance(self.single_observation_space, spaces.Dict):
+            return {
+                "rgb": torch.randint(
+                    0, 256, (self.num_envs, 64, 64, 3), dtype=torch.uint8
+                ),
+                "state": torch.randn(self.num_envs, 4),
+            }
+        return torch.randn(self.num_envs, *self.single_observation_space.shape)
+
+
+class TransformerDoneVecEnv(DummyVecEnv):
+    """Like DummyVecEnv, but env 0 terminates at a chosen global step and reports
+    ``final_observation``, exercising the truncation/termination-boundary path."""
+
+    def __init__(self, observation_space, action_space, done_at_step: int, num_envs: int = 2) -> None:
+        super().__init__(observation_space, action_space, num_envs=num_envs)
+        self._step = 0
+        self._done_at_step = done_at_step
+
+    def reset(self, seed: int | None = None):
+        del seed
+        self._step = 0
+        return self._obs(), {}
+
+    def step(self, actions):
+        del actions
+        self._step += 1
+        rewards = torch.ones(self.num_envs)
+        terminations = torch.zeros(self.num_envs, dtype=torch.bool)
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        infos: dict = {}
+        if self._step == self._done_at_step:
+            terminations[0] = True
+            infos["final_observation"] = self._obs()
+        obs = self._obs()  # gymnasium autoreset convention: next obs is already reset
+        return obs, rewards, terminations, truncations, infos
+
+
+class StructuredFeaturesExtractor(BaseFeaturesExtractor):
+    """Minimal fake extractor declaring a token_and_prop layout, purely to
+    exercise TransformerSAC's ViT opt-out at construction time."""
+
+    def __init__(self, observation_space) -> None:
+        super().__init__(observation_space, features_dim=16)
+
+    def structured_feature_config(self):
+        return {"layout": "token_and_prop", "num_patches": 4, "patch_dim": 4, "prop_dim": 0}
+
+    def extract(self, obs, stop_gradient: bool = False) -> torch.Tensor:
+        return torch.randn(obs.shape[0], 16)
+
+
+def _state_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+
+
+def _dict_space() -> spaces.Dict:
+    return spaces.Dict(
+        {
+            "rgb": spaces.Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
+            "state": spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32),
+        }
+    )
+
+
+def _action_space() -> spaces.Box:
+    return spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+def _transformer_sac_kwargs() -> dict[str, object]:
+    return {
+        "device": "cpu",
+        "buffer_device": "cpu",
+        "buffer_size": 32,
+        "batch_size": 4,
+        "learning_starts": 10,
+        "training_freq": 4,
+        "eval_freq": 0,
+        "log_freq": 0,
+        "net_arch": [16],
+        "burn_in_len": 2,
+        "learning_len": 2,
+        "forward_len": 1,
+        "embed_dim": 8,
+        "head_dim": 4,
+        "num_heads": 2,
+        "num_transformer_layers": 1,
+        "memory_len": 2,
+    }
+
+
+def test_transformer_sac_learn_one_iteration_state():
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = TransformerSAC(env=env, **_transformer_sac_kwargs())
+
+    agent.learn(total_timesteps=40)
+
+    assert agent._global_step == 40
+    assert agent.policy.recurrent_encoder is not None
+
+
+def test_transformer_sac_handles_episode_termination_across_windows():
+    env = TransformerDoneVecEnv(_state_space(), _action_space(), done_at_step=6)
+    agent = TransformerSAC(env=env, **_transformer_sac_kwargs())
+
+    agent.learn(total_timesteps=40)
+
+    assert agent._global_step == 40
+    sample = agent.replay_buffer.sample(4, generator=torch.Generator().manual_seed(0))
+    assert torch.isfinite(sample.rewards).all()
+    assert torch.isfinite(sample.discounts).all()
+
+
+def test_transformer_sac_actor_loss_does_not_train_encoder_or_gtrxl_when_stop_gradient_actor():
+    env = DummyVecEnv(_dict_space(), _action_space())
+    agent = TransformerSAC(env=env, image_keys=("rgb",), **_transformer_sac_kwargs())
+    assert agent._actor_stop_gradient() is True
+
+    obs, _ = agent.env.reset(seed=agent.seed)
+    agent._on_env_reset(obs)
+    for _ in range(20):
+        action, env_action, action_context = agent._rollout_action(obs, False)
+        next_obs, rewards, terminations, truncations, infos = agent.env.step(env_action)
+        stop_bootstrap = torch.zeros(2, dtype=torch.bool)
+        need_final_obs = torch.zeros(2, dtype=torch.bool)
+        replay_kwargs = agent._replay_buffer_add_kwargs(
+            action_context, obs, next_obs, next_obs, infos, need_final_obs
+        )
+        replay_kwargs.update(agent._replay_buffer_step_kwargs(terminations, truncations))
+        agent.replay_buffer.add(obs, next_obs, action, rewards, stop_bootstrap, **replay_kwargs)
+        agent._post_rollout_step(action_context, terminations, truncations, infos)
+        obs = next_obs
+
+    data = agent.replay_buffer.sample(4, generator=torch.Generator().manual_seed(0))
+    actor_loss, _ = agent._actor_loss_from_batch(data)
+
+    agent.policy.zero_grad()
+    actor_loss.backward()
+
+    for name, param in agent.policy.features_extractor.named_parameters():
+        assert param.grad is None or torch.all(param.grad == 0), f"encoder param {name} got actor grad"
+    for name, param in agent.policy.recurrent_encoder.named_parameters():
+        assert param.grad is None or torch.all(param.grad == 0), f"GTrXL param {name} got actor grad"
+
+
+def test_transformer_sac_eval_resets_hidden_state_only_at_episode_boundary():
+    env = DummyVecEnv(_state_space(), _action_space())
+    eval_env = TransformerDoneVecEnv(_state_space(), _action_space(), done_at_step=3)
+    agent = TransformerSAC(env=env, eval_env=eval_env, **_transformer_sac_kwargs())
+
+    agent.policy.eval()
+    obs, _ = agent.eval_env.reset()
+    agent._eval_start_hook()
+    assert torch.all(agent._eval_episode_start == 1.0)
+
+    for step in range(1, 6):
+        env_action, critic_action = agent._eval_action_and_critic_action(obs)
+        obs, rewards, terminations, truncations, infos = agent.eval_env.step(env_action)
+        agent._eval_step_hook(obs, critic_action, rewards, terminations, truncations, infos)
+        if step == 3:
+            assert bool(terminations[0].item())
+            assert agent._eval_episode_start[0].item() == 1.0
+        else:
+            assert agent._eval_episode_start[0].item() == 0.0
+
+
+def test_transformer_sac_priority_replay_updates_after_train_step():
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = TransformerSAC(env=env, **_transformer_sac_kwargs())
+
+    obs, _ = agent.env.reset(seed=agent.seed)
+    agent._on_env_reset(obs)
+    for _ in range(20):
+        action, env_action, action_context = agent._rollout_action(obs, False)
+        next_obs, rewards, terminations, truncations, infos = agent.env.step(env_action)
+        stop_bootstrap, need_final_obs = torch.zeros(2, dtype=torch.bool), torch.zeros(2, dtype=torch.bool)
+        replay_kwargs = agent._replay_buffer_add_kwargs(action_context, obs, next_obs, next_obs, infos, need_final_obs)
+        replay_kwargs.update(agent._replay_buffer_step_kwargs(terminations, truncations))
+        agent.replay_buffer.add(obs, next_obs, action, rewards, stop_bootstrap, **replay_kwargs)
+        agent._post_rollout_step(action_context, terminations, truncations, infos)
+        obs = next_obs
+
+    tree_before = agent.replay_buffer._priority_tree.tree.clone()
+    agent.train(1, compute_info=False)
+    tree_after = agent.replay_buffer._priority_tree.tree
+
+    assert not torch.equal(tree_before, tree_after)
+
+
+def test_transformer_sac_dict_obs_smoke():
+    env = DummyVecEnv(_dict_space(), _action_space())
+    agent = TransformerSAC(env=env, image_keys=("rgb",), **_transformer_sac_kwargs())
+
+    agent.learn(total_timesteps=40)
+
+    assert agent._global_step == 40
+
+
+def test_transformer_sac_rejects_token_and_prop_features():
+    env = DummyVecEnv(_state_space(), _action_space())
+    with pytest.raises(NotImplementedError):
+        TransformerSAC(
+            env=env,
+            policy_kwargs={"features_extractor_class": StructuredFeaturesExtractor},
+            **_transformer_sac_kwargs(),
+        )
+
+
+def test_transformer_sac_rejects_nstep_kwarg():
+    env = DummyVecEnv(_state_space(), _action_space())
+    with pytest.raises(ValueError):
+        TransformerSAC(env=env, nstep=3, **_transformer_sac_kwargs())
+
+
+def test_transformer_sac_rejects_integer_utd_greater_than_one():
+    env = DummyVecEnv(_state_space(), _action_space())
+    with pytest.raises(ValueError):
+        TransformerSAC(env=env, utd=2, **_transformer_sac_kwargs())
+
+
+def test_transformer_sac_rejects_burn_in_len_shorter_than_memory_len():
+    env = DummyVecEnv(_state_space(), _action_space())
+    kwargs = _transformer_sac_kwargs()
+    kwargs["burn_in_len"] = 2
+    kwargs["memory_len"] = 4
+    with pytest.raises(ValueError):
+        TransformerSAC(env=env, **kwargs)
+
+
+def test_transformer_sac_checkpoint_roundtrip(tmp_path):
+    env = DummyVecEnv(_state_space(), _action_space())
+    agent = TransformerSAC(env=env, **_transformer_sac_kwargs())
+    agent.learn(total_timesteps=40)
+    path = tmp_path / "transformer_sac.pt"
+    agent.save(path)
+
+    loaded = TransformerSAC(env=DummyVecEnv(_state_space(), _action_space()), **_transformer_sac_kwargs())
+    loaded.load(path)
+
+    assert loaded._global_step == agent._global_step
+    for key, value in agent.policy.state_dict().items():
+        assert torch.equal(value, loaded.policy.state_dict()[key]), key


### PR DESCRIPTION
## Summary
- Add `RecurrentPPO`/`RecurrentSAC` (generic LSTM/GRU latent module + R2D2-style recurrent replay buffer) and `TransformerPPO`/`TransformerSAC` (GTrXL latent module + burn-in replay), sharing common sequence-model plumbing via `SequencePPO`/`SequenceSAC` base classes.
- Add `TD3` as a thin extension of `DDPG`: `DrQv2Critic` already provides clipped double-Q learning, so `TD3` only overrides three new hooks on `DDPG.train()` — decoupled target policy smoothing, delayed actor/target updates, and Q1-only actor loss.
- Wire all four new algorithms into the online training registry (`_env_request`/`build_*`/`run_*`/`Args` + `registry.register(...)`) following the existing `drqv2.py` pattern.

## Test plan
- [x] `pytest tests/test_recurrent_ppo.py tests/test_recurrent_sac.py tests/test_transformer_ppo.py tests/test_transformer_sac.py tests/test_td3.py tests/test_drqv2_components.py tests/test_gtrxl.py tests/test_recurrent_replay_buffer.py tests/test_recurrent_latent_encoder.py tests/test_transformer_replay_buffer.py tests/test_sum_tree.py tests/test_training_registry.py -q` — 128 passed
- [x] Full suite `pytest tests/` — 604 passed, 3 failed; all 3 failures reproduced identically on `main` (ManiSkill version mismatch, missing example module, pre-existing WSRL dataset test bug), unrelated to this branch
- [x] `python examples/train_online.py <algo> --print-config` sanity-checked for `recurrent_ppo`, `recurrent_sac`, `transformer_ppo`, `transformer_sac`, `td3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)