### PR TITLE
Add q-contrast diagnostics and checkpoint eval fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ docs/superpowers/
 
 # 默认忽略模型权重文件
 *.pt
+
+*.html

--- a/examples/eval_checkpoint.py
+++ b/examples/eval_checkpoint.py
@@ -38,6 +38,7 @@ from rl_garden.common.env_args import (
     MujocoWarpConfig,
     RoboTwinConfig,
 )
+from rl_garden.common.eval_metrics import EVAL_METRIC_ALIASES, EVAL_METRIC_DROP
 from rl_garden.common.resolved_config import resolved_config_json
 from rl_garden.envs.backend_registry import (
     EnvRequest,
@@ -372,7 +373,10 @@ def _append_metric_values(
     remaining: int,
 ) -> int:
     appended = 0
-    for key, value in episode.items():
+    for raw_key, value in episode.items():
+        if raw_key.startswith("_") or raw_key in EVAL_METRIC_DROP or isinstance(value, Mapping):
+            continue
+        key = EVAL_METRIC_ALIASES.get(raw_key, raw_key)
         values = _to_cpu_1d(value)
         if values.numel() == mask.numel():
             values = values[mask]

--- a/examples/eval_checkpoint.py
+++ b/examples/eval_checkpoint.py
@@ -1,0 +1,561 @@
+"""Evaluate a saved rl-garden checkpoint in a live environment.
+
+This is a generic checkpoint evaluation entrypoint: it builds the requested
+algorithm, loads model weights without replay/optimizer state, then runs policy
+evaluation until the requested number of completed episodes is collected.
+
+Example:
+
+    python -u tools/evaluation/eval_checkpoint.py \
+      --phase offline --algorithm calql \
+      --checkpoint-path runs/.../calql_offline_pretrained.pt \
+      --env-id PickCube-v1 --obs-mode state \
+      --num-eval-envs 16 --num-eval-episodes 50 \
+      --capture-video false --output-json /tmp/calql_eval.json
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, is_dataclass
+import importlib
+import json
+from pathlib import Path
+import re
+import time
+from typing import Any, Literal, Mapping, Optional
+
+import torch
+import tyro
+
+from rl_garden.algorithms import OfflineEnvSpec
+from rl_garden.common import Logger, enable_fast_math, seed_everything
+from rl_garden.common.checkpoint import _canonical_algorithm_class, load_checkpoint_file
+from rl_garden.common.env_args import (
+    EnvBackendArgs,
+    ManiSkillConfig,
+    MinariConfig,
+    MujocoConfig,
+    MujocoWarpConfig,
+    RoboTwinConfig,
+)
+from rl_garden.common.resolved_config import resolved_config_json
+from rl_garden.envs.backend_registry import (
+    EnvRequest,
+    make_evaluation_env,
+    make_training_envs,
+)
+
+Phase = Literal["auto", "online", "offline", "off2on"]
+
+
+@dataclass
+class EvalCheckpointArgs(EnvBackendArgs):
+    checkpoint_path: str = ""
+    phase: Phase = "auto"
+    algorithm: str = "auto"
+    config_path: Optional[str] = None
+
+    env_id: str = "PickCube-v1"
+    obs_mode: str = "state"
+    control_mode: str = "pd_joint_delta_pos"
+    render_mode: str = "rgb_array"
+    num_eval_envs: int = 16
+    num_eval_episodes: int = 50
+    max_eval_steps: Optional[int] = None
+    seed: int = 1
+    device: str = "auto"
+    buffer_device: str = "cpu"
+
+    include_state: bool = True
+    camera_width: Optional[int] = 64
+    camera_height: Optional[int] = 64
+    per_camera_rgbd: bool = False
+    frame_stack: int = 1
+    reward_scale: float = 1.0
+    reward_bias: float = 0.0
+
+    capture_video: bool = False
+    video_fps: int = 30
+    eval_output_dir: Optional[str] = None
+    output_json: Optional[str] = None
+    strict: bool = True
+
+    log_type: str = "none"
+    std_log: bool = True
+
+    maniskill: ManiSkillConfig = field(default_factory=ManiSkillConfig)
+    robotwin: RoboTwinConfig = field(default_factory=RoboTwinConfig)
+    minari: MinariConfig = field(default_factory=MinariConfig)
+    mujoco: MujocoConfig = field(default_factory=MujocoConfig)
+    mujoco_warp: MujocoWarpConfig = field(default_factory=MujocoWarpConfig)
+
+
+_PHASES: tuple[str, ...] = ("online", "offline", "off2on")
+
+
+def _snake_case(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def _algorithm_from_class(algorithm_class: Any) -> str | None:
+    if not isinstance(algorithm_class, str):
+        return None
+    canonical = _canonical_algorithm_class(algorithm_class)
+    name = str(canonical)
+    if name.startswith("Off2On"):
+        name = name.removeprefix("Off2On")
+    known = {
+        "AWAC": "awac",
+        "BC": "bc",
+        "CalQL": "calql",
+        "CQL": "cql",
+        "DrQv2": "drqv2",
+        "FlashSAC": "flash_sac",
+        "IQL": "iql",
+        "PPO": "ppo",
+        "RLPD": "rlpd",
+        "SAC": "sac",
+        "TD3": "td3",
+        "TD3BC": "td3_bc",
+        "TDMPC2": "tdmpc2",
+        "WSRL": "wsrl",
+    }
+    if name in known:
+        return known[name]
+    return _snake_case(name)
+
+
+def _registry_for_phase(phase: str):
+    module = importlib.import_module(f"rl_garden.training.{phase}._registry")
+    registry = module.registry
+    registry.discover()
+    return registry
+
+
+def _resolve_phase_and_algorithm(
+    requested_phase: str,
+    requested_algorithm: str,
+    checkpoint: Mapping[str, Any],
+) -> tuple[str, str]:
+    metadata = checkpoint.get("metadata", {})
+    inferred_algorithm = _algorithm_from_class(metadata.get("algorithm_class"))
+    algorithm = requested_algorithm if requested_algorithm != "auto" else inferred_algorithm
+    if algorithm is None:
+        raise SystemExit(
+            "Could not infer algorithm from checkpoint metadata; pass --algorithm."
+        )
+
+    phases = _PHASES if requested_phase == "auto" else (requested_phase,)
+    matches: list[tuple[str, str]] = []
+    for phase in phases:
+        registry = _registry_for_phase(phase)
+        if algorithm in registry.entries():
+            matches.append((phase, algorithm))
+
+    if not matches:
+        raise SystemExit(
+            f"Algorithm {algorithm!r} is not registered for phase "
+            f"{requested_phase!r}."
+        )
+    if requested_phase == "auto" and len(matches) > 1:
+        choices = ", ".join(f"{phase}:{alg}" for phase, alg in matches)
+        raise SystemExit(
+            f"Checkpoint algorithm {algorithm!r} is ambiguous across phases "
+            f"({choices}); pass --phase explicitly."
+        )
+    return matches[0]
+
+
+def _set_existing_attr(target: Any, key: str, value: Any) -> None:
+    if not hasattr(target, key):
+        return
+    current = getattr(target, key)
+    if is_dataclass(current) and isinstance(value, Mapping):
+        _apply_mapping_to_args(current, value)
+    else:
+        setattr(target, key, value)
+
+
+def _apply_mapping_to_args(args: Any, values: Mapping[str, Any]) -> None:
+    for key, value in values.items():
+        _set_existing_attr(args, key, value)
+
+
+def _config_args(config_path: Path) -> Mapping[str, Any]:
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    args = config.get("args", config)
+    if not isinstance(args, Mapping):
+        raise SystemExit(f"Config {config_path} does not contain an args mapping.")
+    return args
+
+
+def _default_config_path(checkpoint_path: Path) -> Path:
+    return checkpoint_path.parent.parent / "config.json"
+
+
+def _load_training_args(
+    phase: str,
+    algorithm: str,
+    eval_args: EvalCheckpointArgs,
+    checkpoint: Mapping[str, Any],
+) -> Any:
+    registry = _registry_for_phase(phase)
+    entry = registry.entries()[algorithm]
+    args = entry.args_cls()
+
+    config_path = (
+        Path(eval_args.config_path)
+        if eval_args.config_path is not None
+        else _default_config_path(Path(eval_args.checkpoint_path))
+    )
+    if config_path.exists():
+        _apply_mapping_to_args(args, _config_args(config_path))
+
+    metadata = checkpoint.get("metadata", {})
+    hyperparameters = metadata.get("hyperparameters", {})
+    if isinstance(hyperparameters, Mapping):
+        _apply_mapping_to_args(args, hyperparameters)
+
+    overrides = {
+        "env_backend": eval_args.env_backend,
+        "env_id": eval_args.env_id,
+        "obs_mode": eval_args.obs_mode,
+        "control_mode": eval_args.control_mode,
+        "render_mode": eval_args.render_mode,
+        "num_envs": eval_args.num_eval_envs,
+        "num_eval_envs": eval_args.num_eval_envs,
+        "num_eval_steps": eval_args.max_eval_steps
+        or max(eval_args.num_eval_episodes * 1000, 1),
+        "seed": eval_args.seed,
+        "device": eval_args.device,
+        "buffer_device": eval_args.buffer_device,
+        "include_state": eval_args.include_state,
+        "camera_width": eval_args.camera_width,
+        "camera_height": eval_args.camera_height,
+        "per_camera_rgbd": eval_args.per_camera_rgbd,
+        "frame_stack": eval_args.frame_stack,
+        "reward_scale": eval_args.reward_scale,
+        "reward_bias": eval_args.reward_bias,
+        "capture_video": eval_args.capture_video,
+        "video_fps": eval_args.video_fps,
+        "eval_output_dir": eval_args.eval_output_dir,
+        "eval_freq": 1,
+        "log_type": eval_args.log_type,
+        "std_log": eval_args.std_log,
+        "load_checkpoint": None,
+        "load_replay_buffer": False,
+        "checkpoint_dir": None,
+        "checkpoint_freq": 0,
+        "save_replay_buffer": False,
+        "save_final_checkpoint": False,
+    }
+    _apply_mapping_to_args(args, overrides)
+    _apply_mapping_to_args(
+        args,
+        {
+            "maniskill": eval_args.maniskill,
+            "robotwin": eval_args.robotwin,
+            "minari": eval_args.minari,
+            "mujoco": eval_args.mujoco,
+            "mujoco_warp": eval_args.mujoco_warp,
+        },
+    )
+    return args
+
+
+def _eval_record_dir(eval_args: EvalCheckpointArgs) -> str | None:
+    if not eval_args.capture_video:
+        return None
+    if eval_args.eval_output_dir is not None:
+        return eval_args.eval_output_dir
+    checkpoint_path = Path(eval_args.checkpoint_path)
+    return str(checkpoint_path.parent / "eval_videos")
+
+
+def _env_request(args: Any, eval_args: EvalCheckpointArgs) -> EnvRequest:
+    is_visual = args.obs_mode != "state"
+    return EnvRequest(
+        env_id=args.env_id,
+        num_envs=args.num_eval_envs,
+        obs_mode=args.obs_mode,
+        control_mode=args.control_mode,
+        render_mode=args.render_mode,
+        seed=args.seed,
+        camera_width=args.camera_width if is_visual else None,
+        camera_height=args.camera_height if is_visual else None,
+        include_state=args.include_state if is_visual else True,
+        per_camera_rgbd=args.per_camera_rgbd if is_visual else False,
+        frame_stack=getattr(args, "frame_stack", 1),
+        reward_scale=getattr(args, "reward_scale", 1.0),
+        reward_bias=getattr(args, "reward_bias", 0.0),
+        num_eval_envs=args.num_eval_envs,
+        eval_record_dir=_eval_record_dir(eval_args),
+        capture_video=eval_args.capture_video,
+        video_fps=eval_args.video_fps,
+        num_eval_steps=args.num_eval_steps,
+        create_eval_env=True,
+        backend_config=args.resolve_backend_config(),
+    )
+
+
+def _training_module(phase: str, algorithm: str):
+    return importlib.import_module(
+        f"rl_garden.training.{phase}.{algorithm.replace('-', '_')}"
+    )
+
+
+def _builder_from_module(module: Any, algorithm: str):
+    expected = f"build_{algorithm.replace('-', '_')}"
+    if hasattr(module, expected):
+        return getattr(module, expected)
+    builders = [
+        getattr(module, name)
+        for name in dir(module)
+        if name.startswith("build_") and callable(getattr(module, name))
+    ]
+    if len(builders) != 1:
+        raise SystemExit(
+            f"Could not identify a unique build_* function in {module.__name__}."
+        )
+    return builders[0]
+
+
+def _build_agent(
+    phase: str,
+    algorithm: str,
+    args: Any,
+    eval_args: EvalCheckpointArgs,
+):
+    logger = Logger(log_type="none")
+    req = _env_request(args, eval_args)
+    module = _training_module(phase, algorithm)
+    build_agent = _builder_from_module(module, algorithm)
+
+    if phase == "offline":
+        eval_env = make_evaluation_env(args.env_backend, req)
+        env_spec = OfflineEnvSpec(
+            eval_env.single_observation_space,
+            eval_env.single_action_space,
+            num_envs=1,
+        )
+        agent = build_agent(args, env_spec, logger, eval_env)
+        return agent, None, eval_env
+
+    train_env, eval_env = make_training_envs(args.env_backend, req)
+    agent = build_agent(args, train_env, eval_env, logger, None)
+    return agent, train_env, eval_env
+
+
+def _reset_env(env: Any, seed: int):
+    try:
+        return env.reset(seed=seed)
+    except TypeError:
+        return env.reset()
+
+
+def _to_cpu_1d(value: Any) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().reshape(-1)
+    return torch.as_tensor(value).detach().cpu().reshape(-1)
+
+
+def _done_mask(infos: Mapping[str, Any], terminations: Any, truncations: Any) -> torch.Tensor:
+    if "_final_info" in infos:
+        return _to_cpu_1d(infos["_final_info"]).bool()
+    return (_to_cpu_1d(terminations).bool() | _to_cpu_1d(truncations).bool())
+
+
+def _append_metric_values(
+    metrics: dict[str, list[float]],
+    episode: Mapping[str, Any],
+    mask: torch.Tensor,
+    remaining: int,
+) -> int:
+    appended = 0
+    for key, value in episode.items():
+        values = _to_cpu_1d(value)
+        if values.numel() == mask.numel():
+            values = values[mask]
+        take = min(values.numel(), remaining)
+        if take <= 0:
+            continue
+        metrics.setdefault(key, []).extend(float(v) for v in values[:take])
+        appended = max(appended, take)
+    return appended
+
+
+def evaluate_agent(
+    agent: Any,
+    eval_env: Any,
+    *,
+    seed: int,
+    num_eval_episodes: int,
+    max_eval_steps: int,
+) -> dict[str, float]:
+    if eval_env is None:
+        raise SystemExit("Evaluation environment was not created.")
+
+    agent.policy.eval()
+    obs, _ = _reset_env(eval_env, seed)
+    agent._eval_start_hook()
+
+    metrics: dict[str, list[float]] = {}
+    running_returns = torch.zeros(eval_env.num_envs, dtype=torch.float32)
+    completed = 0
+    steps = 0
+
+    try:
+        while completed < num_eval_episodes and steps < max_eval_steps:
+            with torch.no_grad():
+                env_action, critic_action = agent._eval_action_and_critic_action(obs)
+                obs_before = obs
+                obs, rewards, terminations, truncations, infos = eval_env.step(env_action)
+                agent._eval_step_hook(
+                    obs_before,
+                    critic_action,
+                    rewards,
+                    terminations,
+                    truncations,
+                    infos,
+                )
+
+            rewards_cpu = _to_cpu_1d(rewards).float()
+            running_returns[: rewards_cpu.numel()] += rewards_cpu
+            mask = _done_mask(infos, terminations, truncations)
+            remaining = num_eval_episodes - completed
+
+            appended = 0
+            if isinstance(infos, Mapping) and "final_info" in infos:
+                final_info = infos["final_info"]
+                if isinstance(final_info, Mapping) and "episode" in final_info:
+                    episode = final_info["episode"]
+                    if isinstance(episode, Mapping):
+                        appended = _append_metric_values(
+                            metrics, episode, mask, remaining
+                        )
+
+            if appended == 0 and mask.any():
+                done_returns = running_returns[mask[: running_returns.numel()]]
+                take = min(done_returns.numel(), remaining)
+                metrics.setdefault("return", []).extend(
+                    float(v) for v in done_returns[:take]
+                )
+                appended = take
+
+            if mask.any():
+                running_returns[mask[: running_returns.numel()]] = 0.0
+            completed += appended
+            steps += 1
+    finally:
+        agent.policy.train()
+
+    if completed < num_eval_episodes:
+        raise SystemExit(
+            f"Only completed {completed}/{num_eval_episodes} episodes within "
+            f"max_eval_steps={max_eval_steps}."
+        )
+
+    out = {
+        key: float(torch.tensor(values, dtype=torch.float32).mean().item())
+        for key, values in sorted(metrics.items())
+        if values
+    }
+    out["episodes_completed"] = float(completed)
+    out["eval_steps"] = float(steps)
+    out.update(agent._eval_finalize_hook())
+    return out
+
+
+def _headline_metrics(metrics: Mapping[str, float]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    if "return" in metrics:
+        out["average_return"] = metrics["return"]
+    for key in ("success_at_end", "success_once", "success"):
+        if key in metrics:
+            out["success_rate"] = metrics[key]
+            break
+    for key in ("success_at_end", "success_once", "success", "episodes_completed"):
+        if key in metrics:
+            out[key] = metrics[key]
+    return out
+
+
+def _write_json(path: str, payload: Mapping[str, Any]) -> None:
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(resolved_config_json(payload) + "\n", encoding="utf-8")
+
+
+def evaluate_checkpoint(eval_args: EvalCheckpointArgs) -> dict[str, Any]:
+    if not eval_args.checkpoint_path:
+        raise SystemExit("--checkpoint-path is required.")
+    if eval_args.num_eval_episodes <= 0:
+        raise SystemExit("--num-eval-episodes must be positive.")
+
+    checkpoint_path = Path(eval_args.checkpoint_path)
+    checkpoint = load_checkpoint_file(checkpoint_path, map_location="cpu")
+    phase, algorithm = _resolve_phase_and_algorithm(
+        eval_args.phase,
+        eval_args.algorithm,
+        checkpoint,
+    )
+    args = _load_training_args(phase, algorithm, eval_args, checkpoint)
+    seed_everything(args.seed)
+    enable_fast_math()
+
+    agent, train_env, eval_env = _build_agent(phase, algorithm, args, eval_args)
+    try:
+        agent.load(
+            checkpoint_path,
+            strict=eval_args.strict,
+            load_replay_buffer=False,
+            load_optimizers=False,
+        )
+        max_eval_steps = eval_args.max_eval_steps or max(eval_args.num_eval_episodes * 1000, 1)
+        metrics = evaluate_agent(
+            agent,
+            eval_env,
+            seed=eval_args.seed,
+            num_eval_episodes=eval_args.num_eval_episodes,
+            max_eval_steps=max_eval_steps,
+        )
+    finally:
+        if eval_env is not None:
+            eval_env.close()
+        if train_env is not None:
+            train_env.close()
+
+    result = {
+        "checkpoint_path": str(checkpoint_path),
+        "phase": phase,
+        "algorithm": algorithm,
+        "env_backend": args.env_backend,
+        "env_id": args.env_id,
+        "obs_mode": args.obs_mode,
+        "control_mode": args.control_mode,
+        "num_eval_envs": args.num_eval_envs,
+        "num_eval_episodes": eval_args.num_eval_episodes,
+        "timestamp": time.strftime("%Y%m%d_%H%M%S", time.localtime()),
+        "headline": _headline_metrics(metrics),
+        "metrics": metrics,
+    }
+    if eval_args.output_json:
+        result["output_json"] = eval_args.output_json
+        _write_json(eval_args.output_json, result)
+    return result
+
+
+def main() -> None:
+    result = evaluate_checkpoint(tyro.cli(EvalCheckpointArgs))
+    print("=== Evaluation Results ===", flush=True)
+    for key, value in result["headline"].items():
+        print(f"{key}: {value:.4f}", flush=True)
+    print("--- all metrics ---", flush=True)
+    for key, value in result["metrics"].items():
+        print(f"{key}: {value:.4f}", flush=True)
+    if "output_json" in result:
+        print(f"output_json: {result['output_json']}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/rl_garden/algorithms/offline.py
+++ b/rl_garden/algorithms/offline.py
@@ -264,12 +264,17 @@ def run_offline_pretraining(
         and hasattr(agent, "_log_eval_metrics")
     )
 
+    interval_update_time = 0.0
+    interval_update_steps = 0
     for step in trange(start_step, final_target, desc=desc):
         global_step = step + 1
         should_log = log_freq > 0 and (
             global_step % log_freq == 0 or global_step == final_target
         )
+        update_t = time.perf_counter()
         last_metrics = agent.train(gradient_steps, compute_info=should_log)
+        interval_update_time += time.perf_counter() - update_t
+        interval_update_steps += gradient_steps
         agent._global_step = global_step
 
         if (
@@ -290,6 +295,21 @@ def run_offline_pretraining(
 
         if log_freq > 0 and global_step % log_freq == 0:
             _log_update_metrics(agent, last_metrics, global_step)
+            logger = getattr(agent, "logger", None)
+            if logger is not None:
+                offline_update_fps = (
+                    interval_update_steps / interval_update_time
+                    if interval_update_time > 0
+                    else float("nan")
+                )
+                logger.add_scalar(
+                    "time/offline_update_time", interval_update_time, global_step
+                )
+                logger.add_scalar(
+                    "time/offline_update_fps", offline_update_fps, global_step
+                )
+            interval_update_time = 0.0
+            interval_update_steps = 0
             if std_log:
                 completed = global_step - start_step
                 progress = 100.0 * completed / num_steps

--- a/rl_garden/buffers/minari_dataset.py
+++ b/rl_garden/buffers/minari_dataset.py
@@ -17,6 +17,7 @@ from rl_garden.buffers._dataset_common import (
     _to_tensor,
 )
 from rl_garden.buffers.base import BaseReplayBuffer
+from rl_garden.common.spaces import canonicalize_floating_observation_space
 
 
 def _require_minari():
@@ -34,7 +35,10 @@ def infer_specs_from_minari(dataset_id: str) -> tuple[spaces.Space, spaces.Space
     """Return the observation/action spaces stored on a Minari dataset."""
     minari = _require_minari()
     dataset = minari.load_dataset(dataset_id, download=True)
-    return dataset.observation_space, dataset.action_space
+    return (
+        canonicalize_floating_observation_space(dataset.observation_space),
+        dataset.action_space,
+    )
 
 
 def load_minari_dataset_to_replay_buffer(

--- a/rl_garden/common/checkpoint.py
+++ b/rl_garden/common/checkpoint.py
@@ -14,6 +14,7 @@ from gymnasium import spaces
 
 from rl_garden.buffers.base import BaseReplayBuffer
 from rl_garden.buffers.dict_buffer import DictArray
+from rl_garden.common.spaces import canonicalize_floating_observation_space
 
 FORMAT_VERSION = 1
 
@@ -50,6 +51,26 @@ def space_metadata(space: spaces.Space) -> dict[str, Any]:
     return {"type": type(space).__name__}
 
 
+def _observation_space_metadata(space: spaces.Space) -> dict[str, Any]:
+    return space_metadata(canonicalize_floating_observation_space(space))
+
+
+def _canonical_observation_metadata(metadata: Any) -> Any:
+    if not isinstance(metadata, dict):
+        return metadata
+    if metadata.get("type") == "Box" and str(metadata.get("dtype")).startswith("float"):
+        return {**metadata, "dtype": "float32"}
+    if metadata.get("type") == "Dict" and isinstance(metadata.get("spaces"), dict):
+        return {
+            **metadata,
+            "spaces": {
+                key: _canonical_observation_metadata(value)
+                for key, value in metadata["spaces"].items()
+            },
+        }
+    return metadata
+
+
 def validate_checkpoint_metadata(
     checkpoint: dict[str, Any],
     *,
@@ -74,9 +95,9 @@ def validate_checkpoint_metadata(
             f"current agent is {algorithm_class!r}"
         )
 
-    current_obs = space_metadata(observation_space)
+    current_obs = _observation_space_metadata(observation_space)
     current_action = space_metadata(action_space)
-    if metadata.get("observation_space") != current_obs:
+    if _canonical_observation_metadata(metadata.get("observation_space")) != current_obs:
         errors.append("observation_space metadata does not match current env")
     if metadata.get("action_space") != current_action:
         errors.append("action_space metadata does not match current env")
@@ -102,7 +123,7 @@ def checkpoint_dict(
             "algorithm_class": algorithm_class,
             "global_step": int(global_step),
             "global_update": int(global_update),
-            "observation_space": space_metadata(observation_space),
+            "observation_space": _observation_space_metadata(observation_space),
             "action_space": space_metadata(action_space),
             "hyperparameters": hyperparameters,
             "replay_buffer_path": replay_buffer_path,

--- a/rl_garden/common/logger.py
+++ b/rl_garden/common/logger.py
@@ -9,6 +9,33 @@ from torch.utils.tensorboard import SummaryWriter
 LogType = Literal["tensorboard", "wandb", "none"]
 
 
+def _flatten_wandb_config(config: dict[str, Any], sep: str = ".") -> dict[str, Any]:
+    """Flatten a resolved-config dict for wandb's config table.
+
+    ``resolved_run_config()`` nests every training arg under one ``"args"``
+    key (so ``config.json`` reads as a structured record), but wandb's table
+    view doesn't expand nested dicts into columns. Promote ``args``' own keys
+    to the top level unprefixed (matching the pre-refactor flat schema every
+    existing wandb report/table filter was built against), and dot-flatten
+    any further nesting (e.g. per-backend ``EnvBackendArgs`` groups).
+    """
+    flat: dict[str, Any] = {}
+
+    def _add(prefix: str, value: Any) -> None:
+        if isinstance(value, dict):
+            for key, sub_value in value.items():
+                _add(f"{prefix}{sep}{key}" if prefix else str(key), sub_value)
+        else:
+            flat[prefix] = value
+
+    for key, value in config.items():
+        if key == "args" and isinstance(value, dict):
+            _add("", value)
+        else:
+            _add(str(key), value)
+    return flat
+
+
 class Logger:
     def __init__(
         self,
@@ -81,7 +108,7 @@ class Logger:
         init_kwargs: dict[str, Any] = {
             "project": wandb_project,
             "name": wandb_name,
-            "config": config or {},
+            "config": _flatten_wandb_config(config or {}),
         }
         if wandb_entity:
             init_kwargs["entity"] = wandb_entity

--- a/rl_garden/common/spaces.py
+++ b/rl_garden/common/spaces.py
@@ -1,0 +1,29 @@
+"""Shared Gymnasium space normalization helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+from gymnasium import spaces
+
+
+def canonicalize_floating_observation_space(space: spaces.Space) -> spaces.Space:
+    """Return rl-garden's runtime observation-space view.
+
+    Floating observations are represented as float32 tensors in the training
+    path. Keep non-floating spaces (for example uint8 images) unchanged.
+    """
+    if isinstance(space, spaces.Dict):
+        return spaces.Dict(
+            {
+                key: canonicalize_floating_observation_space(subspace)
+                for key, subspace in space.spaces.items()
+            }
+        )
+    if isinstance(space, spaces.Box) and np.issubdtype(space.dtype, np.floating):
+        return spaces.Box(
+            low=space.low.astype(np.float32),
+            high=space.high.astype(np.float32),
+            shape=space.shape,
+            dtype=np.float32,
+        )
+    return space

--- a/rl_garden/envs/vector_env.py
+++ b/rl_garden/envs/vector_env.py
@@ -32,31 +32,12 @@ from __future__ import annotations
 
 from typing import Any
 
-import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.vector import AutoresetMode, VectorEnv, VectorWrapper
 from gymnasium.vector.utils import batch_space
 
-
-def _translate_box(space: gym.spaces.Box) -> gym.spaces.Box:
-    if not np.issubdtype(space.dtype, np.floating):
-        # uint8 image spaces etc. pass through unchanged (raw pixel values).
-        return space
-    return gym.spaces.Box(
-        low=space.low.astype(np.float32),
-        high=space.high.astype(np.float32),
-        shape=space.shape,
-        dtype=np.float32,
-    )
-
-
-def _translate_space(space: gym.Space) -> gym.Space:
-    if isinstance(space, gym.spaces.Dict):
-        return gym.spaces.Dict({key: _translate_space(sub) for key, sub in space.spaces.items()})
-    if isinstance(space, gym.spaces.Box):
-        return _translate_box(space)
-    return space
+from rl_garden.common.spaces import canonicalize_floating_observation_space
 
 
 class TorchVectorEnvAdapter(VectorWrapper):
@@ -67,7 +48,9 @@ class TorchVectorEnvAdapter(VectorWrapper):
     def __init__(self, vec_env: VectorEnv, device: str) -> None:
         super().__init__(vec_env)
         self.device = torch.device(device)
-        self.single_observation_space = _translate_space(vec_env.single_observation_space)
+        self.single_observation_space = canonicalize_floating_observation_space(
+            vec_env.single_observation_space
+        )
         self.observation_space = batch_space(self.single_observation_space, vec_env.num_envs)
         self.single_action_space = vec_env.single_action_space
         # off_policy.py's random-exploration phase reads the batched

--- a/rl_garden/envs/wrappers/reward_transform.py
+++ b/rl_garden/envs/wrappers/reward_transform.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 
 import gymnasium as gym
 
+# gymnasium >=1.0 exposes the vector wrapper base class as ``gym.vector.VectorWrapper``;
+# gymnasium 0.29.x (pinned by ManiSkill) only has the equivalent ``VectorEnvWrapper``.
+_VectorWrapperBase = getattr(gym.vector, "VectorWrapper", None) or gym.vector.VectorEnvWrapper
+
 
 class RewardScaleBiasWrapper(gym.Wrapper):
     """Multiply reward by ``scale`` and add ``bias`` on each step.
@@ -28,7 +32,7 @@ class RewardScaleBiasWrapper(gym.Wrapper):
         return obs, self.reward_scale * reward + self.reward_bias, terminated, truncated, info
 
 
-class RewardScaleBiasVectorWrapper(gym.vector.VectorWrapper):
+class RewardScaleBiasVectorWrapper(_VectorWrapperBase):
     """Multiply reward by ``scale`` and add ``bias`` on each step, for vector envs.
 
     ``RewardScaleBiasWrapper`` above subclasses ``gym.Wrapper``, whose

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -436,3 +436,48 @@ def test_legacy_offline_cql_algorithm_class_alias_resolves_to_cql():
         action_space=action_space,
         strict=True,
     )
