### PR TITLE
feat(off2on): add Minari dataset support for offline-to-online WSRL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 maniskill = ["mani_skill"]
 robotwin = ["pillow", "pyyaml"]
-minari = ["minari"]
+minari = ["minari", "gymnasium-robotics"]
 wandb = ["wandb"]
 dev = ["pytest", "ruff"]
 

--- a/rl_garden/envs/minari/env.py
+++ b/rl_garden/envs/minari/env.py
@@ -40,6 +40,8 @@ class _TorchVectorEnvAdapter:
         self.num_envs = vec_env.num_envs
         self.single_observation_space = vec_env.single_observation_space
         self.single_action_space = vec_env.single_action_space
+        self.observation_space = vec_env.observation_space
+        self.action_space = vec_env.action_space
 
     def reset(self, *, seed: Optional[int] = None):
         obs, info = self._vec_env.reset(seed=seed)

--- a/rl_garden/training/_dataset.py
+++ b/rl_garden/training/_dataset.py
@@ -1,0 +1,62 @@
+"""Shared offline dataset specification and replay-loading helpers.
+
+Used by both the ``offline`` and ``off2on`` training packages so neither
+depends on the other's internals.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gymnasium import spaces
+
+from rl_garden.algorithms import infer_specs_from_h5
+from rl_garden.buffers import (
+    infer_specs_from_minari,
+    load_maniskill_h5_to_replay_buffer,
+    load_minari_dataset_to_replay_buffer,
+)
+
+
+def infer_offline_dataset_specs(args: Any) -> tuple[spaces.Space, spaces.Box]:
+    """Infer observation and action spaces for the configured dataset source."""
+    if args.dataset_source == "minari":
+        obs_space, action_space = infer_specs_from_minari(args.offline_dataset_path)
+        if not isinstance(action_space, spaces.Box):
+            raise ValueError(
+                f"Minari dataset {args.offline_dataset_path!r} has a "
+                f"{type(action_space).__name__} action space; only continuous "
+                "(Box) actions are supported."
+            )
+        return obs_space, action_space
+    if args.dataset_source == "maniskill_h5":
+        return infer_specs_from_h5(
+            args.offline_dataset_path,
+            action_low=args.action_low,
+            action_high=args.action_high,
+        )
+    raise ValueError(f"Unsupported offline dataset source: {args.dataset_source!r}")
+
+
+def load_offline_dataset(replay_buffer: Any, args: Any) -> int:
+    """Load the configured offline dataset into ``replay_buffer``."""
+    common_kwargs = {
+        "reward_scale": args.reward_scale,
+        "reward_bias": args.reward_bias,
+        "success_key": args.success_key,
+    }
+    if args.dataset_source == "minari":
+        return load_minari_dataset_to_replay_buffer(
+            replay_buffer,
+            args.offline_dataset_path,
+            num_episodes=args.offline_num_traj,
+            **common_kwargs,
+        )
+    if args.dataset_source == "maniskill_h5":
+        return load_maniskill_h5_to_replay_buffer(
+            replay_buffer,
+            args.offline_dataset_path,
+            num_traj=args.offline_num_traj,
+            **common_kwargs,
+        )
+    raise ValueError(f"Unsupported offline dataset source: {args.dataset_source!r}")

--- a/rl_garden/training/off2on/_args.py
+++ b/rl_garden/training/off2on/_args.py
@@ -14,6 +14,10 @@ from rl_garden.common.training_phase import InitialTrainingPhase
 class WSRLTrainingArgs(EnvRunArgs, CheckpointArgs):
     num_offline_steps: int = 0
     num_online_steps: int = 1_000_000
+    # "maniskill_h5": offline_dataset_path is a filesystem path to a ManiSkill
+    # trajectory H5 file. "minari": offline_dataset_path is a Minari dataset id
+    # instead (e.g. "D4RL/halfcheetah/medium-v2").
+    dataset_source: Literal["maniskill_h5", "minari"] = "maniskill_h5"
     offline_dataset_path: Optional[str] = None
     offline_num_traj: Optional[int] = None
     online_replay_mode: Literal["empty", "append", "mixed"] = "empty"

--- a/rl_garden/training/off2on/_wsrl_runner.py
+++ b/rl_garden/training/off2on/_wsrl_runner.py
@@ -17,6 +17,11 @@ Usage:
     # Offline→online from a ManiSkill trajectory H5
     python examples/train_off2on.py wsrl --env_id PickCube-v1 \\
         --offline_dataset_path demos/pickcube.h5 --num_offline_steps 100000
+
+    # Minari offline pretrain -> online continuation on the recovered live env
+    python examples/train_off2on.py wsrl --dataset_source minari \\
+        --offline_dataset_path "D4RL/antmaze/umaze-v1" --env_backend minari \\
+        --num_offline_steps 100000 --num_online_steps 500000
 """
 
 from __future__ import annotations
