### PR TITLE
feat(envs): add IsaacLab DirectRLEnv scaffold and image-observation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ See [docs/README.md](docs/README.md) for the full index. Highlights:
 
 - [Checkpoint Save & Load](docs/guides/checkpoint.md)
 - [Configuration System](docs/guides/configuration.md)
+- [IsaacLab Camera Training Stall (known issue)](docs/guides/isaaclab-camera-stall.md)
+- [IsaacLab Custom Tasks](docs/guides/isaaclab-custom-tasks.md)
 - [Offline Training Acceleration](docs/guides/offline-acceleration.md)
 - [RoboTwin Integration](docs/guides/robotwin.md)
 - [Teleoperation and Recording](docs/guides/teleop.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Operational how-to for running and configuring the framework.
 
 - [Checkpoint Save & Load](guides/checkpoint.md)
 - [Configuration System](guides/configuration.md)
+- [IsaacLab Camera Training Stall (known issue)](guides/isaaclab-camera-stall.md)
+- [IsaacLab Custom Tasks](guides/isaaclab-custom-tasks.md)
 - [Offline Training Acceleration](guides/offline-acceleration.md)
 - [RoboTwin Integration](guides/robotwin.md)
 - [Teleoperation and Recording](guides/teleop.md)

--- a/docs/guides/isaaclab-camera-stall.md
+++ b/docs/guides/isaaclab-camera-stall.md
@@ -1,0 +1,311 @@
+# IsaacLab Camera-Observation Training Stall (6017-nofwd) — Unresolved
+
+**Status: open, unresolved.** A partial mitigation is in place
+(`post_update_sync()`, see below) but does **not** reliably fix it. Treat
+camera-observation IsaacLab training on host `6017-nofwd` as unreliable —
+runs can hang indefinitely partway through and need to be killed manually.
+State-only IsaacLab training (no camera) is unaffected and fully reliable.
+
+This document records the full investigation for whoever picks this up next,
+so the diagnostic ground already covered doesn't need to be re-derived.
+
+## Symptom
+
+A PPO training run using the IsaacLab backend with `--obs_mode rgb` (or
+`rgbd`) hangs indefinitely, typically within the first 1-2 rollout+update
+cycles, sometimes later. The process:
+
+- Stops producing any new stdout output (running with `python -u`,
+  unbuffered, so this is a real freeze, not a buffering artifact).
+- Stays alive, consuming CPU and GPU resources — it does **not** crash, does
+  **not** raise a Python exception, does **not** get OOM-killed.
+- Must be killed manually (`kill -9`); it never recovers or times out on its
+  own.
+
+The last log lines before the freeze are always the same signature — Kit
+warnings that look like extension/graph teardown, immediately followed by
+silence:
+
+```
+[Warning] [omni.graph.core.plugin] Could not find category 'Replicator:Annotators' for removal
+  (repeated ~8-13 times)
+[Warning] [omni.graph.core.plugin] Could not find category 'Replicator' for removal
+[Warning] [omni.graph.core.plugin] Could not find category 'Replicator:Core' for removal
+[Warning] [omni.physx.plugin] USD stage detach not called, holding a loose ptr to a stage!
+[Warning] [carb] Client omni.syntheticdata.plugin Failed to acquire interface [omni::graph::core::INode v4.10] while unloading all plugins
+```
+
+**Important:** these exact lines also appear during a *normal, successful*
+`env.close()` at the end of a run. Seeing them is not itself proof of a
+stall — the distinguishing signal is whether the process ever produces
+further output / exits afterward.
+
+## Environment
+
+- Host: `6017-nofwd` (shared, multi-GPU, multi-tenant — 4× RTX 4090, other
+  users' jobs routinely at 90-100% utilization).
+- Container: `liuzhaohong_maniskill_isaaclab` (see
+  `.agents/local/personal_config.md`, "Working IsaacLab + rl-garden setup",
+  for the full build recipe).
+- IsaacLab installed at `/opt/envs/isaaclab` inside the container; Isaac Sim
+  5.1 (`isaacsim.core.simulation_manager`, `omni.physics.tensors`).
+- `torch==2.6.0+cu124`, `torchvision==0.21.0`, driver/CUDA per the container
+  (see personal_config.md).
+- No `gdb`, `strace`, or `py-spy` available in this container — diagnosis was
+  limited to `/proc/<pid>/*`, `top -H`, and application-level instrumentation
+  (adding temporary `print(..., flush=True)` statements to rl-garden's own
+  code and rerunning).
+
+## Reproduction
+
+```bash
+docker exec -d liuzhaohong_maniskill_isaaclab bash -lc '
+  source /opt/venv/openvla/bin/activate
+  cd /workspace/Projects/isaac_sim && source ./setup_conda_env.sh
+  export PYTHONPATH="/opt/venv/openvla/lib/python3.11/site-packages:$PYTHONPATH"
+  cd /workspace/Projects/rl-garden
+  python -u examples/train_online.py ppo --env_backend isaaclab \
+    --env_id RlGarden-Cartpole-Direct-Camera-Plain-v0 \
+    --obs_mode rgb --camera_width 64 --camera_height 64 --num_envs 2 \
+    --eval_freq 0 --total_timesteps 192 --num_steps 16 \
+    --isaaclab.sim_device cuda:2 \
+    --log-type none > /tmp/run.log 2>&1
+'
+```
+
+`RlGarden-Cartpole-Direct-Camera-Plain-v0` is a diagnostic task
+(`rl_garden/envs/isaaclab/tasks/cartpole_direct_camera_plain.py`) using
+IsaacLab's plain `Camera` sensor instead of `TiledCamera`, kept in the repo
+specifically to reproduce and test this issue in isolation from the
+`RlGarden-Cartpole-Direct-Camera-v0` task (which uses `TiledCamera`, the
+normal/recommended choice — see [`isaaclab-custom-tasks.md`](isaaclab-custom-tasks.md)). Both stall
+identically (see "Ruled out" below), so either reproduces the bug.
+
+Reproduction rate observed: **stalled in the large majority of attempts**
+across this investigation. Counting only full training-run attempts (not
+standalone env/encoder diagnostics that didn't go through the real PPO
+loop): roughly 2 out of a dozen-plus attempts completed end-to-end
+successfully across the whole investigation, and a dedicated batch of 3
+back-to-back reruns of the identical command *after* the mitigation below
+was implemented stalled 3/3.
+
+## Diagnostic timeline
+
+Numbered in the order things were actually tried, including dead ends —
+kept here so they aren't retried blindly.
+
+1. **First observed** while verifying image-observation support in the
+   IsaacLab backend (`_IsaacLabVecEnvAdapter`, `rl_garden/envs/isaaclab/env.py`).
+   Initial hypothesis: a bug in the new adapter code.
+
+2. **Ruled out: adapter code correctness.** A standalone diagnostic script
+   (bypassing PPO entirely) called `make_isaaclab_env()` directly, did 20
+   `env.step()` calls under `torch.no_grad()` (mimicking rollout collection),
+   then a real `forward()` + `backward()` + `optimizer.step()` on a small
+   `nn.Conv2d` using the collected images. This completed successfully
+   ("ALL DONE" printed, no stall) — proving env creation, the `Dict`
+   observation space, and the adapter's `step()`/`reset()` are all correct.
+
+3. **Ruled out: GPU memory pressure.** GPU memory usage was tracked via
+   `nvidia-smi` before/during/after both successful and stalled runs.
+   Baseline "other users' " memory on the target GPU was stable
+   (~15.6 GiB used out of 24.5 GiB) across every observation, whether the run
+   succeeded or stalled. During one stalled run, memory usage on the target
+   GPU actually *dropped* (~18.3 GiB → ~16.9 GiB) right around the moment of
+   the stall — the opposite of what a memory-pressure/OOM-adjacent slowdown
+   would look like.
+
+4. **Ruled out: cuDNN version mismatch (real bug, but separate from the
+   stall).** Before the stall was even reachable, a `RuntimeError: cuDNN
+   error: CUDNN_STATUS_NOT_INITIALIZED` occurred on the very first `Conv2d`
+   forward pass. Root cause: `nvidia-cudnn-cu12` installed version
+   (`9.1.0.70`) didn't match what `torch.backends.cudnn.version()` reported
+   internally (`92000` = 9.2.0) — a stale/mismatched library, likely left
+   over from an earlier `torch` reinstall in this container's history. Fixed
+   with `pip install --force-reinstall --no-cache-dir torch==2.6.0
+   torchvision==0.21.0 -i https://pypi.tuna.tsinghua.edu.cn/simple` in the
+   `openvla` venv. **Side effect:** this force-reinstall also bumped
+   `numpy`/`pillow`/`gymnasium`/`typing_extensions` to newer versions,
+   breaking pins several other packages need (`isaaclab` wants
+   `gymnasium==1.2.1`, but the working baseline this whole IsaacLab
+   integration was built/verified against uses `gymnasium==0.29.1`, matching
+   `mani-skill`'s pin — `isaaclab`'s own declared pin is not runtime-enforced,
+   same as its `torch>=2.7` pin isn't). Re-pinned back:
+   `pip install "numpy<2" "pillow==11.3.0" "gymnasium==0.29.1" -i
+   https://pypi.tuna.tsinghua.edu.cn/simple`. This is a real, permanent fix
+   for a real (separate) bug — it is **not** the cause of the render stall,
+   confirmed because the stall reproduces before and after this fix, with a
+   different symptom (crash vs. hang) either side.
+
+5. **Ruled out: camera resolution mismatch (real bug, but separate from the
+   stall).** `RuntimeError: mat1 and mat2 shapes cannot be multiplied` — the
+   diagnostic task's `TiledCameraCfg` used `width=100, height=100` (copied
+   from IsaacLab's own official camera example), but rl-garden's default
+   `PlainConv` image encoder only supports 64×64 or 128×128 (hardcoded
+   conv/pool stride schedule, see `rl_garden/encoders/plain_conv.py`'s
+   docstring). Fixed by using 64×64 and passing matching `--camera_width 64
+   --camera_height 64` on the CLI. Real, permanent fix; not the stall's
+   cause (same stall reproduces with correct resolution too).
+
+6. **Ruled out: `clone_in_fabric=True` (real bug, separate from the
+   stall).** The state-only base task's `scene` cfg sets
+   `clone_in_fabric=True`; inherited unchanged by a first camera-task
+   attempt, this caused `RuntimeError: CUDA error: device-side assert
+   triggered` / `IndexKernel.cu:94 ... index out of bounds` inside
+   `TiledCamera`'s `reset()` (mis-sized per-env sensor buffers). Fixed by
+   omitting `clone_in_fabric` for camera-task scene configs, matching what
+   IsaacLab's own `cartpole_camera_env.py` example does. Real, permanent
+   fix; not the stall's cause.
+
+7. **Ruled out: `TiledCamera` specifically.** Wrote a diagnostic task variant
+   (`cartpole_direct_camera_plain.py`) using IsaacLab's plain `Camera` sensor
+   class instead of `TiledCamera` (spawned directly in an overridden
+   `_setup_scene`, bypassing the scaffold's `camera_cfg` field which is typed
+   for `TiledCameraCfg`). Stalls identically. Rules out `TiledCamera`'s
+   tiled-rendering/Warp-kernel reshape path as the specific culprit.
+
+8. **Ruled out: `rendering_mode` setting.** IsaacLab's `AppLauncher` accepts
+   a `rendering_mode` kwarg (`"performance"`/`"balanced"`/`"quality"`,
+   controlling DLSS/post-processing presets). Tried
+   `rendering_mode="performance"` (the lightest preset) when cameras are
+   enabled — no difference, identical stall.
+
+9. **Ruled out: resolution/`num_envs` scale.** Reproduces identically at
+   100×100/`num_envs=4` and at 64×64/`num_envs=2` (the smallest practical
+   configuration).
+
+10. **Instrumented the real code to pinpoint the exact stall location.**
+    Added temporary `print(..., flush=True)` statements throughout
+    `OnPolicyAlgorithm.learn()`'s rollout loop
+    (`rl_garden/algorithms/on_policy.py`) and `PPO.train()`'s minibatch
+    update loop (`rl_garden/algorithms/ppo.py`), then reran the real training
+    command (not a standalone diagnostic). Findings, in order of what was
+    proven:
+    - **All 16 rollout steps of the first cycle succeed**, including every
+      real `PPOPolicy`/`CombinedExtractor`/`PlainConv` forward pass through
+      the actual encoder architecture (not a simplified stand-in).
+    - **The full PPO update phase succeeds too**: 3 epochs × ~10 minibatches
+      = ~30 real backward passes + `optimizer.step()` calls through the CNN,
+      all completing.
+    - **The stall is specifically the *second* rollout cycle's first
+      `env.step()`** — i.e., the first render call that follows the heavy
+      backward-pass burst of a PPO update. This is the precise, reproducible
+      trigger condition.
+    - (All temporary prints were reverted afterward — `git diff`/`git
+      checkout` on both files.)
+
+11. **Mitigation: `torch.cuda.synchronize()` between update and next
+    rollout.** Based on finding #10, added a call right after the update
+    phase, before the next rollout's first `step()`. First attempt: called
+    on *every* `step()` (inside `_IsaacLabVecEnvAdapter.step()`) — this made
+    things **worse**, reliably reintroducing the hang (apparently disrupts
+    Kit's own async cadence between consecutive render calls). Corrected
+    placement: **once per rollout+update cycle**, matching exactly where the
+    instrumented run in #10 proved it works — via a duck-typed
+    `post_update_sync()` hook that `OnPolicyAlgorithm.learn()` calls if the
+    env defines it (no-op for ManiSkill/other backends). One fully
+    instrumented run with this placement completed all 6 rollout+update
+    cycles cleanly. This is the mitigation currently in the code
+    (`_IsaacLabVecEnvAdapter.post_update_sync`, `rl_garden/envs/isaaclab/env.py`;
+    call site in `OnPolicyAlgorithm.learn()`, `rl_garden/algorithms/on_policy.py`).
+
+12. **Reliability check: the mitigation is NOT reliable.** After confirming
+    the fix in principle (#11), reran the identical command 3 more times
+    with no debug instrumentation (clean code). **All 3 stalled.** This
+    means the earlier single success was not a repeatable fix — either the
+    dense `print(flush=True)` calls throughout the instrumented version
+    incidentally provided timing/pacing that a bare sync call doesn't
+    reproduce, or it was a lucky timing window under otherwise-identical
+    code. A follow-up test tried the bare `torch.cuda.synchronize()` call
+    exactly as used in the one successful instrumented run (no explicit
+    device argument, vs. the current code's `torch.cuda.synchronize()` with
+    no device arg — these turned out to already be the same after checking
+    `self.device`'s actual type: a plain string `'cuda:2'`) — that specific
+    variant got through 5 of 6 expected cycles before also stalling on the
+    final one. So the sync **does measurably help** (delays the failure,
+    sometimes past several cycles) but does not close it out reliably.
+
+13. **Root cause mechanism identified** (prompted by the user noticing that
+    IsaacLab/PhysX should be GPU-driven, so sustained high CPU usage during
+    an apparent "hang" was suspicious). During a live stall:
+    ```
+    docker exec liuzhaohong_maniskill_isaaclab top -H -b -n 1 -p <PID>
+    ```
+    showed **342 threads total, only 1 running** — the main Python thread,
+    pinned at 99.9% CPU — **and 341 sleeping** (all of Kit's `carb.tas+`
+    task-worker threads, the `cuda-Ev+` CUDA-event thread, and the `[vkps]`
+    Vulkan-present thread fully idle at 0%). Checking the hot thread:
+    ```
+    cat /proc/<PID>/status   # State: R (running)
+    cat /proc/<PID>/wchan    # 0
+    ```
+    `wchan: 0` on a `Running` thread means it is **not blocked in any
+    kernel wait function** — no futex, no I/O, no blocking-on-GPU-fence
+    syscall. This is the signature of a **CPU busy-wait / spin-loop polling
+    for a GPU completion signal that never arrives** — not genuine
+    GPU-bound computation, and not a proper OS-level block.
+    `/proc/<PID>/stack` and `/proc/<PID>/syscall` were both permission-denied
+    in this container (no `ptrace`/ root capability for that), so the exact
+    C++ call site inside Kit/PhysX/the renderer could not be captured.
+
+    This mechanism is consistent with every other observation: `torch.cuda.
+    synchronize()` only "helps" when the GPU-side work it flushes happens to
+    complete *before* Kit's polling loop starts checking for it — a timing
+    race, not something a single deterministic call can guarantee. GPU
+    memory sometimes dropping right at the stall (see #3) is explained by
+    the GPU-side work having already finished; only the CPU-side signal/fence
+    delivery is stuck.
+
+## Root cause (best current understanding)
+
+A race/bug in Kit's (or PhysX's) CPU-GPU synchronization layer: something in
+the render pipeline polls (busy-waits) for a GPU-side completion signal, and
+under concurrent heavy PyTorch CUDA usage (specifically: right after a
+sustained backward-pass burst), that signal can be delivered late enough, or
+lost/never posted, that the poll loop spins forever. This looks like a bug
+specific to this Isaac Sim/Kit build's interaction with PyTorch on this
+host's driver/CUDA stack — **not a bug in rl-garden's code**. Everything in
+rl-garden (`_IsaacLabVecEnvAdapter`, the `RLGardenDirectRLEnv` scaffold, the
+PPO training loop) has been verified correct in isolation; the stall is
+purely about what happens inside IsaacLab/Kit's own C++ layer when a render
+call follows heavy compute.
+
+## Current mitigation and its limits
+
+`_IsaacLabVecEnvAdapter.post_update_sync()` (`rl_garden/envs/isaaclab/env.py`)
+calls `torch.cuda.synchronize()` when `obs_mode != "state"`. It is invoked
+once per rollout+update cycle from `OnPolicyAlgorithm.learn()`
+(`rl_garden/algorithms/on_policy.py`), via a duck-typed hook lookup
+(`getattr(self.env, "post_update_sync", None)`) — **zero cost/behavior
+change for ManiSkill or any other backend** that doesn't define this method.
+
+This measurably reduces (but does not eliminate) how often the stall occurs.
+Treat any camera-observation IsaacLab training run on this host as likely to
+hang and requiring a hard timeout + manual kill, not something safe to
+launch unattended.
+
+## Next steps if picking this back up
+
+1. **Get a real stack trace at the moment of stall.** `gdb`/`py-spy attach`
+   would need to be installed in the container (or a privileged debug
+   sidecar container attached to the same PID namespace) — neither was
+   available this session. This is the single highest-value next step; it
+   would show the actual C++/Python frames the spinning thread is stuck in,
+   turning "we know it's a spin-wait" into "we know exactly which fence/API
+   call it's polling on."
+2. **Test whether skrl or rsl_rl hit the same issue.** Neither is installed
+   in this container. Their source code doesn't show any special
+   CPU-GPU-sync workaround around the update phase (checked
+   `3rd_party/skrl/skrl/envs/wrappers/torch/isaaclab_envs.py` and the
+   official `scripts/reinforcement_learning/skrl/train.py` inside the
+   IsaacLab install) — so it's plausible they'd hit this too, but that's
+   inferred, not confirmed. Installing skrl and running its official
+   camera-task example would settle whether this is IsaacLab/Kit-general or
+   specific to rl-garden's exact call pattern.
+3. **Try a different/newer Isaac Sim build**, if one becomes available on
+   this host — this could plausibly be a fixed-in-a-later-version Kit bug.
+4. **Architectural workaround (larger change, not attempted):** isolate
+   rendering and PyTorch training into separate processes, communicating
+   observations/actions over shared memory or IPC, so the two CUDA
+   contexts/streams never directly compete within one process. This is a
+   significant redesign, not something to do without discussing scope first.

--- a/docs/guides/isaaclab-custom-tasks.md
+++ b/docs/guides/isaaclab-custom-tasks.md
@@ -1,0 +1,280 @@
+# Writing Custom IsaacLab Tasks
+
+This guide is for adding a new IsaacLab task to rl-garden. It covers the
+`RLGardenDirectRLEnv` scaffold, which is the recommended way to write new
+tasks: you implement four methods, and boilerplate scene setup/reset is
+generic.
+
+If you only want to train PPO on a task that already exists in
+`isaaclab_tasks` (official IsaacLab tasks, e.g. `Isaac-Cartpole-v0`,
+`Isaac-Ant-v0`), you don't need any of this — those run directly through
+`--env_backend isaaclab --env_id <task-id>`, see
+[Training an existing task](#training-an-existing-task) below.
+
+## The four methods you write
+
+`RLGardenDirectRLEnv` (`rl_garden/envs/isaaclab/direct_env.py`) is a subclass
+of IsaacLab's `DirectRLEnv` that provides generic implementations of
+`_setup_scene`, `_reset_idx`, and `_pre_physics_step` for the common case: one
+primary robot (an `Articulation`) plus an optional single camera. You only
+implement the task-specific logic:
+
+| Method | What it does |
+|---|---|
+| `_apply_action(self) -> None` | Send `self.actions` (already scaled by `cfg.action_scale`) to the robot, e.g. `self.robot.set_joint_effort_target(...)`. |
+| `_get_observations(self) -> dict` | Return the observation dict. See [Observation key convention](#observation-key-convention). |
+| `_get_rewards(self) -> torch.Tensor` | Return a `(num_envs,)` reward tensor. |
+| `_get_dones(self) -> tuple[torch.Tensor, torch.Tensor]` | Return `(terminated, time_out)`, each `(num_envs,)` bool tensors. |
+
+Everything else — spawning the robot, ground plane, light, cloning
+environments across `num_envs`, and restoring default joint state on reset —
+is handled by the base class.
+
+## Minimal example
+
+```python
+# rl_garden/envs/isaaclab/tasks/my_task.py
+from __future__ import annotations
+
+import gymnasium as gym
+import torch
+
+from isaaclab.assets import ArticulationCfg
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sim import SimulationCfg
+from isaaclab.utils import configclass
+
+from rl_garden.envs.isaaclab.direct_env import RLGardenDirectEnvCfg, RLGardenDirectRLEnv
+
+MY_ROBOT_CFG: ArticulationCfg = ...  # from isaaclab_assets, or your own
+
+
+@configclass
+class MyTaskEnvCfg(RLGardenDirectEnvCfg):
+    decimation = 2
+    episode_length_s = 5.0
+    action_scale = 1.0
+    action_space = 1          # dim of the action your _apply_action expects
+    observation_space = 4     # dim of your flat state vector (state-only tasks)
+    state_space = 0
+
+    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation)
+    robot_cfg: ArticulationCfg = MY_ROBOT_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    scene: InteractiveSceneCfg = InteractiveSceneCfg(
+        num_envs=4096, env_spacing=4.0, replicate_physics=True, clone_in_fabric=True
+    )
+
+
+class MyTaskEnv(RLGardenDirectRLEnv):
+    cfg: MyTaskEnvCfg
+
+    def _apply_action(self) -> None:
+        self.robot.set_joint_effort_target(self.actions)
+
+    def _get_observations(self) -> dict:
+        return {"state": torch.cat([self.robot.data.joint_pos, self.robot.data.joint_vel], dim=-1)}
+
+    def _get_rewards(self) -> torch.Tensor:
+        return -torch.abs(self.robot.data.joint_pos).sum(dim=-1)
+
+    def _get_dones(self) -> tuple[torch.Tensor, torch.Tensor]:
+        time_out = self.episode_length_buf >= self.max_episode_length - 1
+        terminated = torch.zeros_like(time_out)
+        return terminated, time_out
+
+
+gym.register(
+    id="RlGarden-MyTask-v0",
+    entry_point=f"{__name__}:MyTaskEnv",
+    disable_env_checker=True,
+    # make_isaaclab_env() resolves the cfg through IsaacLab's own
+    # parse_env_cfg()/load_cfg_from_registry(), matching the convention every
+    # native isaaclab_tasks registration uses -- always a string, not an
+    # instance, and always this exact kwarg name.
+    kwargs={"env_cfg_entry_point": f"{__name__}:MyTaskEnvCfg"},
+)
+```
+
+Then register the module so its `gym.register(...)` call actually runs:
+
+```python
+# rl_garden/envs/isaaclab/tasks/__init__.py
+from rl_garden.envs.isaaclab.tasks.my_task import MyTaskEnv
+__all__ = [..., "MyTaskEnv"]
+```
+
+**This import must stay in `rl_garden/envs/isaaclab/tasks/__init__.py`, not
+anywhere at package-import time.** IsaacLab requires its Kit application to
+be booted (`AppLauncher`) before any `isaaclab.*` subclass — including your
+task — can be imported. `make_isaaclab_env()` in `rl_garden/envs/isaaclab/env.py`
+already imports `rl_garden.envs.isaaclab.tasks` at the right point (after
+`get_or_launch_app()`); you don't need to add anything there, just add your
+task's import to that `tasks/__init__.py`.
+
+Full worked reference: `rl_garden/envs/isaaclab/tasks/cartpole_direct.py`
+reimplements IsaacLab's official Cartpole task end-to-end (action scaling,
+reward terms, termination, reset-time pole-angle randomization via the
+`_sample_reset_state` hook — see below).
+
+## Reset-time randomization: `_sample_reset_state`
+
+`_reset_idx` restores default joint pos/vel by default (no randomization). If
+your task needs reset-time randomization (e.g. a random initial pose), override
+the `_sample_reset_state` hook instead of `_reset_idx` itself:
+
+```python
+def _sample_reset_state(self, env_ids, joint_pos, joint_vel):
+    joint_pos[:, self._some_joint_idx] += sample_uniform(-0.1, 0.1, ..., joint_pos.device)
+    return joint_pos, joint_vel
+```
+
+If your `_get_observations()`/`_get_rewards()`/`_get_dones()` read a *cached*
+copy of joint state (as `cartpole_direct.py` does, for a small perf win) rather
+than calling `self.robot.data.joint_pos` fresh each time, update that cache
+inside `_sample_reset_state` too — see the comment in
+`cartpole_direct.py::_sample_reset_state` for why (it's about `_get_observations`
+running after `_reset_idx` within the same `step()` call, so the cache must
+reflect the just-written reset state, not the pre-reset one).
+
+## Observation key convention
+
+Unlike native IsaacLab tasks (which return `{"policy": obs}`),
+`_get_observations()` here must return rl-garden's own cross-backend keys:
+
+- `"state"` — flat proprioceptive tensor, shape `(num_envs, D)`.
+- `"rgb"` / `"depth"` — single-camera image tensors, shape `(num_envs, H, W, C)`.
+- `"rgb_<camera_name>"` / `"depth_<camera_name>"` — for tasks with more than
+  one camera (you choose the names; the adapter picks up any key starting
+  with `rgb`/`depth`).
+
+This is what lets the resulting env plug directly into rl-garden's existing
+`ImageFrameStackWrapper` and `image_keys_from_env` (`rl_garden/common/cli_args.py`)
+with zero extra code — no ManiSkill-specific translation layer is needed for
+IsaacLab tasks.
+
+**Image tensors must be raw pixel values** — e.g.
+`self.camera.data.output["rgb"]` passed through untouched, `uint8` in
+`[0, 255]`. Do **not** apply the mean-subtraction/`/255` normalization
+IsaacLab's own `cartpole_camera_env.py` example does for "better training
+results." rl-garden's image encoders (`rl_garden/encoders/base.py:
+image_needs_normalization`) decide whether to apply `/255` normalization
+based on the declared space's dtype/range, which is inferred from your
+tensor's actual dtype. Pre-normalized input is **silently handled wrong**
+(double-normalized), not rejected with an error — this is a training-quality
+bug, not a crash, so test suites won't catch it. See
+`rl_garden/envs/isaaclab/tasks/cartpole_direct_camera.py` for a correct
+example.
+
+`cfg.observation_space` can't express a `{"rgb": ..., "state": ...}` dict
+shape — for image tasks just set it to a placeholder int (e.g. `1`).
+IsaacLab's `DirectRLEnvCfg.validate()` only checks it's not `MISSING`;
+nothing else in IsaacLab or rl-garden reads this field against your actual
+returned obs. rl-garden's adapter (`_IsaacLabVecEnvAdapter`) builds its real
+`gym.spaces.Dict`/`Box` from the runtime obs tensors instead.
+
+## Adding a camera
+
+Add a `camera_cfg` field to your cfg (type `TiledCameraCfg`); the scaffold's
+`_setup_scene()` spawns it automatically if `cfg.camera_cfg is not None`:
+
+```python
+from isaaclab.sensors import TiledCameraCfg
+
+@configclass
+class MyCameraTaskEnvCfg(MyTaskEnvCfg):
+    camera_cfg: TiledCameraCfg = TiledCameraCfg(
+        prim_path="/World/envs/env_.*/Camera",
+        offset=TiledCameraCfg.OffsetCfg(pos=(-5.0, 0.0, 2.0), rot=(1.0, 0.0, 0.0, 0.0), convention="world"),
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 20.0)
+        ),
+        width=64,
+        height=64,
+    )
+```
+
+Then read `self.camera.data.output["rgb"]` in `_get_observations()`.
+
+**Camera resolution: use 64×64 or 128×128.** rl-garden's default `PlainConv`
+image encoder (`rl_garden/encoders/plain_conv.py`) hardcodes a conv/pool
+stride schedule that only produces a valid feature map for those two sizes
+(any other resolution silently builds a mis-sized `Linear` layer and crashes
+at the first forward pass — `RuntimeError: mat1 and mat2 shapes cannot be
+multiplied`). Pass matching `--camera_width`/`--camera_height` on the training
+CLI (see below); it defaults to 64.
+
+**Scene config for camera tasks must not set `clone_in_fabric=True`.** The
+state-only default (`InteractiveSceneCfg(..., clone_in_fabric=True)`) mis-sizes
+the camera sensor's per-env buffers and crashes with a CUDA `index out of
+bounds` assertion during `env.reset()`. IsaacLab's own camera example
+(`cartpole_camera_env.py`) omits this flag too — see
+`cartpole_direct_camera.py`'s `scene` field for the working config.
+
+**⚠️ Camera observations currently have a known, unresolved reliability
+issue on the 6017-nofwd host — training can hang partway through. Read
+[`isaaclab-camera-stall.md`](isaaclab-camera-stall.md) before relying on this
+for real work.** State-only tasks (no `camera_cfg`) are unaffected and fully
+reliable.
+
+## Training your new task
+
+```bash
+python examples/train_online.py ppo --env_backend isaaclab \
+  --env_id RlGarden-MyTask-v0 --obs_mode state \
+  --num_envs 4096 --eval_freq 0 --total_timesteps 200000
+```
+
+For a camera task:
+
+```bash
+python examples/train_online.py ppo --env_backend isaaclab \
+  --env_id RlGarden-MyTask-Camera-v0 --obs_mode rgb \
+  --camera_width 64 --camera_height 64 --num_envs 32 --eval_freq 0 \
+  --total_timesteps 200000 \
+  --isaaclab.sim_device cuda:0
+```
+
+Relevant IsaacLab-specific CLI flags (`--isaaclab.<field>`, see
+`IsaacLabConfig` in `rl_garden/common/env_args.py`):
+
+- `--isaaclab.headless` (default `True`)
+- `--isaaclab.sim_device` (default `cuda:0`)
+- `--isaaclab.env_kwargs_json` — JSON dict forwarded verbatim as
+  `setattr(env_cfg, key, value)` overrides on the parsed cfg (escape hatch for
+  task-specific cfg fields you want to override from the CLI without adding a
+  dedicated flag).
+
+`--eval_freq 0` is required (or leave it out and it'll be rejected at eval-env
+construction time) — the IsaacLab backend does not support a separate live
+eval env; `AppLauncher` only supports one Isaac Sim instance per process.
+
+## Training an existing task
+
+Native `isaaclab_tasks` tasks (state-only) work through the same backend with
+zero extra code:
+
+```bash
+python examples/train_online.py ppo --env_backend isaaclab \
+  --env_id Isaac-Cartpole-Direct-v0 --obs_mode state \
+  --num_envs 4096 --eval_freq 0 --total_timesteps 200000
+```
+
+This works for both `ManagerBasedRLEnv` and `DirectRLEnv` native tasks
+because both use the `"policy"` observation-group key by convention, which
+`_IsaacLabVecEnvAdapter` falls back to when it doesn't find rl-garden's own
+`"state"` key. Native image-observation tasks (e.g.
+`Isaac-Cartpole-RGB-Camera-Direct-v0`) are **not** supported — those return a
+single un-split `"policy"` image tensor with no separate state key, which
+doesn't fit rl-garden's `Dict` obs convention. Write a scaffold-based task
+instead if you need images.
+
+## Overriding scene setup entirely
+
+If your task doesn't fit "one articulation + optional camera" (multiple
+objects, non-rigid bodies, a custom scene layout), override `_setup_scene`
+and/or `_reset_idx` wholesale instead of relying on the scaffold's generic
+versions — they're ordinary methods on a `DirectRLEnv` subclass, nothing
+about the scaffold prevents this. Look at `RLGardenDirectRLEnv`'s own
+implementation in `rl_garden/envs/isaaclab/direct_env.py` as your starting
+point to copy from.

--- a/rl_garden/algorithms/on_policy.py
+++ b/rl_garden/algorithms/on_policy.py
@@ -287,6 +287,13 @@ class OnPolicyAlgorithm(BaseAlgorithm):
 
             update_t = time.perf_counter()
             losses = self.train()
+            # Duck-typed hook some env backends need after a heavy training
+            # burst, before the next rollout's first step() (e.g. IsaacLab's
+            # Kit renderer hangs on the next render call otherwise). No-op
+            # for backends that don't define it.
+            post_update_hook = getattr(self.env, "post_update_sync", None)
+            if post_update_hook is not None:
+                post_update_hook()
             update_time = time.perf_counter() - update_t
             cumulative["update_time"] += update_time
 

--- a/rl_garden/common/env_args.py
+++ b/rl_garden/common/env_args.py
@@ -119,6 +119,18 @@ class MujocoWarpConfig:
 
 
 @dataclass
+class IsaacLabConfig:
+    """IsaacLab-specific env settings. CLI prefix: ``--isaaclab.<field>``"""
+
+    headless: bool = True
+    sim_device: str = "cuda:0"
+    # JSON-encoded dict forwarded verbatim to IsaacLabEnvConfig.env_kwargs
+    # (e.g. task-specific cfg overrides). Escape hatch, same convention as
+    # ManiSkillConfig.env_kwargs_json.
+    env_kwargs_json: str = "{}"
+
+
+@dataclass
 class EnvBackendArgs:
     """Mixin: adds ``env_backend`` selector and per-backend sub-configs.
 
@@ -133,6 +145,7 @@ class EnvBackendArgs:
     d4rl_legacy: D4RLLegacyConfig = field(default_factory=D4RLLegacyConfig)
     mujoco: MujocoConfig = field(default_factory=MujocoConfig)
     mujoco_warp: MujocoWarpConfig = field(default_factory=MujocoWarpConfig)
+    isaaclab: IsaacLabConfig = field(default_factory=IsaacLabConfig)
 
     def resolve_backend_config(self):
         from rl_garden.envs.backend_registry import resolve_backend_config

--- a/rl_garden/envs/backends/isaaclab.py
+++ b/rl_garden/envs/backends/isaaclab.py
@@ -1,0 +1,59 @@
+"""IsaacLab env backend — registered as ``"isaaclab"``.
+
+Supports both ``ManagerBasedRLEnv`` and ``DirectRLEnv`` tasks (native
+``isaaclab_tasks`` or rl-garden's own ``RLGardenDirectRLEnv``-scaffold
+tasks), state or image observations. No live eval env (see
+``rl_garden.envs.isaaclab.env`` module docstring and
+``.agents/rules/adding-env-backend.md``).
+"""
+from __future__ import annotations
+
+import json
+
+from rl_garden.envs.backend_registry import (
+    EnvBackend,
+    EnvRequest,
+    register_env_backend,
+)
+
+
+class IsaacLabBackend(EnvBackend):
+    api_version = 2
+    config_field = "isaaclab"
+
+    @classmethod
+    def resolve_config(cls, req: EnvRequest, *, is_eval: bool):
+        from rl_garden.envs.isaaclab import IsaacLabEnvConfig
+
+        il = req.backend_config  # IsaacLabConfig or None
+        return IsaacLabEnvConfig(
+            env_id=req.env_id,
+            num_envs=req.num_envs,
+            seed=req.seed,
+            headless=il.headless if il is not None else True,
+            sim_device=il.sim_device if il is not None else "cuda:0",
+            obs_mode=req.obs_mode,
+            frame_stack=req.frame_stack,
+            env_kwargs=(
+                json.loads(il.env_kwargs_json) if il is not None and il.env_kwargs_json else {}
+            ),
+        )
+
+    _make_cfg = resolve_config
+
+    @classmethod
+    def make_train_env(cls, req: EnvRequest):
+        from rl_garden.envs.isaaclab import make_isaaclab_env
+
+        return make_isaaclab_env(cls.resolve_config(req, is_eval=False))
+
+    @classmethod
+    def make_eval_env(cls, req: EnvRequest):
+        raise NotImplementedError(
+            "IsaacLab backend does not support a separate live eval env in v1 "
+            "(AppLauncher only supports one Isaac Sim instance per process). "
+            "Pass --eval_freq 0 to skip eval env creation."
+        )
+
+
+register_env_backend("isaaclab", IsaacLabBackend)

--- a/rl_garden/envs/isaaclab/__init__.py
+++ b/rl_garden/envs/isaaclab/__init__.py
@@ -1,0 +1,4 @@
+from rl_garden.envs.isaaclab.config import IsaacLabEnvConfig
+from rl_garden.envs.isaaclab.env import make_isaaclab_env
+
+__all__ = ["IsaacLabEnvConfig", "make_isaaclab_env"]

--- a/rl_garden/envs/isaaclab/app.py
+++ b/rl_garden/envs/isaaclab/app.py
@@ -1,0 +1,85 @@
+"""Process-wide Isaac Sim application singleton.
+
+IsaacLab requires constructing an ``AppLauncher`` (which boots the Isaac
+Sim/Kit application) before any ``isaaclab.*`` / ``isaaclab_tasks.*`` module
+is imported, and a process can only host one such application. ``rl_garden``
+has no separate eval-env process for the IsaacLab backend in v1 (see
+``rl_garden.envs.backends.isaaclab``), so this singleton only ever needs to
+be launched once per training run.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Optional
+
+_APP: Optional[Any] = None
+
+
+def _scrub_bundled_torch_from_syspath() -> None:
+    """Remove Kit extension ``pip_prebundle`` dirs that ship their own torch.
+
+    Several Isaac Sim extensions (e.g. ``omni.isaac.ml_archive``) bundle a
+    separate copy of ``torch`` -- including a ``torch._dynamo`` build from a
+    different torch version -- and add their ``pip_prebundle`` directory to
+    ``sys.path`` as part of AppLauncher's own Kit bootstrap. Because
+    ``torch`` itself is already imported (resolving correctly to the venv's
+    copy) by the time this runs, only *lazily*-imported submodules of
+    ``torch`` (e.g. ``torch._dynamo.repro.after_dynamo``, touched only once
+    something calls ``torch.compile``) are at risk of resolving to the
+    bundled copy instead, producing cross-version ImportErrors. Drop any
+    such path so every subsequent ``torch.*`` submodule import can only find
+    the venv's own copy.
+    """
+    sys.path[:] = [
+        p
+        for p in sys.path
+        if not (os.path.basename(p.rstrip("/")) == "pip_prebundle" and os.path.isdir(os.path.join(p, "torch")))
+    ]
+
+
+def get_or_launch_app(headless: bool, sim_device: str, enable_cameras: bool = False) -> Any:
+    """Return the process-wide Isaac Sim app, launching it on first call.
+
+    ``enable_cameras`` must be True if the env being built spawns any camera
+    sensor (e.g. ``TiledCamera``) -- IsaacLab raises at sensor-init time
+    otherwise ("A camera was spawned without the --enable_cameras flag").
+    Since this is a process-wide singleton, once launched without cameras a
+    later call requesting them can't retroactively enable rendering.
+    """
+    global _APP
+    if _APP is not None:
+        return _APP
+
+    # Exercise torch.compile end-to-end from the venv's own torch *before*
+    # AppLauncher boots Kit. Some Kit extensions (e.g. omni.isaac.ml_archive)
+    # bundle their own torch._dynamo build and import pieces of it as part
+    # of their own initialization; whichever copy of a given torch._dynamo
+    # submodule gets imported first wins the sys.modules caching race for
+    # the rest of the process. Actually calling a compiled function (not
+    # just importing torch._dynamo) walks the same lazy-import chain
+    # torch.compile itself needs (eval_frame -> get_compiler_fn ->
+    # repro.after_dynamo -> debug_utils -> testing -> types, at least as of
+    # torch 2.6), so every submodule it touches gets cached from the venv
+    # copy first, regardless of how deep that chain is or changes across
+    # torch versions.
+    import torch
+
+    @torch.compile
+    def _warm_up_dynamo(x: "torch.Tensor") -> "torch.Tensor":
+        return x + 1
+
+    _warm_up_dynamo(torch.zeros(1))
+
+    from isaaclab.app import AppLauncher
+
+    launcher_kwargs = dict(headless=headless, device=sim_device, enable_cameras=enable_cameras)
+    if enable_cameras:
+        # "performance" trims DLSS/post-processing overhead relative to the
+        # "balanced" default -- camera-observation training has no need for
+        # display-quality rendering.
+        launcher_kwargs["rendering_mode"] = "performance"
+    launcher = AppLauncher(**launcher_kwargs)
+    _APP = launcher.app
+    _scrub_bundled_torch_from_syspath()
+    return _APP

--- a/rl_garden/envs/isaaclab/config.py
+++ b/rl_garden/envs/isaaclab/config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class IsaacLabEnvConfig:
+    env_id: str
+    num_envs: int
+    seed: int
+    headless: bool = True
+    sim_device: str = "cuda:0"
+    obs_mode: str = "state"
+    frame_stack: int = 1
+    env_kwargs: dict = field(default_factory=dict)

--- a/rl_garden/envs/isaaclab/direct_env.py
+++ b/rl_garden/envs/isaaclab/direct_env.py
@@ -1,0 +1,129 @@
+"""rl-garden's ``DirectRLEnv`` authoring scaffold.
+
+IsaacLab's ``DirectRLEnv`` (direct-implementation style) skips the
+``ManagerBasedRLEnv`` per-term dispatch and expects task authors to write
+fully-tensorized batch computations directly. In practice, every real Direct
+task also overrides the same two boilerplate methods
+(``_setup_scene``/``_reset_idx``) to do the same thing: spawn one primary
+articulation (+ optionally one camera), clone/replicate the scene, and on
+reset restore default joint state with a scene-origin offset (see IsaacLab's
+own ``cartpole_env.py``/``cartpole_camera_env.py``).
+
+``RLGardenDirectRLEnv`` covers exactly that common shape declaratively via
+``RLGardenDirectEnvCfg.robot_cfg``/``camera_cfg``, so a task author only has
+to implement the four methods that are genuinely task-specific:
+``_apply_action``, ``_get_observations``, ``_get_rewards``, ``_get_dones``.
+Tasks with a different scene shape (multiple objects, non-default reset
+randomization beyond ``_sample_reset_state``, etc.) can still override
+``_setup_scene``/``_reset_idx`` wholesale, same as any ``DirectRLEnv``
+subclass.
+
+Observation key convention: unlike IsaacLab's native tasks (which return
+``{"policy": obs}``), ``_get_observations()`` here should return rl-garden's
+own cross-backend keys -- ``"state"`` for the flat proprioceptive tensor,
+``"rgb"``/``"depth"`` (or ``"rgb_<camera>"``/``"depth_<camera>"`` for
+multi-camera tasks) for images -- so the resulting env plugs directly into
+the same ``ImageFrameStackWrapper`` used for other backends. Image tensors
+must be **raw pixel values** (e.g. ``camera.data.output["rgb"]`` passed
+through untouched, uint8 ``[0, 255]``): do NOT apply the mean-subtraction
+IsaacLab's own ``cartpole_camera_env.py`` example does for RGB. rl-garden's
+image encoders decide whether to apply ``/255`` normalization from the
+declared space's dtype/range (see
+``rl_garden.encoders.base.image_needs_normalization``), so pre-normalized
+input is silently handled wrong rather than raising an error.
+
+``cfg.observation_space``/``cfg.action_space`` still need placeholder values
+(any int is fine, e.g. ``1``) to satisfy ``DirectRLEnvCfg.validate()`` --
+IsaacLab never checks the runtime obs dict against them, and rl-garden's own
+adapter builds its ``gym.spaces.Dict``/``Box`` from the runtime obs/action
+tensors instead.
+"""
+from __future__ import annotations
+
+from dataclasses import MISSING
+from typing import Optional, Sequence, Tuple
+
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import Articulation, ArticulationCfg
+from isaaclab.envs import DirectRLEnv, DirectRLEnvCfg
+from isaaclab.sensors import TiledCamera, TiledCameraCfg
+from isaaclab.sim.spawners.from_files import GroundPlaneCfg, spawn_ground_plane
+from isaaclab.utils import configclass
+
+
+@configclass
+class RLGardenDirectEnvCfg(DirectRLEnvCfg):
+    """``DirectRLEnvCfg`` + declarative scene config for ``RLGardenDirectRLEnv``.
+
+    ``decimation``/``episode_length_s``/``scene``/``observation_space``/
+    ``action_space`` are still owned by the concrete per-task cfg, exactly as
+    in a plain ``DirectRLEnvCfg`` subclass -- this only adds the scene fields
+    that ``RLGardenDirectRLEnv``'s generic ``_setup_scene``/``_reset_idx``
+    consume.
+    """
+
+    robot_cfg: ArticulationCfg = MISSING
+    camera_cfg: Optional[TiledCameraCfg] = None
+    action_scale: float = 1.0
+
+
+class RLGardenDirectRLEnv(DirectRLEnv):
+    """Task authors override ``_apply_action``/``_get_observations``/
+    ``_get_rewards``/``_get_dones``; ``_setup_scene``/``_reset_idx``/
+    ``_pre_physics_step`` already have generic implementations for the
+    single-articulation (+ optional single-camera) case.
+    """
+
+    cfg: RLGardenDirectEnvCfg
+
+    def _setup_scene(self) -> None:
+        self.robot = Articulation(self.cfg.robot_cfg)
+        self.scene.articulations["robot"] = self.robot
+        if self.cfg.camera_cfg is not None:
+            self.camera = TiledCamera(self.cfg.camera_cfg)
+            self.scene.sensors["camera"] = self.camera
+
+        spawn_ground_plane(prim_path="/World/ground", cfg=GroundPlaneCfg())
+        self.scene.clone_environments(copy_from_source=False)
+        if self.device == "cpu":
+            # CPU simulation needs collisions filtered explicitly.
+            self.scene.filter_collisions(global_prim_paths=[])
+
+        light_cfg = sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75))
+        light_cfg.func("/World/Light", light_cfg)
+
+    def _reset_idx(self, env_ids: Optional[Sequence[int]]) -> None:
+        if env_ids is None:
+            env_ids = self.robot._ALL_INDICES
+        super()._reset_idx(env_ids)
+
+        joint_pos = self.robot.data.default_joint_pos[env_ids]
+        joint_vel = self.robot.data.default_joint_vel[env_ids]
+        joint_pos, joint_vel = self._sample_reset_state(env_ids, joint_pos, joint_vel)
+
+        default_root_state = self.robot.data.default_root_state[env_ids]
+        default_root_state[:, :3] += self.scene.env_origins[env_ids]
+
+        self.robot.write_root_pose_to_sim(default_root_state[:, :7], env_ids)
+        self.robot.write_root_velocity_to_sim(default_root_state[:, 7:], env_ids)
+        self.robot.write_joint_state_to_sim(joint_pos, joint_vel, None, env_ids)
+
+    def _sample_reset_state(
+        self,
+        env_ids: Sequence[int],
+        joint_pos: torch.Tensor,
+        joint_vel: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Optional hook for reset-time randomization (e.g. initial pose jitter).
+
+        Default: no randomization, joints reset to their default pos/vel.
+        """
+        return joint_pos, joint_vel
+
+    def _pre_physics_step(self, actions: torch.Tensor) -> None:
+        self.actions = self.cfg.action_scale * actions.clone()
+
+    # _apply_action / _get_observations / _get_rewards / _get_dones stay
+    # abstract (inherited from DirectRLEnv) -- task authors implement these.

--- a/rl_garden/envs/isaaclab/env.py
+++ b/rl_garden/envs/isaaclab/env.py
@@ -1,0 +1,190 @@
+"""IsaacLab environment factory.
+
+Wraps a raw IsaacLab env (``ManagerBasedRLEnv`` or ``DirectRLEnv``, native
+``isaaclab_tasks`` task or an ``RLGardenDirectRLEnv``-scaffold task) with
+``_IsaacLabVecEnvAdapter`` so it exposes the same shape the rest of
+``rl_garden`` targets: ``num_envs`` / ``single_observation_space`` /
+``single_action_space``, and ``step``/``reset`` returning GPU tensors plus
+the standard Gymnasium ``(obs, reward, terminated, truncated, info)`` tuple.
+
+Observation extraction:
+- ``obs_mode="state"``: looks for a ``"state"`` key (rl-garden scaffold
+  convention) first, falling back to ``"policy"`` (every native IsaacLab
+  task's own convention -- both ``ManagerBasedRLEnv`` and ``DirectRLEnv``
+  tasks use it).
+- ``obs_mode`` in ``("rgb", "rgbd")``: requires rl-garden's own cross-backend
+  key convention directly (``"rgb"``/``"depth"``/``"rgb_<cam>"``/
+  ``"depth_<cam>"``, plus ``"state"`` if the task returns one) -- only
+  ``RLGardenDirectRLEnv``-scaffold tasks are expected to satisfy this;
+  native single-``"policy"``-image tasks (e.g. ``Isaac-Cartpole-RGB-Camera-
+  Direct-v0``) aren't supported by this backend.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+from rl_garden.envs.isaaclab.config import IsaacLabEnvConfig
+
+
+def _box_from_tensor(tensor: torch.Tensor) -> gym.spaces.Box:
+    if tensor.dtype == torch.uint8:
+        return gym.spaces.Box(low=0, high=255, shape=tuple(tensor.shape[1:]), dtype=np.uint8)
+    return gym.spaces.Box(
+        low=-float("inf"),
+        high=float("inf"),
+        shape=tuple(tensor.shape[1:]),
+        dtype=np.float32,
+    )
+
+
+class _IsaacLabVecEnvAdapter(gym.Env):
+    """Adapts an IsaacLab env to the rl-garden env shape (see module docstring)."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(self, env: Any, seed: int, obs_mode: str = "state") -> None:
+        self._env = env
+        self._seed = seed
+        self.obs_mode = obs_mode
+        # gym.make() wraps the raw env in OrderEnforcing, which rejects
+        # attribute access before the first reset() -- go through .unwrapped
+        # for env-level attributes that aren't part of the standard gym.Env
+        # surface (num_envs, device).
+        unwrapped = env.unwrapped
+        self.num_envs = unwrapped.num_envs
+        self.device = unwrapped.device
+
+        obs_dict, _ = env.reset(seed=seed)
+        self._last_obs = self._extract_obs(obs_dict)
+        # Duck-typed attribute expected by wrappers like ImageFrameStackWrapper
+        # on env.unwrapped (mirrors mani_skill.envs.sapien_env.BaseEnv).
+        self._init_raw_obs = self._last_obs
+        self.single_observation_space = self._build_observation_space(self._last_obs)
+
+        # IsaacLab's action_space is already batched as (num_envs, action_dim),
+        # unlike Gymnasium's vector-env convention where single_action_space
+        # describes one env -- slice off the leading num_envs dimension.
+        action_space = unwrapped.action_space
+        self.single_action_space = gym.spaces.Box(
+            low=action_space.low[0],
+            high=action_space.high[0],
+            shape=action_space.shape[1:],
+            dtype=action_space.dtype,
+        )
+
+    def _extract_obs(self, obs_dict: dict):
+        if self.obs_mode == "state":
+            if "state" in obs_dict:
+                return obs_dict["state"]
+            if "policy" in obs_dict:
+                return obs_dict["policy"]
+            raise ValueError(
+                "IsaacLab backend (obs_mode='state') requires a 'state' or "
+                f"'policy' observation key, got keys {sorted(obs_dict)!r}."
+            )
+        image_keys = [key for key in obs_dict if key.startswith(("rgb", "depth"))]
+        if not image_keys:
+            raise ValueError(
+                f"IsaacLab backend (obs_mode={self.obs_mode!r}) requires "
+                "'rgb'/'depth'-prefixed observation keys (rl-garden's own "
+                "cross-backend convention -- see RLGardenDirectRLEnv's "
+                f"docstring), got keys {sorted(obs_dict)!r}."
+            )
+        out = {key: obs_dict[key] for key in image_keys}
+        if "state" in obs_dict:
+            out["state"] = obs_dict["state"]
+        return out
+
+    def _build_observation_space(self, obs):
+        if isinstance(obs, dict):
+            return gym.spaces.Dict({key: _box_from_tensor(value) for key, value in obs.items()})
+        return _box_from_tensor(obs)
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        obs_dict, info = self._env.reset(seed=seed if seed is not None else self._seed)
+        self._last_obs = self._extract_obs(obs_dict)
+        return self._last_obs, info
+
+    def step(self, actions: torch.Tensor):
+        obs_dict, reward, terminated, truncated, info = self._env.step(actions)
+        self._last_obs = self._extract_obs(obs_dict)
+        return self._last_obs, reward, terminated, truncated, info
+
+    def update_obs_space(self, obs) -> None:
+        """Duck-typed hook expected on ``env.unwrapped`` by wrappers like
+        ``ImageFrameStackWrapper`` (mirrors
+        ``mani_skill.envs.sapien_env.BaseEnv.update_obs_space``)."""
+        self._init_raw_obs = obs
+        self.single_observation_space = self._build_observation_space(obs)
+
+    def post_update_sync(self) -> None:
+        """Duck-typed hook ``OnPolicyAlgorithm.learn()`` calls once per
+        rollout+update cycle, right after the update phase and before the
+        next rollout's first ``step()``.
+
+        Mitigation (not a confirmed full fix) for a render-pipeline stall
+        observed on 6017-nofwd: Kit's camera-rendering pipeline can hang
+        indefinitely on a render call that follows a sustained PyTorch CUDA
+        compute burst (e.g. a PPO update's many backward passes). A single
+        ``torch.cuda.synchronize()`` here measurably reduces how often this
+        happens (state-only tasks never need it; observed several camera-
+        task runs get through many more rollout+update cycles with this than
+        without) but did NOT reliably eliminate the stall across repeated
+        runs in testing -- it looks like a timing-sensitive race rather than
+        something a single sync deterministically resolves. Syncing before
+        every ``step()`` instead of once per cycle made it worse (reintroduced
+        the hang reliably), so keep this placement (once per cycle) if
+        investigating further.
+        """
+        if self.obs_mode != "state":
+            torch.cuda.synchronize()
+
+    def close(self) -> None:
+        self._env.close()
+
+
+def make_isaaclab_env(cfg: IsaacLabEnvConfig):
+    """Build an IsaacLab env according to ``cfg``."""
+    from rl_garden.envs.isaaclab.app import get_or_launch_app
+
+    get_or_launch_app(cfg.headless, cfg.sim_device, enable_cameras=(cfg.obs_mode != "state"))
+
+    import isaaclab_tasks  # noqa: F401  (registers native gym ids)
+
+    # Must come after get_or_launch_app(): registering rl-garden's own tasks
+    # imports RLGardenDirectRLEnv, which subclasses isaaclab.envs.DirectRLEnv
+    # -- IsaacLab requires Kit to already be running before any isaaclab.*
+    # subclass can be imported.
+    import rl_garden.envs.isaaclab.tasks  # noqa: F401
+    from isaaclab_tasks.utils import parse_env_cfg
+
+    env_cfg = parse_env_cfg(cfg.env_id, device=cfg.sim_device, num_envs=cfg.num_envs)
+    for key, value in cfg.env_kwargs.items():
+        setattr(env_cfg, key, value)
+
+    env = gym.make(cfg.env_id, cfg=env_cfg)
+    adapter = _IsaacLabVecEnvAdapter(env, seed=cfg.seed, obs_mode=cfg.obs_mode)
+
+    if cfg.frame_stack > 1:
+        if cfg.obs_mode == "state":
+            raise ValueError("frame_stack > 1 requires a visual observation mode")
+        from rl_garden.envs.wrappers import ImageFrameStackWrapper
+
+        wrapped = ImageFrameStackWrapper(adapter, frame_stack=cfg.frame_stack)
+        # ImageFrameStackWrapper doesn't forward arbitrary attributes -- copy
+        # the rl-garden env-shape attributes onto the outermost object.
+        # single_observation_space is already the post-frame-stack space at
+        # this point (ImageFrameStackWrapper.__init__ calls update_obs_space
+        # on the adapter before returning).
+        wrapped.num_envs = adapter.num_envs
+        wrapped.device = adapter.device
+        wrapped.single_action_space = adapter.single_action_space
+        wrapped.single_observation_space = adapter.single_observation_space
+        wrapped.post_update_sync = adapter.post_update_sync
+        return wrapped
+
+    return adapter

--- a/rl_garden/envs/isaaclab/tasks/__init__.py
+++ b/rl_garden/envs/isaaclab/tasks/__init__.py
@@ -1,0 +1,12 @@
+"""rl-garden's own IsaacLab tasks, built on ``RLGardenDirectRLEnv``.
+
+Import time triggers each task module's ``gym.register(...)`` call. Must
+only be imported *after* ``get_or_launch_app()`` has booted Kit (see
+``rl_garden.envs.isaaclab.env.make_isaaclab_env``) -- IsaacLab requires the
+app to exist before any ``isaaclab.*`` subclass can be imported.
+"""
+from rl_garden.envs.isaaclab.tasks.cartpole_direct import CartpoleDirectEnv
+from rl_garden.envs.isaaclab.tasks.cartpole_direct_camera import CartpoleDirectCameraEnv
+from rl_garden.envs.isaaclab.tasks.cartpole_direct_camera_plain import CartpoleDirectCameraPlainEnv
+
+__all__ = ["CartpoleDirectEnv", "CartpoleDirectCameraEnv", "CartpoleDirectCameraPlainEnv"]

--- a/rl_garden/envs/isaaclab/tasks/cartpole_direct.py
+++ b/rl_garden/envs/isaaclab/tasks/cartpole_direct.py
@@ -1,0 +1,164 @@
+"""``RLGardenDirectRLEnv`` reimplementation of IsaacLab's official Cartpole
+Direct task, registered as ``RlGarden-Cartpole-Direct-v0``.
+
+Logic (action scaling, reward terms, termination condition, reset pole-angle
+jitter) is copied from ``isaaclab_tasks.direct.cartpole.cartpole_env``. This
+exists to verify parity: the scaffold's generic ``_setup_scene``/
+``_reset_idx`` should behave identically to the official hand-written
+version, only the observation key (``"state"`` instead of ``"policy"``, per
+rl-garden's cross-backend convention) differs.
+"""
+from __future__ import annotations
+
+import math
+from typing import Sequence, Tuple
+
+import gymnasium as gym
+import torch
+
+from isaaclab_assets.robots.cartpole import CARTPOLE_CFG
+
+from isaaclab.assets import ArticulationCfg
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sim import SimulationCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.math import sample_uniform
+
+from rl_garden.envs.isaaclab.direct_env import RLGardenDirectEnvCfg, RLGardenDirectRLEnv
+
+
+@configclass
+class CartpoleDirectEnvCfg(RLGardenDirectEnvCfg):
+    decimation = 2
+    episode_length_s = 5.0
+    action_scale = 100.0  # [N]
+    action_space = 1
+    observation_space = 4
+    state_space = 0
+
+    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation)
+
+    robot_cfg: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    cart_dof_name = "slider_to_cart"
+    pole_dof_name = "cart_to_pole"
+
+    scene: InteractiveSceneCfg = InteractiveSceneCfg(
+        num_envs=4096, env_spacing=4.0, replicate_physics=True, clone_in_fabric=True
+    )
+
+    max_cart_pos = 3.0
+    initial_pole_angle_range = [-0.25, 0.25]
+
+    rew_scale_alive = 1.0
+    rew_scale_terminated = -2.0
+    rew_scale_pole_pos = -1.0
+    rew_scale_cart_vel = -0.01
+    rew_scale_pole_vel = -0.005
+
+
+class CartpoleDirectEnv(RLGardenDirectRLEnv):
+    cfg: CartpoleDirectEnvCfg
+
+    def __init__(self, cfg: CartpoleDirectEnvCfg, render_mode: str | None = None, **kwargs):
+        super().__init__(cfg, render_mode, **kwargs)
+
+        self._cart_dof_idx, _ = self.robot.find_joints(self.cfg.cart_dof_name)
+        self._pole_dof_idx, _ = self.robot.find_joints(self.cfg.pole_dof_name)
+
+        self.joint_pos = self.robot.data.joint_pos
+        self.joint_vel = self.robot.data.joint_vel
+
+    def _apply_action(self) -> None:
+        self.robot.set_joint_effort_target(self.actions, joint_ids=self._cart_dof_idx)
+
+    def _get_observations(self) -> dict:
+        obs = torch.cat(
+            (
+                self.joint_pos[:, self._pole_dof_idx[0]].unsqueeze(dim=1),
+                self.joint_vel[:, self._pole_dof_idx[0]].unsqueeze(dim=1),
+                self.joint_pos[:, self._cart_dof_idx[0]].unsqueeze(dim=1),
+                self.joint_vel[:, self._cart_dof_idx[0]].unsqueeze(dim=1),
+            ),
+            dim=-1,
+        )
+        return {"state": obs}
+
+    def _get_rewards(self) -> torch.Tensor:
+        return _compute_rewards(
+            self.cfg.rew_scale_alive,
+            self.cfg.rew_scale_terminated,
+            self.cfg.rew_scale_pole_pos,
+            self.cfg.rew_scale_cart_vel,
+            self.cfg.rew_scale_pole_vel,
+            self.joint_pos[:, self._pole_dof_idx[0]],
+            self.joint_vel[:, self._pole_dof_idx[0]],
+            self.joint_pos[:, self._cart_dof_idx[0]],
+            self.joint_vel[:, self._cart_dof_idx[0]],
+            self.reset_terminated,
+        )
+
+    def _get_dones(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        self.joint_pos = self.robot.data.joint_pos
+        self.joint_vel = self.robot.data.joint_vel
+
+        time_out = self.episode_length_buf >= self.max_episode_length - 1
+        out_of_bounds = torch.any(
+            torch.abs(self.joint_pos[:, self._cart_dof_idx]) > self.cfg.max_cart_pos, dim=1
+        )
+        out_of_bounds = out_of_bounds | torch.any(
+            torch.abs(self.joint_pos[:, self._pole_dof_idx]) > math.pi / 2, dim=1
+        )
+        return out_of_bounds, time_out
+
+    def _sample_reset_state(
+        self,
+        env_ids: Sequence[int],
+        joint_pos: torch.Tensor,
+        joint_vel: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        joint_pos[:, self._pole_dof_idx] += sample_uniform(
+            self.cfg.initial_pole_angle_range[0] * math.pi,
+            self.cfg.initial_pole_angle_range[1] * math.pi,
+            joint_pos[:, self._pole_dof_idx].shape,
+            joint_pos.device,
+        )
+        # _get_observations() reads the cached self.joint_pos/self.joint_vel
+        # (last refreshed in _get_dones(), which runs before _reset_idx() in
+        # DirectRLEnv.step()) -- sync the just-reset envs' slice now so the
+        # observation returned for this step reflects the actual post-reset
+        # state, matching the official cartpole_env.py's own _reset_idx patch.
+        self.joint_pos[env_ids] = joint_pos
+        self.joint_vel[env_ids] = joint_vel
+        return joint_pos, joint_vel
+
+
+@torch.jit.script
+def _compute_rewards(
+    rew_scale_alive: float,
+    rew_scale_terminated: float,
+    rew_scale_pole_pos: float,
+    rew_scale_cart_vel: float,
+    rew_scale_pole_vel: float,
+    pole_pos: torch.Tensor,
+    pole_vel: torch.Tensor,
+    cart_pos: torch.Tensor,
+    cart_vel: torch.Tensor,
+    reset_terminated: torch.Tensor,
+) -> torch.Tensor:
+    rew_alive = rew_scale_alive * (1.0 - reset_terminated.float())
+    rew_termination = rew_scale_terminated * reset_terminated.float()
+    rew_pole_pos = rew_scale_pole_pos * torch.sum(torch.square(pole_pos).unsqueeze(dim=1), dim=-1)
+    rew_cart_vel = rew_scale_cart_vel * torch.sum(torch.abs(cart_vel).unsqueeze(dim=1), dim=-1)
+    rew_pole_vel = rew_scale_pole_vel * torch.sum(torch.abs(pole_vel).unsqueeze(dim=1), dim=-1)
+    return rew_alive + rew_termination + rew_pole_pos + rew_cart_vel + rew_pole_vel
+
+
+gym.register(
+    id="RlGarden-Cartpole-Direct-v0",
+    entry_point=f"{__name__}:CartpoleDirectEnv",
+    disable_env_checker=True,
+    # make_isaaclab_env() resolves this via IsaacLab's own
+    # parse_env_cfg()/load_cfg_from_registry(), matching the convention every
+    # native isaaclab_tasks registration uses.
+    kwargs={"env_cfg_entry_point": f"{__name__}:CartpoleDirectEnvCfg"},
+)

--- a/rl_garden/envs/isaaclab/tasks/cartpole_direct_camera.py
+++ b/rl_garden/envs/isaaclab/tasks/cartpole_direct_camera.py
@@ -1,0 +1,65 @@
+"""Camera variant of ``CartpoleDirectEnv``, registered as
+``RlGarden-Cartpole-Direct-Camera-v0``.
+
+Verifies the image-observation path: unlike IsaacLab's own
+``cartpole_camera_env.py`` (which mean-subtracts the RGB tensor for
+"better training results"), ``_get_observations()`` here returns the
+``TiledCamera`` output untouched -- raw ``uint8`` ``[0, 255]`` -- per
+``RLGardenDirectRLEnv``'s documented image convention. It also returns a
+``"state"`` key alongside ``"rgb"`` (the same 4-value state
+``CartpoleDirectEnv`` uses), demonstrating the state+image ``include_state``
+case for backends other than ManiSkill.
+"""
+from __future__ import annotations
+
+import gymnasium as gym
+
+import isaaclab.sim as sim_utils
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import TiledCameraCfg
+from isaaclab.utils import configclass
+
+from rl_garden.envs.isaaclab.tasks.cartpole_direct import CartpoleDirectEnv, CartpoleDirectEnvCfg
+
+
+@configclass
+class CartpoleDirectCameraEnvCfg(CartpoleDirectEnvCfg):
+    camera_cfg: TiledCameraCfg = TiledCameraCfg(
+        prim_path="/World/envs/env_.*/Camera",
+        offset=TiledCameraCfg.OffsetCfg(pos=(-5.0, 0.0, 2.0), rot=(1.0, 0.0, 0.0, 0.0), convention="world"),
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 20.0)
+        ),
+        # rl-garden's default PlainConv image encoder only supports 64x64 or
+        # 128x128 inputs (hardcoded conv/pool stride schedule) -- match the
+        # CLI's --camera_width/--camera_height default of 64.
+        width=64,
+        height=64,
+    )
+    # observation_space can't express the {"rgb": ..., "state": ...} dict
+    # shape RLGardenDirectRLEnv-scaffold tasks return -- placeholder value
+    # only, see direct_env.py's module docstring. rl-garden's own adapter
+    # builds its gym.spaces.Dict from the runtime obs dict instead.
+    observation_space = 1
+    # clone_in_fabric=True (used by the state-only base cfg) mis-sizes the
+    # camera sensor's per-env buffers -- IsaacLab's own camera example
+    # (cartpole_camera_env.py) omits it too.
+    scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=32, env_spacing=4.0, replicate_physics=True)
+
+
+class CartpoleDirectCameraEnv(CartpoleDirectEnv):
+    cfg: CartpoleDirectCameraEnvCfg
+
+    def _get_observations(self) -> dict:
+        state = super()._get_observations()["state"]
+        rgb = self.camera.data.output["rgb"]
+        return {"rgb": rgb, "state": state}
+
+
+gym.register(
+    id="RlGarden-Cartpole-Direct-Camera-v0",
+    entry_point=f"{__name__}:CartpoleDirectCameraEnv",
+    disable_env_checker=True,
+    kwargs={"env_cfg_entry_point": f"{__name__}:CartpoleDirectCameraEnvCfg"},
+)

--- a/rl_garden/envs/isaaclab/tasks/cartpole_direct_camera_plain.py
+++ b/rl_garden/envs/isaaclab/tasks/cartpole_direct_camera_plain.py
@@ -1,0 +1,64 @@
+"""Diagnostic variant of ``CartpoleDirectCameraEnv`` using IsaacLab's plain
+``Camera`` sensor instead of ``TiledCamera``, registered as
+``RlGarden-Cartpole-Direct-Camera-Plain-v0``.
+
+``TiledCamera``-based training reliably stalls on 6017-nofwd right after env
+setup completes (Replicator graph teardown/reload warnings with no further
+progress, reproducible independent of ``num_envs``, resolution, and
+``rendering_mode``). This variant isolates whether ``TiledCamera``'s
+Replicator-based tiled-rendering path specifically is at fault, by spawning
+a plain ``Camera`` directly in ``_setup_scene()`` instead of going through
+``RLGardenDirectRLEnv``'s ``camera_cfg`` field (which is typed for
+``TiledCameraCfg``).
+"""
+from __future__ import annotations
+
+import gymnasium as gym
+
+import isaaclab.sim as sim_utils
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import Camera, CameraCfg
+from isaaclab.utils import configclass
+
+from rl_garden.envs.isaaclab.tasks.cartpole_direct import CartpoleDirectEnv, CartpoleDirectEnvCfg
+
+_CAMERA_CFG = CameraCfg(
+    prim_path="/World/envs/env_.*/Camera",
+    offset=CameraCfg.OffsetCfg(pos=(-5.0, 0.0, 2.0), rot=(1.0, 0.0, 0.0, 0.0), convention="world"),
+    data_types=["rgb"],
+    spawn=sim_utils.PinholeCameraCfg(
+        focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 20.0)
+    ),
+    width=64,
+    height=64,
+)
+
+
+@configclass
+class CartpoleDirectCameraPlainEnvCfg(CartpoleDirectEnvCfg):
+    observation_space = 1
+    # clone_in_fabric=True (used by the state-only base cfg) mis-sizes camera
+    # sensor per-env buffers -- same fix as CartpoleDirectCameraEnvCfg.
+    scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=32, env_spacing=4.0, replicate_physics=True)
+
+
+class CartpoleDirectCameraPlainEnv(CartpoleDirectEnv):
+    cfg: CartpoleDirectCameraPlainEnvCfg
+
+    def _setup_scene(self) -> None:
+        super()._setup_scene()
+        self.camera = Camera(_CAMERA_CFG)
+        self.scene.sensors["camera"] = self.camera
+
+    def _get_observations(self) -> dict:
+        state = super()._get_observations()["state"]
+        rgb = self.camera.data.output["rgb"]
+        return {"rgb": rgb, "state": state}
+
+
+gym.register(
+    id="RlGarden-Cartpole-Direct-Camera-Plain-v0",
+    entry_point=f"{__name__}:CartpoleDirectCameraPlainEnv",
+    disable_env_checker=True,
+    kwargs={"env_cfg_entry_point": f"{__name__}:CartpoleDirectCameraPlainEnvCfg"},
+)

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -375,6 +375,23 @@ def _make_mujoco_req(mj, *, num_envs: int = 2, num_eval_envs: int = 3):
     )
 
 
+def _make_isaaclab_req(il, *, obs_mode: str = "state"):
+    from rl_garden.envs.backend_registry import EnvRequest
+
+    return EnvRequest(
+        env_id="Isaac-Cartpole-v0",
+        num_envs=4,
+        num_eval_envs=4,
+        obs_mode=obs_mode,
+        control_mode="",
+        render_mode="rgb_array",
+        seed=1,
+        camera_width=None,
+        camera_height=None,
+        backend_config=il,
+    )
+
+
 def test_mujoco_config_defaults() -> None:
     from rl_garden.common.env_args import MujocoConfig
 
@@ -540,6 +557,75 @@ def test_mujoco_warp_backend_render_flags_follow_obs_mode() -> None:
     assert state_cfg.render_rgb is False and state_cfg.render_depth is False
     assert rgb_cfg.render_rgb is True and rgb_cfg.render_depth is False
     assert rgbd_cfg.render_rgb is True and rgbd_cfg.render_depth is True
+
+
+def test_isaaclab_config_defaults() -> None:
+    from rl_garden.common.env_args import IsaacLabConfig
+
+    il = IsaacLabConfig()
+
+    assert il.headless is True
+    assert il.sim_device == "cuda:0"
+    assert il.env_kwargs_json == "{}"
+
+
+def test_isaaclab_backend_make_cfg_forwards_env_kwargs_json() -> None:
+    import json
+
+    from rl_garden.common.env_args import IsaacLabConfig
+    from rl_garden.envs.backends.isaaclab import IsaacLabBackend
+
+    il = IsaacLabConfig(
+        headless=False,
+        sim_device="cuda:1",
+        env_kwargs_json=json.dumps({"episode_length_s": 10.0}),
+    )
+    req = _make_isaaclab_req(il)
+
+    cfg = IsaacLabBackend._make_cfg(req, is_eval=False)
+
+    assert cfg.env_id == "Isaac-Cartpole-v0"
+    assert cfg.num_envs == 4
+    assert cfg.headless is False
+    assert cfg.sim_device == "cuda:1"
+    assert cfg.env_kwargs == {"episode_length_s": 10.0}
+    assert cfg.obs_mode == "state"
+    assert cfg.frame_stack == 1
+
+
+def test_isaaclab_backend_make_cfg_forwards_obs_mode_and_frame_stack() -> None:
+    from rl_garden.common.env_args import IsaacLabConfig
+    from rl_garden.envs.backend_registry import EnvRequest
+    from rl_garden.envs.backends.isaaclab import IsaacLabBackend
+
+    req = EnvRequest(
+        env_id="RlGarden-Cartpole-Direct-v0",
+        num_envs=4,
+        num_eval_envs=4,
+        obs_mode="rgb",
+        control_mode="",
+        render_mode="rgb_array",
+        seed=1,
+        camera_width=100,
+        camera_height=100,
+        frame_stack=3,
+        backend_config=IsaacLabConfig(),
+    )
+
+    cfg = IsaacLabBackend._make_cfg(req, is_eval=False)
+
+    assert cfg.obs_mode == "rgb"
+    assert cfg.frame_stack == 3
+
+
+def test_isaaclab_backend_make_eval_env_not_supported_in_v1() -> None:
+    from rl_garden.common.env_args import IsaacLabConfig
+    from rl_garden.envs.backends.isaaclab import IsaacLabBackend
+
+    req = _make_isaaclab_req(IsaacLabConfig())
+
+    with pytest.raises(NotImplementedError, match="eval_freq 0"):
+        IsaacLabBackend.make_eval_env(req)
 
 
 def test_robotwin_config_defaults() -> None:


### PR DESCRIPTION
## Summary
- Rebase of `feat/isaac-support` onto current `main` (26 commits of drift since the original fork point).
- Adds `RLGardenDirectRLEnv`/`RLGardenDirectEnvCfg` scaffold on top of IsaacLab's `DirectRLEnv`, plus image-observation support (`obs_mode rgb/rgbd`) in `_IsaacLabVecEnvAdapter`.
- Docs relocated from the flat `docs/` root into `docs/guides/` (`isaaclab-camera-stall.md`, `isaaclab-custom-tasks.md`) to match main's current `guides/design/roadmaps` layout — nothing sits loose in `docs/` root.
- `IsaacLabBackend` upgraded to the `api_version = 2` `EnvBackend` contract main introduced after this branch's original commit (`resolve_config(req, *, is_eval)`, `_make_cfg` kept as a back-compat alias). `make_eval_env` still raises `NotImplementedError` — IsaacLab's `AppLauncher` only supports one Isaac Sim instance per process, so there's no live eval env in v1; pass `--eval_freq 0`.
- Known, unresolved issue carried over as-is: camera-observation training can intermittently stall on host `6017-nofwd` (Kit renderer hang after a heavy backward-pass burst). A partial mitigation (`post_update_sync` hook in `on_policy.py`, `torch.cuda.synchronize` once per rollout+update cycle) reduces but doesn't eliminate it. Full writeup in `docs/guides/isaaclab-camera-stall.md`. State-only IsaacLab training is unaffected.

## Test plan
- [x] `pytest tests/test_cli_args.py` — 69 passed
- [x] `pytest tests/` (full suite) — 1015 passed; 9 pre-existing environment-dependent failures (no Vulkan/CUDA/spacemouse hardware, one network timeout) confirmed identical on plain `origin/main`
- [ ] Camera-observation training smoke test (requires IsaacLab + GPU host, not run in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)