+
+
+def test_observation_metadata_float64_matches_runtime_float32():
+    from gymnasium import spaces as gym_spaces
+
+    from rl_garden.common.checkpoint import (
+        FORMAT_VERSION,
+        space_metadata,
+        validate_checkpoint_metadata,
+    )
+
+    checkpoint_obs = gym_spaces.Dict(
+        {
+            "observation": gym_spaces.Box(
+                low=-1.0, high=1.0, shape=(3,), dtype=np.float64
+            ),
+            "rgb": gym_spaces.Box(low=0, high=255, shape=(4, 4, 3), dtype=np.uint8),
+        }
+    )
+    runtime_obs = gym_spaces.Dict(
+        {
+            "observation": gym_spaces.Box(
+                low=-1.0, high=1.0, shape=(3,), dtype=np.float32
+            ),
+            "rgb": gym_spaces.Box(low=0, high=255, shape=(4, 4, 3), dtype=np.uint8),
+        }
+    )
+    action_space = gym_spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+    checkpoint = {
+        "format_version": FORMAT_VERSION,
+        "metadata": {
+            "algorithm_class": "CalQL",
+            "observation_space": space_metadata(checkpoint_obs),
+            "action_space": space_metadata(action_space),
+        },
+    }
+
+    validate_checkpoint_metadata(
+        checkpoint,
+        algorithm_class="CalQL",
+        compatible_algorithms=("CalQL",),
+        observation_space=runtime_obs,
+        action_space=action_space,
+        strict=True,
+    )