@@ -26,11 +31,11 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from gymnasium import spaces
 from tqdm import trange
 
 from rl_garden.algorithms import WSRL
 from rl_garden.algorithms.offline import _log_eval_stdout
-from rl_garden.buffers import load_maniskill_h5_to_replay_buffer
 from rl_garden.common import Logger, enable_fast_math, seed_everything
 from rl_garden.common.cli_args import (
     image_encoder_factory_from_args,
@@ -41,6 +46,7 @@ from rl_garden.common.cli_args import (
     )
 from rl_garden.common.resolved_config import persist_resolved_config
 from rl_garden.envs.backend_registry import EnvRequest, make_training_envs
+from rl_garden.training._dataset import load_offline_dataset
 from rl_garden.training.off2on._args import (
     warn_if_wsrl_warmup_uses_uninitialized_policy,
     wsrl_initial_training_phase_from_args,
@@ -161,20 +167,33 @@ def _set_offline_probe(agent: WSRL, logger: Logger, std_log: bool) -> None:
         print(f"[offline] probe_size={probe_size}", flush=True)
 
 
+def _resolve_env_id(args: WSRLOff2OnArgs) -> str:
+    """Default the online env_id to the Minari dataset id, unless overridden.
+
+    Only applies when ``dataset_source == "minari"`` and ``env_id`` is left at
+    its ``EnvRunArgs`` default; an explicit ``--env_id`` always wins.
+    """
+    if args.dataset_source == "minari" and args.env_id == "PickCube-v1":
+        return args.offline_dataset_path
+    return args.env_id
+
+
+def _require_continuous_action_space(env, args: WSRLOff2OnArgs) -> None:
+    if not isinstance(env.single_action_space, spaces.Box):
+        raise ValueError(
+            f"env_backend={args.env_backend!r} env_id={args.env_id!r} has a "
+            f"{type(env.single_action_space).__name__} action space; WSRL only "
+            "supports continuous (Box) actions."
+        )
+
+
 def _switch_to_online_mode(
     agent: WSRL, args: WSRLOff2OnArgs, logger: Logger
 ) -> None:
     if args.num_offline_steps == 0:
         warn_if_wsrl_warmup_uses_uninitialized_policy(args)
         if args.load_checkpoint is not None and args.offline_dataset_path is not None:
-            loaded = load_maniskill_h5_to_replay_buffer(
-                agent.replay_buffer,
-                args.offline_dataset_path,
-                num_traj=args.offline_num_traj,
-                reward_scale=args.reward_scale,
-                reward_bias=args.reward_bias,
-                success_key=args.success_key,
-            )
+            loaded = load_offline_dataset(agent.replay_buffer, args)
             logger.add_summary("wsrl/offline_loaded_transitions", loaded)
             _set_offline_probe(agent, logger, args.std_log)
     agent.switch_to_online_mode(
@@ -189,6 +208,8 @@ def run_wsrl(args: WSRLOff2OnArgs) -> None:
     import torch
     seed_everything(args.seed)
     enable_fast_math()
+
+    args.env_id = _resolve_env_id(args)
 
     if args.buffer_device == "cuda" and not torch.cuda.is_available():
         warnings.warn("CUDA not available; falling back to CPU buffer.", stacklevel=2)
@@ -254,6 +275,7 @@ def run_wsrl(args: WSRLOff2OnArgs) -> None:
         backend_config=backend_config,
     )
     env, eval_env = make_training_envs(args.env_backend, req)
+    _require_continuous_action_space(env, args)
 
     image_kwargs: dict = {}
     if is_visual:
@@ -347,14 +369,7 @@ def run_wsrl(args: WSRLOff2OnArgs) -> None:
             raise ValueError(
                 "--offline_dataset_path is required when --num_offline_steps > 0."
             )
-        loaded = load_maniskill_h5_to_replay_buffer(
-            agent.replay_buffer,
-            args.offline_dataset_path,
-            num_traj=args.offline_num_traj,
-            reward_scale=args.reward_scale,
-            reward_bias=args.reward_bias,
-            success_key=args.success_key,
-        )
+        loaded = load_offline_dataset(agent.replay_buffer, args)
         offline_start_step = agent._global_step
         logger.add_summary("wsrl/offline_loaded_transitions", loaded)
         logger.add_summary("wsrl/offline_start_step", offline_start_step)

--- a/rl_garden/training/offline/_runner.py
+++ b/rl_garden/training/offline/_runner.py
@@ -9,20 +9,12 @@ from typing import Any, Callable
 import torch
 from gymnasium import spaces
 
-from rl_garden.algorithms import (
-    OfflineEnvSpec,
-    infer_specs_from_h5,
-    run_offline_pretraining,
-)
-from rl_garden.buffers import (
-    infer_specs_from_minari,
-    load_maniskill_h5_to_replay_buffer,
-    load_minari_dataset_to_replay_buffer,
-)
+from rl_garden.algorithms import OfflineEnvSpec, run_offline_pretraining
 from rl_garden.common import Logger, enable_fast_math, seed_everything
 from rl_garden.common.cli_args import resolve_checkpoint_dir
 from rl_garden.common.resolved_config import persist_resolved_config
 from rl_garden.envs.backend_registry import EnvRequest, make_evaluation_env
+from rl_garden.training._dataset import infer_offline_dataset_specs, load_offline_dataset
 
 
 def _save_filename(args: Any, algorithm: str) -> str:
@@ -104,14 +96,7 @@ def run_offline(
         + f"\n|resolved_algorithm|{algorithm}|",
     )
 
-    if args.dataset_source == "minari":
-        obs_space, action_space = infer_specs_from_minari(args.offline_dataset_path)
-    else:
-        obs_space, action_space = infer_specs_from_h5(
-            args.offline_dataset_path,
-            action_low=args.action_low,
-            action_high=args.action_high,
-        )
+    obs_space, action_space = infer_offline_dataset_specs(args)
     env_spec = OfflineEnvSpec(obs_space, action_space, num_envs=args.spec_num_envs)
     if args.std_log:
         obs_desc = obs_space.shape if isinstance(obs_space, spaces.Box) else obs_space
@@ -122,24 +107,7 @@ def run_offline(
         )
 
     agent = build_agent(args, env_spec, logger)
-    if args.dataset_source == "minari":
-        loaded = load_minari_dataset_to_replay_buffer(
-            agent.replay_buffer,
-            args.offline_dataset_path,
-            num_episodes=args.offline_num_traj,
-            reward_scale=args.reward_scale,
-            reward_bias=args.reward_bias,
-            success_key=args.success_key,
-        )
-    else:
-        loaded = load_maniskill_h5_to_replay_buffer(
-            agent.replay_buffer,
-            args.offline_dataset_path,
-            num_traj=args.offline_num_traj,
-            reward_scale=args.reward_scale,
-            reward_bias=args.reward_bias,
-            success_key=args.success_key,
-        )
+    loaded = load_offline_dataset(agent.replay_buffer, args)
     logger.add_summary("offline/loaded_transitions", loaded)
     if args.std_log:
         print(f"[pretrain] loaded_transitions={loaded}", flush=True)

--- a/tests/test_off2on_wsrl_runner.py
+++ b/tests/test_off2on_wsrl_runner.py
@@ -1,0 +1,60 @@
+"""Tests for off2on/_wsrl_runner.py's Minari wiring helpers."""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from gymnasium import spaces
+
+from rl_garden.training.off2on._wsrl_runner import (
+    _require_continuous_action_space,
+    _resolve_env_id,
+)
+
+
+def _args(**overrides):
+    defaults = dict(
+        dataset_source="maniskill_h5",
+        env_id="PickCube-v1",
+        offline_dataset_path=None,
+        env_backend="maniskill",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_resolve_env_id_binds_to_minari_dataset_when_default(monkeypatch):
+    args = _args(
+        dataset_source="minari",
+        env_id="PickCube-v1",
+        offline_dataset_path="D4RL/antmaze/umaze-v1",
+    )
+    assert _resolve_env_id(args) == "D4RL/antmaze/umaze-v1"
+
+
+def test_resolve_env_id_respects_explicit_override():
+    args = _args(
+        dataset_source="minari",
+        env_id="D4RL/antmaze/large-play-v1",
+        offline_dataset_path="D4RL/antmaze/umaze-v1",
+    )
+    assert _resolve_env_id(args) == "D4RL/antmaze/large-play-v1"
+
+
+def test_resolve_env_id_unaffected_for_maniskill_h5():
+    args = _args(dataset_source="maniskill_h5", env_id="PickCube-v1")
+    assert _resolve_env_id(args) == "PickCube-v1"
+
+
+def test_require_continuous_action_space_allows_box():
+    env = SimpleNamespace(
+        single_action_space=spaces.Box(low=-1, high=1, shape=(2,), dtype=np.float32)
+    )
+    _require_continuous_action_space(env, _args())
+
+
+def test_require_continuous_action_space_rejects_discrete():
+    env = SimpleNamespace(single_action_space=spaces.Discrete(4))
+    with pytest.raises(ValueError, match="Discrete"):
+        _require_continuous_action_space(
+            env, _args(env_backend="minari", env_id="atari/pong/expert-v0")
+        )

--- a/tests/test_training_dataset_dispatch.py
+++ b/tests/test_training_dataset_dispatch.py
@@ -1,0 +1,149 @@
+"""Tests for the shared offline dataset dispatcher used by offline and off2on."""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from gymnasium import spaces
+
+from rl_garden.training._dataset import infer_offline_dataset_specs, load_offline_dataset
+
+
+def _args(**overrides):
+    defaults = dict(
+        dataset_source="maniskill_h5",
+        offline_dataset_path="demos/pickcube.h5",
+        offline_num_traj=None,
+        action_low=-1.0,
+        action_high=1.0,
+        reward_scale=1.0,
+        reward_bias=0.0,
+        success_key=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _box_spaces():
+    return (
+        spaces.Box(low=-np.inf, high=np.inf, shape=(4,), dtype=np.float32),
+        spaces.Box(low=-1, high=1, shape=(2,), dtype=np.float32),
+    )
+
+
+def test_infer_specs_routes_to_h5(monkeypatch):
+    obs_space, action_space = _box_spaces()
+    called = {}
+
+    def _fake_infer_specs_from_h5(path, *, action_low, action_high):
+        called["path"] = path
+        called["action_low"] = action_low
+        called["action_high"] = action_high
+        return obs_space, action_space
+
+    monkeypatch.setattr(
+        "rl_garden.training._dataset.infer_specs_from_h5", _fake_infer_specs_from_h5
+    )
+
+    result = infer_offline_dataset_specs(_args(dataset_source="maniskill_h5"))
+    assert result == (obs_space, action_space)
+    assert called == {"path": "demos/pickcube.h5", "action_low": -1.0, "action_high": 1.0}
+
+
+def test_infer_specs_routes_to_minari(monkeypatch):
+    obs_space, action_space = _box_spaces()
+    called = {}
+
+    def _fake_infer_specs_from_minari(dataset_id):
+        called["dataset_id"] = dataset_id
+        return obs_space, action_space
+
+    monkeypatch.setattr(
+        "rl_garden.training._dataset.infer_specs_from_minari",
+        _fake_infer_specs_from_minari,
+    )
+
+    args = _args(dataset_source="minari", offline_dataset_path="D4RL/halfcheetah/medium-v0")
+    result = infer_offline_dataset_specs(args)
+    assert result == (obs_space, action_space)
+    assert called == {"dataset_id": "D4RL/halfcheetah/medium-v0"}
+
+
+def test_infer_specs_rejects_discrete_minari_action_space(monkeypatch):
+    obs_space = spaces.Box(low=-np.inf, high=np.inf, shape=(4,), dtype=np.float32)
+    discrete_action_space = spaces.Discrete(4)
+
+    monkeypatch.setattr(
+        "rl_garden.training._dataset.infer_specs_from_minari",
+        lambda dataset_id: (obs_space, discrete_action_space),
+    )
+
+    args = _args(dataset_source="minari", offline_dataset_path="atari/pong/expert-v0")
+    with pytest.raises(ValueError, match="Discrete"):
+        infer_offline_dataset_specs(args)
+
+
+def test_infer_specs_unsupported_source_raises():
+    with pytest.raises(ValueError, match="Unsupported offline dataset source"):
+        infer_offline_dataset_specs(_args(dataset_source="bogus"))
+
+
+def test_load_offline_dataset_routes_to_h5(monkeypatch):
+    called = {}
+
+    def _fake_load_maniskill_h5(replay_buffer, path, *, num_traj, reward_scale, reward_bias, success_key):
+        called.update(
+            replay_buffer=replay_buffer,
+            path=path,
+            num_traj=num_traj,
+            reward_scale=reward_scale,
+            reward_bias=reward_bias,
+            success_key=success_key,
+        )
+        return 42
+
+    monkeypatch.setattr(
+        "rl_garden.training._dataset.load_maniskill_h5_to_replay_buffer",
+        _fake_load_maniskill_h5,
+    )
+
+    buffer = object()
+    loaded = load_offline_dataset(buffer, _args(dataset_source="maniskill_h5"))
+    assert loaded == 42
+    assert called["replay_buffer"] is buffer
+    assert called["path"] == "demos/pickcube.h5"
+
+
+def test_load_offline_dataset_routes_to_minari(monkeypatch):
+    called = {}
+
+    def _fake_load_minari(replay_buffer, dataset_id, *, num_episodes, reward_scale, reward_bias, success_key):
+        called.update(
+            replay_buffer=replay_buffer,
+            dataset_id=dataset_id,
+            num_episodes=num_episodes,
+            reward_scale=reward_scale,
+            reward_bias=reward_bias,
+            success_key=success_key,
+        )
+        return 7
+
+    monkeypatch.setattr(
+        "rl_garden.training._dataset.load_minari_dataset_to_replay_buffer",
+        _fake_load_minari,
+    )
+
+    buffer = object()
+    args = _args(
+        dataset_source="minari",
+        offline_dataset_path="D4RL/halfcheetah/medium-v0",
+        offline_num_traj=10,
+    )
+    loaded = load_offline_dataset(buffer, args)
+    assert loaded == 7
+    assert called["dataset_id"] == "D4RL/halfcheetah/medium-v0"
+    assert called["num_episodes"] == 10
+
+
+def test_load_offline_dataset_unsupported_source_raises():
+    with pytest.raises(ValueError, match="Unsupported offline dataset source"):
+        load_offline_dataset(object(), _args(dataset_source="bogus"))


### PR DESCRIPTION
## Summary
- Add `dataset_source` (`maniskill_h5` / `minari`) to the off2on WSRL runner, reusing `make_minari_env` for the live online-phase env
- Extract shared offline dataset dispatch (`infer_offline_dataset_specs` / `load_offline_dataset`) into `rl_garden/training/_dataset.py`, used by both `offline` and `off2on` runners (pure refactor for `offline`, no behavior change)
- Default online `env_id` to the Minari `offline_dataset_path` when unset, so the live env recovers from the same dataset used for offline pretraining; explicit `--env_id` always wins
- Guard against non-continuous (Discrete) action spaces at both the dataset-spec and live-env level — this feature is scoped to Box actions only
- Fix a latent bug in `rl_garden/envs/minari/env.py`'s `_TorchVectorEnvAdapter`: it never exposed vectorized `action_space`/`observation_space` (only `single_*`), which crashed `OffPolicyAlgorithm._explore_action` on first real online rollout (previously unexercised, since the offline package only used this backend for periodic eval scoring)
- Add `gymnasium-robotics` to the `minari` extra in `pyproject.toml` (required by `dataset.recover_environment()` for D4RL AntMaze/PointMaze/Adroit/Kitchen)

## Verification
- `pytest tests/test_training_dataset_dispatch.py tests/test_off2on_wsrl_runner.py tests/test_minari_dataset_loader.py tests/test_minari_env_backend.py -q` → 22 passed
- `pytest tests/ -k offline --ignore=tests/test_act_provider.py -q` → 26 passed (refactor is behavior-preserving; `test_act_provider.py` collection error is a pre-existing missing-`torchvision` dependency gap, unrelated to this branch, also present on `main`)
- Real end-to-end smoke test (non-mocked): offline BC on `D4RL/pointmaze/umaze-v2` (dict/goal-conditioned obs), and off2on CalQL/WSRL offline pretrain → checkpoint → online continuation on the live recovered PointMaze env, both exiting code 0

## Test plan
- [x] Feature unit tests pass
- [x] Offline regression suite passes (refactor verification)
- [x] Real end-to-end offline + off2on online-phase smoke test on a live Minari/D4RL env

🤖 Generated with [Claude Code](https://claude.com/claude-code)