--- a/tests/test_eval_checkpoint.py
+++ b/tests/test_eval_checkpoint.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "examples" / "eval_checkpoint.py"
+    spec = importlib.util.spec_from_file_location("eval_checkpoint", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+eval_checkpoint = _load_module()
+
+
+class _Policy:
+    def __init__(self):
+        self.training = True
+
+    def eval(self):
+        self.training = False
+
+    def train(self):
+        self.training = True
+
+
+class _Agent:
+    def __init__(self):
+        self.policy = _Policy()
+        self.started = False
+        self.finalized = False
+        self.hook_steps = 0
+
+    def _eval_start_hook(self):
+        self.started = True
+
+    def _eval_action_and_critic_action(self, obs):
+        batch = obs.shape[0]
+        action = torch.zeros(batch, 1)
+        return action, action
+
+    def _eval_step_hook(
+        self, obs_before, critic_action, rewards, terminations, truncations, infos
+    ):
+        self.hook_steps += 1
+
+    def _eval_finalize_hook(self):
+        self.finalized = True
+        return {"extra_metric": 7.0}
+
+
+class _VectorEvalEnv:
+    num_envs = 2
+
+    def __init__(self):
+        self.step_count = 0
+
+    def reset(self, seed=None):
+        self.step_count = 0
+        return torch.zeros(self.num_envs, 3), {}
+
+    def step(self, action):
+        self.step_count += 1
+        obs = torch.zeros(self.num_envs, 3)
+        rewards = torch.tensor([1.0, 2.0])
+        terminations = torch.tensor([self.step_count == 1, self.step_count == 2])
+        truncations = torch.zeros(self.num_envs, dtype=torch.bool)
+        if self.step_count == 1:
+            infos = {
+                "_final_info": torch.tensor([True, False]),
+                "final_info": {
+                    "episode": {
+                        "return": torch.tensor([11.0, 0.0]),
+                        "success_at_end": torch.tensor([1.0, 0.0]),
+                    }
+                },
+            }
+        else:
+            infos = {
+                "_final_info": torch.tensor([False, True]),
+                "final_info": {
+                    "episode": {
+                        "return": torch.tensor([0.0, 22.0]),
+                        "success_at_end": torch.tensor([0.0, 0.0]),
+                    }
+                },
+            }
+        return obs, rewards, terminations, truncations, infos
+
+
+def test_algorithm_from_class_handles_off2on_prefix_and_alias():
+    assert eval_checkpoint._algorithm_from_class("Off2OnIQL") == "iql"
+    assert eval_checkpoint._algorithm_from_class("OfflineCalQL") == "calql"
+
+
+def test_headline_metrics_prefers_success_at_end():
+    metrics = {
+        "return": 3.5,
+        "success_at_end": 0.25,
+        "success_once": 0.75,
+        "episodes_completed": 8.0,
+    }
+
+    headline = eval_checkpoint._headline_metrics(metrics)
+
+    assert headline["average_return"] == 3.5
+    assert headline["success_rate"] == 0.25
+    assert headline["success_once"] == 0.75
+
+
+def test_apply_mapping_to_args_updates_nested_dataclass():
+    args = eval_checkpoint.EvalCheckpointArgs()
+
+    eval_checkpoint._apply_mapping_to_args(
+        args,
+        {
+            "env_id": "StackCube-v1",
+            "maniskill": {"sim_backend": "physx_cpu", "reward_mode": "dense"},
+            "unknown": "ignored",
+        },
+    )
+
+    assert args.env_id == "StackCube-v1"
+    assert args.maniskill.sim_backend == "physx_cpu"
+    assert args.maniskill.reward_mode == "dense"
+    assert not hasattr(args, "unknown")
+
+
+def test_append_metric_values_masks_final_info():
+    metrics = {}
+    mask = torch.tensor([False, True, True])
+
+    appended = eval_checkpoint._append_metric_values(
+        metrics,
+        {"return": torch.tensor([1.0, 2.0, 3.0])},
+        mask,
+        remaining=1,
+    )
+
+    assert appended == 1
+    assert metrics == {"return": [2.0]}
+
+
+def test_evaluate_agent_collects_completed_episode_metrics():
+    agent = _Agent()
+    env = _VectorEvalEnv()
+
+    metrics = eval_checkpoint.evaluate_agent(
+        agent,
+        env,
+        seed=123,
+        num_eval_episodes=2,
+        max_eval_steps=4,
+    )
+
+    assert metrics["return"] == pytest.approx(16.5)
+    assert metrics["success_at_end"] == pytest.approx(0.5)
+    assert metrics["episodes_completed"] == 2.0
+    assert metrics["eval_steps"] == 2.0
+    assert metrics["extra_metric"] == 7.0
+    assert agent.started
+    assert agent.finalized
+    assert agent.hook_steps == 2
+    assert agent.policy.training
+
+
+def test_resolve_phase_auto_reports_ambiguous_algorithm(monkeypatch):
+    class _Registry:
+        def __init__(self, entries):
+            self._entries = entries
+
+        def discover(self):
+            pass
+
+        def entries(self):
+            return self._entries
+
+    registries = {
+        "online": _Registry({}),
+        "offline": _Registry({"iql": SimpleNamespace()}),
+        "off2on": _Registry({"iql": SimpleNamespace()}),
+    }
+    monkeypatch.setattr(
+        eval_checkpoint,
+        "_registry_for_phase",
+        lambda phase: registries[phase],
+    )
+
+    checkpoint = {"metadata": {"algorithm_class": "Off2OnIQL"}}
+
+    with pytest.raises(SystemExit, match="ambiguous"):
+        eval_checkpoint._resolve_phase_and_algorithm("auto", "auto", checkpoint)

--- a/tests/test_eval_checkpoint.py
+++ b/tests/test_eval_checkpoint.py
@@ -151,6 +151,31 @@ def test_append_metric_values_masks_final_info():
     assert metrics == {"return": [2.0]}
 
 
+def test_append_metric_values_aliases_raw_gym_keys_and_drops_wall_clock_time():
+    metrics = {}
+    mask = torch.tensor([True])
+
+    appended = eval_checkpoint._append_metric_values(
+        metrics,
+        {
+            "r": torch.tensor([5.0]),
+            "l": torch.tensor([12.0]),
+            "t": torch.tensor([0.031]),
+            "success": torch.tensor([1.0]),
+            "_r": torch.tensor([True]),
+        },
+        mask,
+        remaining=1,
+    )
+
+    assert appended == 1
+    assert metrics == {
+        "return": [5.0],
+        "episode_len": [12.0],
+        "success_at_end": [1.0],
+    }
+
+
 def test_evaluate_agent_collects_completed_episode_metrics():
     agent = _Agent()
     env = _VectorEvalEnv()

--- a/tests/test_minari_dataset_loader.py
+++ b/tests/test_minari_dataset_loader.py
@@ -10,6 +10,7 @@ from gymnasium import spaces
 from rl_garden.buffers import (
     MCTensorReplayBuffer,
     TensorReplayBuffer,
+    infer_specs_from_minari,
     load_minari_dataset_to_replay_buffer,
 )
 
@@ -60,6 +61,28 @@ def _make_box_dataset(episodes) -> _FakeMinariDataset:
         observation_space=spaces.Box(low=-np.inf, high=np.inf, shape=(1,), dtype=np.float32),
         action_space=spaces.Box(low=-1, high=1, shape=(2,), dtype=np.float32),
     )
+
+
+def test_infer_specs_canonicalizes_floating_observation_spaces(monkeypatch):
+    dataset = _FakeMinariDataset(
+        [],
+        observation_space=spaces.Dict(
+            {
+                "observation": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(27,), dtype=np.float64
+                ),
+                "rgb": spaces.Box(low=0, high=255, shape=(8, 8, 3), dtype=np.uint8),
+            }
+        ),
+        action_space=spaces.Box(low=-1, high=1, shape=(2,), dtype=np.float64),
+    )
+    _install_fake_minari(monkeypatch, dataset)
+
+    obs_space, action_space = infer_specs_from_minari("fake/dataset-v0")
+
+    assert obs_space["observation"].dtype == np.float32
+    assert obs_space["rgb"].dtype == np.uint8
+    assert action_space.dtype == np.float64
 
 
 def test_done_is_terminations_only_not_truncations(monkeypatch):

--- a/tests/test_probe_q_contrast_local_noise.py
+++ b/tests/test_probe_q_contrast_local_noise.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import torch
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "diagnostics"
+    / "probe_q_contrast_local_noise.py"
+)
+_SPEC = importlib.util.spec_from_file_location("probe_q_contrast_local_noise", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+probe = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = probe
+_SPEC.loader.exec_module(probe)
+
+
+def test_fixed_radius_noise_preserves_radius_when_unclipped() -> None:
+    actions = torch.zeros((8, 3))
+    low = torch.full((3,), -1.0)
+    high = torch.full((3,), 1.0)
+    generator = torch.Generator().manual_seed(123)
+
+    noisy, effective_radius, clip_fraction = probe.fixed_radius_noise(
+        actions,
+        radius=0.2,
+        n=5,
+        low=low,
+        high=high,
+        generator=generator,
+    )
+
+    assert noisy.shape == (8, 5, 3)
+    assert torch.allclose(effective_radius, torch.full((8, 5), 0.2), atol=1e-6)
+    assert torch.count_nonzero(clip_fraction) == 0
+
+
+def test_fixed_radius_noise_reports_clipping() -> None:
+    actions = torch.full((4, 2), 0.99)
+    low = torch.full((2,), -1.0)
+    high = torch.full((2,), 1.0)
+    generator = torch.Generator().manual_seed(1)
+
+    noisy, _effective_radius, clip_fraction = probe.fixed_radius_noise(
+        actions,
+        radius=0.5,
+        n=16,
+        low=low,
+        high=high,
+        generator=generator,
+    )
+
+    assert torch.all(noisy <= 1.0)
+    assert torch.all(noisy >= -1.0)
+    assert clip_fraction.mean() > 0
+
+
+def test_local_q_contrast_samples_use_min_q_and_boltzmann_metrics() -> None:
+    class ToyPolicy:
+        def q_values_all(self, features, actions, target=False):
+            del target
+            base_q = -(actions - features).pow(2).sum(dim=-1, keepdim=True)
+            return torch.stack([base_q + 1.0, base_q], dim=0)
+
+    features = torch.zeros((6, 2))
+    actions = torch.zeros((6, 2))
+    low = torch.full((2,), -1.0)
+    high = torch.full((2,), 1.0)
+    generator = torch.Generator().manual_seed(4)
+
+    samples = probe.local_q_contrast_samples(
+        ToyPolicy(),
+        features,
+        actions,
+        radius=0.1,
+        num_noisy_actions=8,
+        denominator=0.001,
+        action_low=low,
+        action_high=high,
+        generator=generator,
+    )
+
+    assert torch.allclose(samples["q_anchor"], torch.zeros(6))
+    assert torch.all(samples["q_drop"] > 0)
+    assert torch.allclose(samples["local_lipschitz"], torch.full((6,), 0.1), atol=1e-5)
+    assert torch.all(samples["dq_over_denominator"] > 0)
+    assert torch.all(samples["local_ess"] < 2.0)
+    assert torch.all(samples["anchor_top1"] == 1.0)
+    assert torch.allclose(samples["action_grad_norm"], torch.zeros(6))
+
+
+def test_summarize_samples_reports_requested_quantiles() -> None:
+    summary = probe.summarize_samples(
+        {
+            "q_drop": [torch.tensor([1.0, 2.0, 3.0])],
+            "local_ess": [torch.tensor([1.0, 2.0, 3.0])],
+            "max_weight": [torch.tensor([0.2, 0.5, 0.9])],
+            "action_grad_norm": [torch.tensor([1.0, 2.0, 100.0])],
+        }
+    )
+
+    assert summary["q_drop_mean"] == 2.0
+    assert summary["q_drop_p50"] == 2.0
+    assert summary["local_ess_p10"] == torch.quantile(
+        torch.tensor([1.0, 2.0, 3.0]), 0.1
+    ).item()
+    assert summary["max_weight_p90"] == torch.quantile(
+        torch.tensor([0.2, 0.5, 0.9]), 0.9
+    ).item()
+    assert summary["action_grad_norm_p99"] == torch.quantile(
+        torch.tensor([1.0, 2.0, 100.0]), 0.99
+    ).item()

--- a/tools/diagnostics/probe_q_contrast_local_noise.py
+++ b/tools/diagnostics/probe_q_contrast_local_noise.py
@@ -1,0 +1,460 @@
+"""Probe local Q contrast around offline and actor actions.
+
+This diagnostic samples states/actions from a ManiSkill H5 offline dataset, keeps
+each state fixed, perturbs an anchor action at fixed L2 radii, and reports how
+sharply the checkpoint critic's min-Q changes in that local action neighborhood.
+
+Example:
+    python tools/diagnostics/probe_q_contrast_local_noise.py \
+      --algorithm calql \
+      --dataset_path datasets/pickcube_mixed_500k.h5 \
+      --checkpoint_path runs/calql_offline_pretrain__1__1779864949/checkpoints/calql_offline_pretrained.pt \
+      --max_transitions 4096 \
+      --output_json /tmp/q_contrast_pickcube_calql.json
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+import numpy as np
+import torch
+import tyro
+
+from rl_garden.algorithms import OfflineEnvSpec
+from rl_garden.common import seed_everything
+from rl_garden.training._dataset import infer_offline_dataset_specs
+from rl_garden.training.offline.calql import CalQLArgs, build_calql
+from rl_garden.training.offline.iql import IQLArgs, build_iql
+
+
+Algorithm = Literal["calql", "iql"]
+AnchorGroup = Literal["dataset_action", "actor_det_action"]
+
+
+@dataclass
+class Args:
+    algorithm: Algorithm
+    dataset_path: str
+    checkpoint_path: str
+    output_json: Optional[str] = None
+
+    max_transitions: int = 4096
+    batch_size: int = 256
+    num_noisy_actions: int = 64
+    radii: tuple[float, ...] = (0.01, 0.02, 0.05, 0.1, 0.2)
+    anchor_groups: tuple[AnchorGroup, ...] = ("dataset_action", "actor_det_action")
+    seed: int = 1
+    device: str = "auto"
+
+    # Defaults match the PickCube IQL/Cal-QL 1m runs found on 6017-nofwd.
+    gamma: float = 0.8
+    tau: float = 0.005
+    action_low: float = -1.0
+    action_high: float = 1.0
+    n_critics: int = 10
+    critic_subsample_size: int = 2
+    actor_use_layer_norm: bool = True
+    critic_use_layer_norm: bool = True
+    image_fusion_mode: Literal["stack_channels", "per_key"] = "stack_channels"
+    include_state: bool = True
+    encoder: Literal["plain_conv", "resnet10", "resnet18", "vit"] = "plain_conv"
+    encoder_features_dim: int = 256
+    per_camera_rgbd: bool = False
+    obs_mode: str = "rgb"
+    camera_width: Optional[int] = 64
+    camera_height: Optional[int] = 64
+    plain_conv_pooling: Literal["flatten", "gap", "adaptive_max"] = "flatten"
+    plain_conv_weight_init: Literal["kaiming_uniform", "orthogonal"] = "kaiming_uniform"
+    plain_conv_last_act: bool = True
+    image_augmentation: Literal["none", "random_shift"] = "none"
+    image_random_shift_pad: int = 4
+    vit_fusion_mode: Literal["per_key", "stack_channels"] = "per_key"
+    vit_embed_dim: int = 128
+    vit_depth: int = 1
+    vit_num_heads: int = 4
+    vit_embed_norm: bool = False
+    vit_augmentation: Literal["random_shift", "none"] = "random_shift"
+    vit_random_shift_pad: int = 4
+    vit_actor_feature_dim: int = 128
+    vit_critic_spatial_emb_dim: int = 1024
+    pretrained_weights: Optional[str] = None
+    freeze_resnet_encoder: bool = False
+    freeze_resnet_backbone: bool = False
+
+    # IQL denominator for dq/temperature. Cal-QL uses the loaded SAC alpha.
+    temperature: float = 3.0
+
+
+@dataclass
+class DemoBatch:
+    obs: Any
+    actions: torch.Tensor
+    num_available_transitions: int
+    num_selected_transitions: int
+    num_total_episodes: int
+
+
+def _natural_key(name: str) -> tuple[str, int]:
+    match = re.search(r"(\d+)$", name)
+    return (
+        name[: match.start()] if match else name,
+        int(match.group(1)) if match else -1,
+    )
+
+
+def _trajectory_keys(handle: Any) -> list[str]:
+    keys = [key for key in handle.keys() if key.startswith("traj_")]
+    return sorted(keys, key=_natural_key)
+
+
+def _dataset_node(group: Any, *names: str) -> Any:
+    for name in names:
+        if name in group:
+            return group[name]
+    raise KeyError(f"None of {names!r} found under H5 group {group.name!r}.")
+
+
+def _read_obs_at(obs_group: Any, index: int) -> Any:
+    if hasattr(obs_group, "items"):
+        return {
+            key: torch.as_tensor(np.asarray(value[index]))
+            for key, value in obs_group.items()
+        }
+    return torch.as_tensor(np.asarray(obs_group[index]))
+
+
+def _stack_obs(samples: list[Any]) -> Any:
+    first = samples[0]
+    if isinstance(first, dict):
+        return {
+            key: torch.stack([sample[key] for sample in samples], dim=0)
+            for key in first.keys()
+        }
+    return torch.stack(samples, dim=0)
+
+
+def _slice_obs(obs: Any, start: int, stop: int) -> Any:
+    if isinstance(obs, dict):
+        return {key: value[start:stop] for key, value in obs.items()}
+    return obs[start:stop]
+
+
+def _to_device(tree: Any, device: torch.device) -> Any:
+    if isinstance(tree, torch.Tensor):
+        return tree.to(device)
+    if isinstance(tree, dict):
+        return {key: _to_device(value, device) for key, value in tree.items()}
+    return tree
+
+
+def load_demo_batch(
+    dataset_path: str | Path,
+    *,
+    max_transitions: int,
+    seed: int,
+) -> DemoBatch:
+    import h5py
+
+    rng = np.random.default_rng(seed)
+    candidates: list[tuple[str, int]] = []
+    with h5py.File(dataset_path, "r") as handle:
+        traj_keys = _trajectory_keys(handle)
+        for traj_key in traj_keys:
+            actions_node = _dataset_node(handle[traj_key], "actions", "action")
+            candidates.extend((traj_key, i) for i in range(len(actions_node)))
+        if not candidates:
+            raise ValueError(f"No transitions found in {dataset_path}.")
+        num_available = len(candidates)
+        if max_transitions > 0 and len(candidates) > max_transitions:
+            selected = rng.choice(len(candidates), size=max_transitions, replace=False)
+            candidates = [candidates[int(i)] for i in selected]
+
+        obs_samples: list[Any] = []
+        action_samples: list[torch.Tensor] = []
+        for traj_key, index in candidates:
+            traj = handle[traj_key]
+            obs_group = _dataset_node(traj, "obs", "observations")
+            actions_node = _dataset_node(traj, "actions", "action")
+            obs_samples.append(_read_obs_at(obs_group, index))
+            action_samples.append(
+                torch.as_tensor(np.asarray(actions_node[index])).float()
+            )
+
+    return DemoBatch(
+        obs=_stack_obs(obs_samples),
+        actions=torch.stack(action_samples, dim=0),
+        num_available_transitions=num_available,
+        num_selected_transitions=len(candidates),
+        num_total_episodes=len(traj_keys),
+    )
+
+
+def fixed_radius_noise(
+    actions: torch.Tensor,
+    *,
+    radius: float,
+    n: int,
+    low: torch.Tensor,
+    high: torch.Tensor,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if radius <= 0:
+        raise ValueError(f"radius must be positive, got {radius}.")
+    if n <= 0:
+        raise ValueError(f"n must be positive, got {n}.")
+    noise = torch.randn(
+        actions.shape[0],
+        n,
+        actions.shape[-1],
+        device=actions.device,
+        dtype=actions.dtype,
+        generator=generator,
+    )
+    noise = radius * noise / noise.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+    raw = actions[:, None, :] + noise
+    noisy = raw.clamp(low.view(1, 1, -1), high.view(1, 1, -1))
+    delta = noisy - actions[:, None, :]
+    effective_radius = delta.norm(dim=-1)
+    clip_fraction = (raw != noisy).any(dim=-1).float()
+    return noisy, effective_radius, clip_fraction
+
+
+def _min_q(policy: Any, features: torch.Tensor, actions: torch.Tensor) -> torch.Tensor:
+    return policy.q_values_all(features, actions, target=False).min(dim=0).values.squeeze(-1)
+
+
+def _actor_input(policy: Any, features: torch.Tensor) -> torch.Tensor:
+    if hasattr(policy, "_transform_features_for_actor"):
+        return policy._transform_features_for_actor(features)
+    return features
+
+
+def deterministic_actor_action(policy: Any, features: torch.Tensor) -> torch.Tensor:
+    return policy.actor.deterministic_action(_actor_input(policy, features))
+
+
+def action_grad_norm(
+    policy: Any,
+    features: torch.Tensor,
+    actions: torch.Tensor,
+) -> torch.Tensor:
+    probe_actions = actions.detach().clone().requires_grad_(True)
+    q = _min_q(policy, features.detach(), probe_actions).sum()
+    grad = torch.autograd.grad(
+        q,
+        probe_actions,
+        retain_graph=False,
+        create_graph=False,
+        allow_unused=False,
+    )[0]
+    return grad.norm(dim=-1).detach()
+
+
+def local_q_contrast_samples(
+    policy: Any,
+    features: torch.Tensor,
+    anchor_actions: torch.Tensor,
+    *,
+    radius: float,
+    num_noisy_actions: int,
+    denominator: float,
+    action_low: torch.Tensor,
+    action_high: torch.Tensor,
+    generator: torch.Generator,
+) -> dict[str, torch.Tensor]:
+    noisy, effective_radius, clip_fraction = fixed_radius_noise(
+        anchor_actions,
+        radius=radius,
+        n=num_noisy_actions,
+        low=action_low,
+        high=action_high,
+        generator=generator,
+    )
+    batch = anchor_actions.shape[0]
+    flat_features = (
+        features[:, None, :]
+        .expand(batch, num_noisy_actions, features.shape[-1])
+        .reshape(batch * num_noisy_actions, features.shape[-1])
+    )
+    flat_noisy = noisy.reshape(batch * num_noisy_actions, anchor_actions.shape[-1])
+    q_anchor = _min_q(policy, features, anchor_actions)
+    q_noisy = _min_q(policy, flat_features, flat_noisy).reshape(
+        batch, num_noisy_actions
+    )
+    abs_dq_each = (q_noisy - q_anchor[:, None]).abs()
+    q_drop_each = q_anchor[:, None] - q_noisy
+    logits = torch.cat([q_anchor[:, None], q_noisy], dim=1) / max(denominator, 1e-12)
+    weights = torch.softmax(logits - logits.max(dim=1, keepdim=True).values, dim=1)
+    ess = 1.0 / weights.pow(2).sum(dim=1).clamp_min(1e-12)
+    entropy = -(weights * weights.clamp_min(1e-12).log()).sum(dim=1)
+    grad_norm = action_grad_norm(policy, features, anchor_actions)
+    return {
+        "q_anchor": q_anchor.detach(),
+        "q_noisy_mean": q_noisy.mean(dim=1).detach(),
+        "q_drop": q_drop_each.mean(dim=1).detach(),
+        "abs_dq": abs_dq_each.mean(dim=1).detach(),
+        "local_lipschitz": (
+            abs_dq_each / effective_radius.clamp_min(1e-12)
+        ).mean(dim=1).detach(),
+        "dq_over_denominator": (
+            abs_dq_each / max(denominator, 1e-12)
+        ).mean(dim=1).detach(),
+        "local_ess": ess.detach(),
+        "local_entropy": entropy.detach(),
+        "max_weight": weights.max(dim=1).values.detach(),
+        "anchor_top1": (q_anchor >= q_noisy.max(dim=1).values).float().detach(),
+        "action_grad_norm": grad_norm,
+        "effective_radius": effective_radius.mean(dim=1).detach(),
+        "clip_fraction": clip_fraction.mean(dim=1).detach(),
+    }
+
+
+def summarize_samples(samples: dict[str, list[torch.Tensor]]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for key, parts in samples.items():
+        values = torch.cat(parts, dim=0).float()
+        out[f"{key}_mean"] = float(values.mean().item())
+        if key in {
+            "q_drop",
+            "abs_dq",
+            "local_lipschitz",
+            "dq_over_denominator",
+            "action_grad_norm",
+        }:
+            out[f"{key}_p50"] = float(torch.quantile(values, 0.5).item())
+            out[f"{key}_p90"] = float(torch.quantile(values, 0.9).item())
+        if key == "action_grad_norm":
+            out[f"{key}_p99"] = float(torch.quantile(values, 0.99).item())
+        if key == "local_ess":
+            out[f"{key}_p10"] = float(torch.quantile(values, 0.1).item())
+        if key == "max_weight":
+            out[f"{key}_p90"] = float(torch.quantile(values, 0.9).item())
+    return out
+
+
+def _args_for_algorithm(args: Args) -> Any:
+    algo_args = CalQLArgs() if args.algorithm == "calql" else IQLArgs()
+    for key, value in asdict(args).items():
+        if key == "dataset_path":
+            setattr(algo_args, "offline_dataset_path", value)
+        elif hasattr(algo_args, key):
+            setattr(algo_args, key, value)
+    setattr(algo_args, "dataset_source", "maniskill_h5")
+    setattr(algo_args, "buffer_device", "cpu")
+    setattr(algo_args, "batch_size", max(1, min(args.batch_size, 256)))
+    setattr(algo_args, "save_replay_buffer", False)
+    setattr(algo_args, "std_log", False)
+    setattr(algo_args, "eval_freq", 0)
+    return algo_args
+
+
+def _build_agent(args: Args) -> Any:
+    algo_args = _args_for_algorithm(args)
+    obs_space, action_space = infer_offline_dataset_specs(algo_args)
+    env_spec = OfflineEnvSpec(obs_space, action_space, num_envs=1)
+    if args.algorithm == "calql":
+        agent = build_calql(algo_args, env_spec, logger=None, eval_env=None)
+    else:
+        agent = build_iql(algo_args, env_spec, logger=None, eval_env=None)
+    agent.load(args.checkpoint_path, load_replay_buffer=False, load_optimizers=False)
+    agent.policy.eval()
+    return agent
+
+
+def _denominator(agent: Any, args: Args) -> tuple[str, float]:
+    if args.algorithm == "calql" and hasattr(agent, "_current_alpha"):
+        return "alpha", float(agent._current_alpha().detach().cpu().item())
+    return "iql_temperature", float(args.temperature)
+
+
+def probe_agent(agent: Any, batch: DemoBatch, args: Args) -> dict[str, Any]:
+    device = torch.device(agent.device)
+    obs = _to_device(batch.obs, device)
+    actions = batch.actions.to(device)
+    action_low = torch.full(
+        (actions.shape[-1],), args.action_low, dtype=actions.dtype, device=device
+    )
+    action_high = torch.full(
+        (actions.shape[-1],), args.action_high, dtype=actions.dtype, device=device
+    )
+    denom_name, denom = _denominator(agent, args)
+    generator = torch.Generator(device=device).manual_seed(args.seed + 100_003)
+    results: list[dict[str, Any]] = []
+
+    for anchor_group in args.anchor_groups:
+        acc_by_radius: dict[float, dict[str, list[torch.Tensor]]] = {
+            radius: {} for radius in args.radii
+        }
+        for start in range(0, actions.shape[0], args.batch_size):
+            stop = min(start + args.batch_size, actions.shape[0])
+            obs_chunk = _slice_obs(obs, start, stop)
+            dataset_actions = actions[start:stop]
+            with torch.no_grad():
+                features = agent.policy.extract_features(obs_chunk, stop_gradient=True)
+                if anchor_group == "dataset_action":
+                    anchor_actions = dataset_actions
+                else:
+                    anchor_actions = deterministic_actor_action(agent.policy, features)
+            for radius in args.radii:
+                acc = acc_by_radius[radius]
+                samples = local_q_contrast_samples(
+                    agent.policy,
+                    features.detach(),
+                    anchor_actions.detach(),
+                    radius=radius,
+                    num_noisy_actions=args.num_noisy_actions,
+                    denominator=denom,
+                    action_low=action_low,
+                    action_high=action_high,
+                    generator=generator,
+                )
+                for key, value in samples.items():
+                    acc.setdefault(key, []).append(value.cpu())
+        for radius, acc in acc_by_radius.items():
+            results.append(
+                {
+                    "anchor_group": anchor_group,
+                    "radius": radius,
+                    "num_states": batch.num_selected_transitions,
+                    "num_noisy_actions": args.num_noisy_actions,
+                    "action_dim": int(actions.shape[-1]),
+                    "denominator_name": denom_name,
+                    "denominator_value": denom,
+                    **summarize_samples(acc),
+                }
+            )
+    return {
+        "checkpoint_path": args.checkpoint_path,
+        "algorithm": args.algorithm,
+        "dataset_path": args.dataset_path,
+        "num_available_transitions": batch.num_available_transitions,
+        "num_selected_transitions": batch.num_selected_transitions,
+        "num_total_episodes": batch.num_total_episodes,
+        "results": results,
+    }
+
+
+def main() -> None:
+    args = tyro.cli(Args)
+    seed_everything(args.seed)
+    batch = load_demo_batch(
+        args.dataset_path,
+        max_transitions=args.max_transitions,
+        seed=args.seed,
+    )
+    agent = _build_agent(args)
+    payload = {"args": asdict(args), **probe_agent(agent, batch, args)}
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    print(text)
+    if args.output_json is not None:
+        Path(args.output_json).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output_json).write_text(text + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add checkpoint evaluation entrypoint and q-contrast local-noise diagnostics
- share eval metric aliases with eval_checkpoint
- flatten wandb config for run-level hyperparameter columns
- log offline update-speed timing metrics
- handle Gymnasium pre/post-1.0 reward transform step signatures

## Commit policy
This PR intentionally keeps the 5 content commits separate after rebasing onto latest main. The first commit is the q-contrast/eval body; the following 4 commits are focused fixes. If main should keep one commit, use GitHub squash merge at merge time rather than pre-squashing the PR branch.

## Tests
- python -m pytest tests/test_checkpoint.py tests/test_eval_checkpoint.py tests/test_minari_dataset_loader.py tests/test_probe_q_contrast_local_noise.py
- 29 passed, 16 warnings